### PR TITLE
chore: release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0](https://github.com/azerozero/grob/compare/v0.18.0...v0.19.0) - 2026-03-19
+
+### Added
+
+- *(security)* mTLS client certs for providers + DLP key rotation
+
+### Other
+
+- *(ci)* add cargo-semver-checks and Semgrep SAST
+
 ## [0.18.0](https://github.com/azerozero/grob/compare/v0.17.1...v0.18.0) - 2026-03-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.18.0 -> 0.19.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ProviderConfig.tls_cert in /tmp/.tmpjsvbMD/grob/src/providers/mod.rs:263
  field ProviderConfig.tls_key in /tmp/.tmpjsvbMD/grob/src/providers/mod.rs:266
  field ProviderConfig.tls_ca in /tmp/.tmpjsvbMD/grob/src/providers/mod.rs:269
  field DlpConfig.key_rotation_hours in /tmp/.tmpjsvbMD/grob/src/features/dlp/config.rs:53
  field ProviderParams.tls_identity in /tmp/.tmpjsvbMD/grob/src/providers/mod.rs:185
  field ProviderParams.tls_ca in /tmp/.tmpjsvbMD/grob/src/providers/mod.rs:187

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  grob::providers::build_provider_client now takes 3 parameters instead of 1, in /tmp/.tmpjsvbMD/grob/src/providers/mod.rs:89
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.19.0](https://github.com/azerozero/grob/compare/v0.18.0...v0.19.0) - 2026-03-19

### Added

- *(security)* mTLS client certs for providers + DLP key rotation

### Other

- *(ci)* add cargo-semver-checks and Semgrep SAST
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).