### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/azerozero/grob/compare/v0.10.1...v0.10.2) - 2026-03-02
+
+### Other
+
+- split large files to fit 200-500 line ideal zone
+
 ## [0.10.1](https://github.com/azerozero/grob/compare/v0.10.0...v0.10.1) - 2026-03-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.10.1 -> 0.10.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.2](https://github.com/azerozero/grob/compare/v0.10.1...v0.10.2) - 2026-03-02

### Other

- split large files to fit 200-500 line ideal zone
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).