### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1](https://github.com/azerozero/grob/compare/v0.17.0...v0.17.1) - 2026-03-17
+
+### Fixed
+
+- *(ux)* gracefully disable providers with missing API keys instead of crashing
+
 ## [0.17.0](https://github.com/azerozero/grob/compare/v0.16.2...v0.17.0) - 2026-03-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.17.0 -> 0.17.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.17.1](https://github.com/azerozero/grob/compare/v0.17.0...v0.17.1) - 2026-03-17

### Fixed

- *(ux)* gracefully disable providers with missing API keys instead of crashing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).