### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/azerozero/grob/compare/v0.17.1...v0.18.0) - 2026-03-18
+
+### Added
+
+- security hardening + grob watch + OTel + virtual keys + log export + compliance + docs
+
 ## [0.17.1](https://github.com/azerozero/grob/compare/v0.17.0...v0.17.1) - 2026-03-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.17.1 -> 0.18.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AppConfig.otel in /tmp/.tmpFMnvRp/grob/src/cli/mod.rs:79
  field AppConfig.log_export in /tmp/.tmpFMnvRp/grob/src/cli/mod.rs:82

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Commands::Doctor 17 -> 19 in /tmp/.tmpFMnvRp/grob/src/cli/args.rs:136
  variant Commands::Upgrade 18 -> 20 in /tmp/.tmpFMnvRp/grob/src/cli/args.rs:141
  variant Commands::Harness 19 -> 21 in /tmp/.tmpFMnvRp/grob/src/cli/args.rs:144

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Commands:Watch in /tmp/.tmpFMnvRp/grob/src/cli/args.rs:128
  variant Commands:Key in /tmp/.tmpFMnvRp/grob/src/cli/args.rs:130
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.18.0](https://github.com/azerozero/grob/compare/v0.17.1...v0.18.0) - 2026-03-18

### Added

- security hardening + grob watch + OTel + virtual keys + log export + compliance + docs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).