### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/azerozero/grob/compare/v0.15.3...v0.16.0) - 2026-03-16
+
+### Added
+
+- bootstrap UX overhaul — wizard auth/compliance/budget + startup warnings
+
+### Fixed
+
+- upgrade quinn-proto 0.11.13 → 0.11.14 (RUSTSEC-2026-0037 DoS fix)
+
+### Other
+
+- add OWASP LLM Top 10 coverage reference
+
 ## [0.15.3](https://github.com/azerozero/grob/compare/v0.15.2...v0.15.3) - 2026-03-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.15.3"
+version = "0.16.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.15.3 -> 0.16.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Commands::Doctor 16 -> 17 in /tmp/.tmpes8hdw/grob/src/cli/args.rs:127
  variant Commands::Upgrade 17 -> 18 in /tmp/.tmpes8hdw/grob/src/cli/args.rs:132
  variant Commands::Harness 18 -> 19 in /tmp/.tmpes8hdw/grob/src/cli/args.rs:135

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Commands:Setup in /tmp/.tmpes8hdw/grob/src/cli/args.rs:125
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.0](https://github.com/azerozero/grob/compare/v0.15.3...v0.16.0) - 2026-03-16

### Added

- bootstrap UX overhaul — wizard auth/compliance/budget + startup warnings

### Fixed

- upgrade quinn-proto 0.11.13 → 0.11.14 (RUSTSEC-2026-0037 DoS fix)

### Other

- add OWASP LLM Top 10 coverage reference
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).