### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/azerozero/grob/compare/v0.13.2...v0.14.0) - 2026-03-08
+
+### Added
+
+- add --reload flag to grob preset apply
+
 ## [0.13.2](https://github.com/azerozero/grob/compare/v0.13.1...v0.13.2) - 2026-03-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.13.2 -> 0.14.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field reload of variant PresetAction::Apply in /tmp/.tmphmCncI/grob/src/cli/args.rs:200

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  grob::commands::preset::cmd_preset_apply now takes 4 parameters instead of 2, in /tmp/.tmphmCncI/grob/src/commands/preset.rs:41
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.0](https://github.com/azerozero/grob/compare/v0.13.2...v0.14.0) - 2026-03-08

### Added

- add --reload flag to grob preset apply
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).