### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/azerozero/grob/compare/v0.10.3...v0.11.0) - 2026-03-02
+
+### Added
+
+- add pass-through provider mode for wildcard model routing
+
 ## [0.10.3](https://github.com/azerozero/grob/compare/v0.10.2...v0.10.3) - 2026-03-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.10.3"
+version = "0.11.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.10.3 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ProviderConfig.pass_through in /tmp/.tmpNWOWkT/grob/src/providers/mod.rs:185
  field ProviderParams.pass_through in /tmp/.tmpNWOWkT/grob/src/providers/mod.rs:123
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/azerozero/grob/compare/v0.10.3...v0.11.0) - 2026-03-02

### Added

- add pass-through provider mode for wildcard model routing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).