### PR TITLE
chore: release v0.9.0

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,40 @@
+# Nextest configuration — https://nexte.st/book/configuration
+# Run with: cargo nextest run
+
+[store]
+dir = "target/nextest"
+
+# Default profile: local dev and CI
+[profile.default]
+# Retry flaky tests once before failing
+retries = 1
+# Per-test timeout (catch infinite loops / deadlocks)
+slow-timeout = { period = "30s", terminate-after = 2 }
+# Fail fast: stop on first failure in CI (overridden in dev profile)
+fail-fast = true
+# Status output level
+status-level = "pass"
+final-status-level = "flaky"
+
+# Local development: more lenient
+[profile.dev]
+retries = 0
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+# CI profile: strict, with JUnit output for test reporting
+[profile.ci]
+retries = 2
+fail-fast = true
+slow-timeout = { period = "30s", terminate-after = 2 }
+status-level = "retry"
+final-status-level = "slow"
+
+# Test groups — isolate heavy tests that can't run in parallel
+[test-groups.serial-integration]
+max-threads = 1
+
+# Assign integration tests to serial group (they bind ports / use shared state)
+[[profile.default.overrides]]
+filter = "test(/^integration/)"
+test-group = "serial-integration"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,29 @@ jobs:
         with:
           shared-key: test-${{ matrix.os }}
           save-if: ${{ github.ref == 'refs/heads/develop' }}
-      - run: cargo test
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --profile ci
+      - run: cargo test --doc
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: coverage
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   audit:
     name: Security Audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/azerozero/grob/compare/v0.1.3...v0.9.0) - 2026-02-26
+
+### Added
+
+- *(dx)* add nextest, insta, tracing-test, coverage, cargo-chef
+
+### Fixed
+
+- remove invalid release_branch field from release-plz.toml
+
+### Other
+
+- add develop branch workflow and auto-merge release PRs
+- enable auto-merge for release-plz PRs
+
 ### Added
 
 - **Budget enforcement**: global, per-provider, and per-model monthly spend limits (`[budget]`, `budget_usd`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +699,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -944,6 +962,7 @@ dependencies = [
  "hex",
  "hmac",
  "http",
+ "insta",
  "jsonwebtoken",
  "memchr",
  "metrics",
@@ -951,7 +970,6 @@ dependencies = [
  "mockito",
  "moka",
  "nix",
- "once_cell",
  "p256",
  "pin-project",
  "proptest",
@@ -976,6 +994,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "unicode-normalization",
  "url",
  "uuid",
@@ -1317,6 +1336,19 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.46.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -2957,6 +2989,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3393,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,7 @@ anyhow = "1"
 thiserror = "1"
 
 # Utilities
-once_cell = "1"            # Lazy statics
-async-trait = "0.1"        # Async trait support
+async-trait = "0.1"        # Async trait support (needed for dyn Provider dispatch)
 dirs = "5"                 # User directories
 regex = "1"                # Regular expressions
 uuid = { version = "1.0", features = ["v4", "serde"] }  # UUID generation for streaming
@@ -112,6 +111,8 @@ tokio-test = "0.4"
 mockito = "1"
 criterion = "0.5"          # Benchmarking
 tempfile = "3"             # Temporary directory testing
+insta = { version = "1", features = ["json", "yaml"] }  # Snapshot testing
+tracing-test = "0.2"       # Capture tracing logs in tests
 
 # Property Testing
 proptest = "1"
@@ -128,7 +129,9 @@ tls = ["axum-server", "rustls", "rustls-pemfile"]
 # ecdsa: trait crate required for p256::ecdsa::signature::Signer bounds
 # tower: required by tower-http for Service/Layer trait impls
 # rustls/rustls-pemfile: behind optional "tls" feature flag
-ignored = ["ecdsa", "tower", "rustls", "rustls-pemfile"]
+# insta: snapshot testing — used incrementally as tests are converted
+# tracing-test: used via #[traced_test] attribute on individual tests
+ignored = ["ecdsa", "tower", "rustls", "rustls-pemfile", "insta", "tracing-test"]
 
 [profile.release]
 opt-level = 3

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,8 +8,6 @@ git_tag_name = "v{{ version }}"
 git_tag_enable = true
 changelog_update = true
 pr_labels = ["release"]
-# Release PRs target main from develop
-release_branch = "main"
 
 [[package]]
 name = "grob"

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,17 +1,17 @@
 use crate::cli::AppConfig;
 use crate::models::{AnthropicRequest, MessageContent, RouteDecision, RouteType, SystemPrompt};
 use anyhow::Result;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 use tracing::{debug, info};
 
 /// Regex to detect capture group references ($1, $name, ${1}, ${name})
-static CAPTURE_REF_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\$(?:\d+|[a-zA-Z_]\w*|\{[^}]+\})").unwrap());
+static CAPTURE_REF_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\$(?:\d+|[a-zA-Z_]\w*|\{[^}]+\})").unwrap());
 
 /// Pre-compiled regex for subagent model tag extraction (avoids per-request compilation)
-static SUBAGENT_TAG_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"<GROB-SUBAGENT-MODEL>(.*?)</GROB-SUBAGENT-MODEL>").unwrap());
+static SUBAGENT_TAG_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<GROB-SUBAGENT-MODEL>(.*?)</GROB-SUBAGENT-MODEL>").unwrap());
 
 /// Check if a string contains capture group references
 fn contains_capture_reference(s: &str) -> bool {


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.1.3 -> 0.9.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/azerozero/grob/compare/v0.1.3...v0.9.0) - 2026-02-26

