### PR TITLE
chore: release v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1](https://github.com/azerozero/grob/compare/v0.23.0...v0.23.1) - 2026-03-20
+
+### Fixed
+
+- *(ci)* limit feature powerset to depth 2 (66 combos instead of 1561)
+
 ## [0.23.0](https://github.com/azerozero/grob/compare/v0.22.1...v0.23.0) - 2026-03-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.23.0 -> 0.23.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.1](https://github.com/azerozero/grob/compare/v0.23.0...v0.23.1) - 2026-03-20

### Fixed

- *(ci)* limit feature powerset to depth 2 (66 combos instead of 1561)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).