### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/azerozero/grob/compare/v0.20.1...v0.21.0) - 2026-03-19
+
+### Added
+
+- *(cli)* grob bench — self-contained performance evaluation
+
+### Other
+
+- clean up project tree structure
+- correct benchmark headline to pure overhead (~100us)
+- add direct-to-mock baseline for accurate overhead calculation
+- add benchmark headline to README (227us P50 with all features)
+- audit signing + proxy overhead infrastructure
+
 ## [0.20.1](https://github.com/azerozero/grob/compare/v0.20.0...v0.20.1) - 2026-03-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.20.1"
+version = "0.21.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.20.1 -> 0.21.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Commands::Doctor 20 -> 21 in /tmp/.tmpT2IPjK/grob/src/cli/args.rs:150
  variant Commands::Upgrade 21 -> 22 in /tmp/.tmpT2IPjK/grob/src/cli/args.rs:155
  variant Commands::Harness 22 -> 23 in /tmp/.tmpT2IPjK/grob/src/cli/args.rs:158

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Commands:Bench in /tmp/.tmpT2IPjK/grob/src/cli/args.rs:138
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.0](https://github.com/azerozero/grob/compare/v0.20.1...v0.21.0) - 2026-03-19

### Added

- *(cli)* grob bench — self-contained performance evaluation

### Other

- clean up project tree structure
- correct benchmark headline to pure overhead (~100us)
- add direct-to-mock baseline for accurate overhead calculation
- add benchmark headline to README (227us P50 with all features)
- audit signing + proxy overhead infrastructure
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).