### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/azerozero/grob/compare/v0.19.2...v0.20.0) - 2026-03-19
+
+### Added
+
+- multi-account key pool + config promotion pipeline
+
 ## [0.19.2](https://github.com/azerozero/grob/compare/v0.19.1...v0.19.2) - 2026-03-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.19.2"
+version = "0.20.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.19.2 -> 0.20.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ProviderParams.key_pool in /tmp/.tmpufMq4m/grob/src/providers/mod.rs:199
  field ProviderConfig.pool in /tmp/.tmpufMq4m/grob/src/providers/mod.rs:285

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Commands::Doctor 19 -> 20 in /tmp/.tmpufMq4m/grob/src/cli/args.rs:138
  variant Commands::Upgrade 20 -> 21 in /tmp/.tmpufMq4m/grob/src/cli/args.rs:143
  variant Commands::Harness 21 -> 22 in /tmp/.tmpufMq4m/grob/src/cli/args.rs:146

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field env of variant PresetAction::Export in /tmp/.tmpufMq4m/grob/src/cli/args.rs:258

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant PresetAction:Push in /tmp/.tmpufMq4m/grob/src/cli/args.rs:263
  variant PresetAction:Pull in /tmp/.tmpufMq4m/grob/src/cli/args.rs:274
  variant Commands:Rollback in /tmp/.tmpufMq4m/grob/src/cli/args.rs:136

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  grob::commands::preset::cmd_preset_export now takes 3 parameters instead of 2, in /tmp/.tmpufMq4m/grob/src/commands/preset.rs:110
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.0](https://github.com/azerozero/grob/compare/v0.19.2...v0.20.0) - 2026-03-19

### Added

- multi-account key pool + config promotion pipeline
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).