### PR TITLE
chore: release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/azerozero/grob/compare/v0.20.0...v0.20.1) - 2026-03-19
+
+### Added
+
+- *(observability)* x-grob-overhead-duration-ms header + DLP benchmark scenarios
+
 ## [0.20.0](https://github.com/azerozero/grob/compare/v0.19.2...v0.20.0) - 2026-03-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.20.0 -> 0.20.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.1](https://github.com/azerozero/grob/compare/v0.20.0...v0.20.1) - 2026-03-19

### Added

- *(observability)* x-grob-overhead-duration-ms header + DLP benchmark scenarios
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).