### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/azerozero/grob/compare/v0.21.0...v0.22.0) - 2026-03-20
+
+### Fixed
+
+- resolve merge conflicts (accept enhanced bench)
+
 ## [0.21.0](https://github.com/azerozero/grob/compare/v0.20.1...v0.21.0) - 2026-03-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.21.0 -> 0.22.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field concurrency of variant Commands::Bench in /tmp/.tmpV3s2fq/grob/src/cli/args.rs:150
  field payload of variant Commands::Bench in /tmp/.tmpV3s2fq/grob/src/cli/args.rs:153

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  grob::commands::bench::cmd_bench now takes 6 parameters instead of 4, in /tmp/.tmpV3s2fq/grob/src/commands/bench.rs:669
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.0](https://github.com/azerozero/grob/compare/v0.21.0...v0.22.0) - 2026-03-20

### Fixed

- resolve merge conflicts (accept enhanced bench)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).