### PR TITLE
chore: release v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2](https://github.com/azerozero/grob/compare/v0.16.1...v0.16.2) - 2026-03-16
+
+### Fixed
+
+- *(security)* resolve 21 CodeQL alerts (2 critical, 18 high, 1 medium)
+
 ## [0.16.1](https://github.com/azerozero/grob/compare/v0.16.0...v0.16.1) - 2026-03-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.16.1 -> 0.16.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.2](https://github.com/azerozero/grob/compare/v0.16.1...v0.16.2) - 2026-03-16

### Fixed

- *(security)* resolve 21 CodeQL alerts (2 critical, 18 high, 1 medium)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).