### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/azerozero/grob/compare/v0.16.2...v0.17.0) - 2026-03-16
+
+### Added
+
+- *(security)* Merkle tree batch signing for audit log + Ed25519 support
+
 ## [0.16.2](https://github.com/azerozero/grob/compare/v0.16.1...v0.16.2) - 2026-03-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.16.2 -> 0.17.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type AuditLog is no longer UnwindSafe, in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:253
  type AuditLog is no longer RefUnwindSafe, in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:253
  type AuditLog is no longer UnwindSafe, in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:253
  type AuditLog is no longer RefUnwindSafe, in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:253

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AuditConfig.batch_size in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:191
  field AuditConfig.flush_interval_ms in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:193
  field AuditConfig.include_merkle_proof in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:195
  field AuditEntry.batch_id in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:138
  field AuditEntry.batch_index in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:141
  field AuditEntry.merkle_root in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:144
  field AuditEntry.merkle_proof in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:147
  field SecurityConfig.audit_batch_size in /tmp/.tmpun5QqV/grob/src/cli/config.rs:54
  field SecurityConfig.audit_flush_interval_ms in /tmp/.tmpun5QqV/grob/src/cli/config.rs:57
  field SecurityConfig.audit_include_merkle_proof in /tmp/.tmpun5QqV/grob/src/cli/config.rs:60

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum grob::security::audit_log::SigningMaterial, previously in file /tmp/release-plz-grob-1DCqFw/worktree/target/package/grob-0.16.2/src/security/audit_log.rs:50

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant SigningAlgorithm::HmacSha256 1 -> 2 in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:30

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant SigningAlgorithm:Ed25519 in /tmp/.tmpun5QqV/grob/src/security/audit_log.rs:28
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.17.0](https://github.com/azerozero/grob/compare/v0.16.2...v0.17.0) - 2026-03-16

### Added

- *(security)* Merkle tree batch signing for audit log + Ed25519 support
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).