### Added

- *(dx)* add nextest, insta, tracing-test, coverage, cargo-chef

### Fixed

- remove invalid release_branch field from release-plz.toml

### Other

- add develop branch workflow and auto-merge release PRs
- enable auto-merge for release-plz PRs

### Added

- **Budget enforcement**: global, per-provider, and per-model monthly spend limits (`[budget]`, `budget_usd`)
- **Spend tracking**: persistent monthly spend in `~/.grob/spend.json` with auto-reset
- **`grob spend` command**: show current month's spend breakdown by provider and model
- **Spend in `grob status`**: shows spend summary line
- **Dynamic pricing**: fetches model prices from OpenRouter API at startup (refreshes every 24h)
- **OAuth cost tracking**: OAuth/subscription requests correctly tracked as $0
- **Rate limit visibility**: parses and logs Anthropic rate limit headers, warns when low
- **Prometheus metrics**: `grob_spend_usd`, `grob_request_cost_usd`, `grob_ratelimit_hits_total`, `grob_ratelimit_tokens_remaining`, `grob_input_tokens_total`, `grob_output_tokens_total`
- **CI: cargo-audit** (security advisories), **cargo-deny** (licenses/bans), **cargo-machete** (unused deps)

### Fixed

- **Security**: HTML-escape OAuth callback parameters to prevent reflected XSS
- **Security**: Use constant-time comparison for API key authentication (`subtle` crate)
- **Security**: Redact API keys in `/api/config` JSON response
- **Security**: Remove sensitive data from debug logs (OAuth codes, PKCE verifiers, token responses, upstream bodies)
- **Bug**: Default port mismatch (serde default was 3456, docs/template was 13456) -- now consistently 13456
- **Bug**: `auth_type` value in default config template used `"api_key"` instead of correct `"apikey"`
- **Bug**: `grob model` hid providers without explicit `enabled = true` (now uses `is_enabled()`)
- **Bug**: Parse errors returned HTTP 500 instead of HTTP 400
- **Bug**: `SIGCONT` used for process existence check instead of signal 0 (no side effects)
- **Docs**: Removed all stale Admin UI / web UI / RapidSpec references (no admin UI exists)
- **Docs**: Fixed OAuth callback HTML: "admin panel" references changed to "terminal"
- **Docs**: Fixed default config template: removed non-existent "web UI" references
- **Docs**: Rewrote design-principles.md for CLI-only project (removed Admin UI sections)
- **Docs**: Removed Admin UI references from gemini-integration.md
- **Docs**: Fixed CONFIGURATION.md values: tracing path, `omit_system_prompt` default, `auto_sync` default, `auth_type` value
- **Docs**: Added missing `project_id`/`location` Vertex AI fields to CONFIGURATION.md
- **Docs**: Fixed OAUTH_SETUP.md: "Future" endpoints label (already implemented), added refresh/delete endpoints
- **Docs**: Updated stale model names (claude-sonnet-4-5 → 4-6, claude-opus-4-1 → 4-6) across presets, configs, tests
- **Docs**: OpenAI streaming and tool calling marked as unsupported but were implemented
- **Docs**: Documented `[server.tracing]`, `prompt_rules`, `inject_continuation_prompt`, preset `sync_interval`/`auto_sync`
- **Docs**: Rewrote CLAUDE.md for actual project architecture (was stale RapidSpec template)

### Changed

- **License**: Switched from Elastic License v2 (ELv2) to **AGPL-3.0** with commercial dual licensing
- **Dependency**: `metrics-exporter-prometheus` now uses `http-listener` feature only (removes OpenSSL-licensed `aws-lc-sys`)

### Removed

- Unused dependencies: `config`, `dashmap`, `oauth2`, `tiktoken-rs`, `tokio-stream`, `tower`, `tower-http`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).