### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/azerozero/grob/compare/v0.9.0...v0.10.0) - 2026-03-02
+
+### Added
+
+- trait contracts + adaptive provider scoring
+- codebase hardening — dead code, JWT cache, handler dedup, feature flags, tests
+- wire dead code into handlers and remove #[allow(dead_code)]
+- *(dx)* add nextest, insta, tracing-test, coverage, cargo-chef
+
+### Fixed
+
+- enable git_only mode in release-plz for tag-based versioning
+- configure release-plz to bump from git tags instead of crates.io
+- use current_month() in migration test to avoid month rollover failure
+- remove invalid release_branch field from release-plz.toml
+
+### Other
+
+- split god modules and extract submodules for maintainability
+- clean code overhaul — split god modules, extract functions, add tests
+- apply cargo fmt formatting
+- release v0.9.0 ([#5](https://github.com/azerozero/grob/pull/5))
+- add develop branch workflow and auto-merge release PRs
+- enable auto-merge for release-plz PRs
+
 ## [0.9.0](https://github.com/azerozero/grob/compare/v0.1.3...v0.9.0) - 2026-02-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field InjectionDetection.start in /tmp/.tmpiEtwvQ/grob/src/features/dlp/prompt_injection.rs:22
  field InjectionDetection.end in /tmp/.tmpiEtwvQ/grob/src/features/dlp/prompt_injection.rs:23
  field AuditConfig.signing_algorithm in /tmp/.tmpiEtwvQ/grob/src/security/audit_log.rs:169
  field AuditConfig.hmac_key_path in /tmp/.tmpiEtwvQ/grob/src/security/audit_log.rs:171
  field JwtCacheEntry.claims in /tmp/.tmpiEtwvQ/grob/src/security/cache.rs:15
  field AuditEntry.signature_algorithm in /tmp/.tmpiEtwvQ/grob/src/security/audit_log.rs:122
  field AuditEntry.model_name in /tmp/.tmpiEtwvQ/grob/src/security/audit_log.rs:125
  field AuditEntry.input_tokens in /tmp/.tmpiEtwvQ/grob/src/security/audit_log.rs:128
  field AuditEntry.output_tokens in /tmp/.tmpiEtwvQ/grob/src/security/audit_log.rs:131
  field AuditEntry.risk_level in /tmp/.tmpiEtwvQ/grob/src/security/audit_log.rs:134
  field TlsConfig.acme in /tmp/.tmpiEtwvQ/grob/src/cli/config.rs:433
  field AppConfig.cache in /tmp/.tmpiEtwvQ/grob/src/cli/mod.rs:45
  field AppConfig.compliance in /tmp/.tmpiEtwvQ/grob/src/cli/mod.rs:48

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field GeminiProvider.oauth_provider in /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:30
  field GeminiProvider.api_timeout in /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:33

--- failure copy_impl_added: type now implements Copy ---

Description:
A public type now implements Copy, causing non-move closures to capture it by reference instead of moving it.
        ref: https://github.com/rust-lang/rust/issues/100905
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/copy_impl_added.ron

Failed in:
  grob::security::audit_log::AuditEvent in /tmp/.tmpiEtwvQ/grob/src/security/audit_log.rs:72

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function grob::preset::get_preset_content, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/preset.rs:106
  function grob::pid::get_pid_file, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/pid.rs:6
  function grob::features::token_pricing::get_pricing, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/features/token_pricing/mod.rs:315

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  ProviderRegistry::get_provider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/registry.rs:213
  ProviderRegistry::get_provider_for_model, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/registry.rs:218
  ProviderRegistry::get_provider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/registry.rs:213
  ProviderRegistry::get_provider_for_model, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/registry.rs:218
  OAuthClient::get_authorization_url, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/auth/oauth.rs:167
  OAuthClient::get_valid_token, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/auth/oauth.rs:582
  OAuthClient::create_api_key, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/auth/oauth.rs:598
  OAuthClient::get_authorization_url, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/auth/oauth.rs:167
  OAuthClient::get_valid_token, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/auth/oauth.rs:582
  OAuthClient::create_api_key, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/auth/oauth.rs:598
  AnthropicCompatibleProvider::zai, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/anthropic_compatible.rs:383
  AnthropicCompatibleProvider::minimax, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/anthropic_compatible.rs:395
  AnthropicCompatibleProvider::zenmux, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/anthropic_compatible.rs:407
  AnthropicCompatibleProvider::kimi_coding, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/anthropic_compatible.rs:419
  AnthropicCompatibleProvider::zai, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/anthropic_compatible.rs:383
  AnthropicCompatibleProvider::minimax, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/anthropic_compatible.rs:395
  AnthropicCompatibleProvider::zenmux, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/anthropic_compatible.rs:407
  AnthropicCompatibleProvider::kimi_coding, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/anthropic_compatible.rs:419

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  grob::providers::openai::OpenAIProvider::with_headers now takes 2 parameters instead of 7, in /tmp/.tmpiEtwvQ/grob/src/providers/openai/mod.rs:46
  grob::providers::OpenAIProvider::with_headers now takes 2 parameters instead of 7, in /tmp/.tmpiEtwvQ/grob/src/providers/openai/mod.rs:46
  grob::providers::registry::ProviderRegistry::from_configs_with_models now takes 4 parameters instead of 3, in /tmp/.tmpiEtwvQ/grob/src/providers/registry.rs:172
  grob::providers::ProviderRegistry::from_configs_with_models now takes 4 parameters instead of 3, in /tmp/.tmpiEtwvQ/grob/src/providers/registry.rs:172
  grob::providers::anthropic_compatible::AnthropicCompatibleProvider::new now takes 1 parameters instead of 6, in /tmp/.tmpiEtwvQ/grob/src/providers/anthropic_compatible.rs:279
  grob::providers::anthropic_compatible::AnthropicCompatibleProvider::with_headers now takes 2 parameters instead of 7, in /tmp/.tmpiEtwvQ/grob/src/providers/anthropic_compatible.rs:283
  grob::providers::AnthropicCompatibleProvider::new now takes 1 parameters instead of 6, in /tmp/.tmpiEtwvQ/grob/src/providers/anthropic_compatible.rs:279
  grob::providers::AnthropicCompatibleProvider::with_headers now takes 2 parameters instead of 7, in /tmp/.tmpiEtwvQ/grob/src/providers/anthropic_compatible.rs:283
  grob::features::token_pricing::spend::SpendTracker::check_warnings now takes [3, 3] parameters instead of 6, in [ /tmp/.tmpiEtwvQ/grob/src/features/token_pricing/spend.rs:265 , /tmp/.tmpiEtwvQ/grob/src/features/token_pricing/spend.rs:346 ]
  grob::providers::gemini::GeminiProvider::new now takes 4 parameters instead of 9, in /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:49

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct grob::server::openai_compat::OpenAIStreamChoice, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/openai_compat.rs:471
  struct grob::server::openai_compat::OpenAIStreamToolCallDelta, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/openai_compat.rs:488
  struct grob::models::Usage, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/models/mod.rs:247
  struct grob::server::openai_compat::OpenAIStreamFunctionDelta, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/openai_compat.rs:499
  struct grob::cli::SecurityTomlConfig, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/cli/mod.rs:43
  struct grob::server::openai_compat::OpenAIStreamChunk, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/openai_compat.rs:462
  struct grob::server::openai_compat::OpenAIStreamDelta, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/openai_compat.rs:478

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field _start of struct InjectionDetection, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/features/dlp/prompt_injection.rs:22
  field _end of struct InjectionDetection, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/features/dlp/prompt_injection.rs:23
  field verifier of struct PKCEVerifier, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/auth/oauth.rs:29
  field challenge of struct PKCEVerifier, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/auth/oauth.rs:30
  field input_tokens of struct TokenCounter, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/features/token_pricing/mod.rs:325
  field output_tokens of struct TokenCounter, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/features/token_pricing/mod.rs:327
  field model of struct TokenCounter, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/features/token_pricing/mod.rs:330
  field _window of struct RateLimitConfig, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/security/rate_limit.rs:19
  field _window of struct RateLimitConfig, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/security/rate_limit.rs:19
  field path of struct PresetInfo, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/preset.rs:17
  field latency_ms of struct MappingResult, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/preset.rs:1127
  field rotation_size of struct AuditConfig, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/security/audit_log.rs:94
  field retention_days of struct AuditConfig, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/security/audit_log.rs:96
  field encrypt of struct AuditConfig, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/security/audit_log.rs:100
  field event_type of struct DlpEvent, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/features/dlp/dfa.rs:21
  field _claims of struct JwtCacheEntry, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/security/cache.rs:15
  field _token_hash of struct JwtCacheEntry, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/security/cache.rs:17
  field name of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:18
  field api_key of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:19
  field base_url of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:20
  field models of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:21
  field client of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:22
  field custom_headers of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:23
  field project_id of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:25
  field location of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:26
  field oauth_provider_id of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:28
  field token_store of struct GeminiProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/gemini.rs:29
  field message_tracer of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:79
  field metrics_handle of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:80
  field spend_tracker of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:84
  field pricing_table of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:86
  field dlp_sessions of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:88
  field jwt_validator of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:90
  field tap_sender of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:92
  field rate_limiter of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:94
  field circuit_breakers of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:96
  field audit_log of struct AppState, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/server/mod.rs:98

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field PKCEVerifier.verifier in file /tmp/.tmpiEtwvQ/grob/src/auth/oauth.rs:28
  field PKCEVerifier.challenge in file /tmp/.tmpiEtwvQ/grob/src/auth/oauth.rs:28
  field GeminiProvider.api_key in file /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:20
  field GeminiProvider.base_url in file /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:20
  field GeminiProvider.models in file /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:20
  field GeminiProvider.client in file /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:20
  field GeminiProvider.custom_headers in file /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:20
  field GeminiProvider.project_id in file /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:20
  field GeminiProvider.location in file /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:20
  field GeminiProvider.token_store in file /tmp/.tmpiEtwvQ/grob/src/providers/gemini/mod.rs:20

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_missing.ron

Failed in:
  trait grob::providers::AnthropicProvider, previously in file /tmp/release-plz-grob-6pc9js/worktree/target/package/grob-0.9.0/src/providers/mod.rs:53
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/azerozero/grob/compare/v0.9.0...v0.10.0) - 2026-03-02

### Added

- trait contracts + adaptive provider scoring
- codebase hardening — dead code, JWT cache, handler dedup, feature flags, tests
- wire dead code into handlers and remove #[allow(dead_code)]
- *(dx)* add nextest, insta, tracing-test, coverage, cargo-chef

### Fixed

- enable git_only mode in release-plz for tag-based versioning
- configure release-plz to bump from git tags instead of crates.io
- use current_month() in migration test to avoid month rollover failure
- remove invalid release_branch field from release-plz.toml

### Other

- split god modules and extract submodules for maintainability
- clean code overhaul — split god modules, extract functions, add tests
- apply cargo fmt formatting
- release v0.9.0 ([#5](https://github.com/azerozero/grob/pull/5))
- add develop branch workflow and auto-merge release PRs
- enable auto-merge for release-plz PRs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).