### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/azerozero/grob/compare/v0.13.0...v0.13.1) - 2026-03-08
+
+### Fixed
+
+- convert release to draft before asset upload to avoid immutable error
+
+### Other
+
+- add doc comments to all 430 undocumented public items
+- add capabilities inventory and fix 3 accuracy issues
+- update DCI report to v0.13.0 (score 8.4/10)
+- add ~100 doc comments, curl examples, feature highlights, fix OCI license
+
 ## [0.13.0](https://github.com/azerozero/grob/compare/v0.12.4...v0.13.0) - 2026-03-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.13.0 -> 0.13.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.1](https://github.com/azerozero/grob/compare/v0.13.0...v0.13.1) - 2026-03-08

### Fixed

- convert release to draft before asset upload to avoid immutable error

### Other

- add doc comments to all 430 undocumented public items
- add capabilities inventory and fix 3 accuracy issues
- update DCI report to v0.13.0 (score 8.4/10)
- add ~100 doc comments, curl examples, feature highlights, fix OCI license
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).