### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/azerozero/grob/compare/v0.14.1...v0.15.0) - 2026-03-08
+
+### Other
+
+- rename AnthropicRequest → CanonicalRequest + add RequestExtensions
+
 ## [0.14.1](https://github.com/azerozero/grob/compare/v0.14.0...v0.14.1) - 2026-03-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.14.1 -> 0.15.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OpenAIRequest.response_format in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:35
  field OpenAIRequest.reasoning_effort in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:38
  field OpenAIRequest.seed in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:41
  field OpenAIRequest.frequency_penalty in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:44
  field OpenAIRequest.presence_penalty in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:47
  field OpenAIRequest.parallel_tool_calls in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:50
  field OpenAIRequest.user in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:53
  field OpenAIRequest.logprobs in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:56
  field OpenAIRequest.top_logprobs in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:59
  field OpenAIRequest.service_tier in /tmp/.tmpS9jf78/grob/src/server/openai_compat/types.rs:62

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function grob::server::openai_compat::transform_openai_to_anthropic, previously in file /tmp/release-plz-grob-Nx1BQg/worktree/target/package/grob-0.14.1/src/server/openai_compat/transform.rs:174
  function grob::server::openai_compat::transform_anthropic_to_openai, previously in file /tmp/release-plz-grob-Nx1BQg/worktree/target/package/grob-0.14.1/src/server/openai_compat/transform.rs:254

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct grob::models::AnthropicRequest, previously in file /tmp/release-plz-grob-Nx1BQg/worktree/target/package/grob-0.14.1/src/models/mod.rs:8
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.0](https://github.com/azerozero/grob/compare/v0.14.1...v0.15.0) - 2026-03-08

### Other

- rename AnthropicRequest → CanonicalRequest + add RequestExtensions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).