### PR TITLE
chore: release v0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2](https://github.com/azerozero/grob/compare/v0.24.1...v0.24.2) - 2026-03-21
+
+### Fixed
+
+- *(ci)* use gitleaks binary instead of paid org action
+
+### Other
+
+- add gitleaks secret scanning to CI pipeline
+- *(bench)* add AWS benchmark results with competitor comparison
+- *(roadmap)* clarify XDP DLP (byte scan, no JSON needed) + single-node gains
+- *(roadmap)* upgrade Phase 4.4 with Hyperscan kernel DLP
+- *(roadmap)* complete rewrite with Tier 4 mesh + pricing + benchmarks
+
 ## [0.24.1](https://github.com/azerozero/grob/compare/v0.24.0...v0.24.1) - 2026-03-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.24.1 -> 0.24.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.24.2](https://github.com/azerozero/grob/compare/v0.24.1...v0.24.2) - 2026-03-21

### Fixed

- *(ci)* use gitleaks binary instead of paid org action

### Other

- add gitleaks secret scanning to CI pipeline
- *(bench)* add AWS benchmark results with competitor comparison
- *(roadmap)* clarify XDP DLP (byte scan, no JSON needed) + single-node gains
- *(roadmap)* upgrade Phase 4.4 with Hyperscan kernel DLP
- *(roadmap)* complete rewrite with Tier 4 mesh + pricing + benchmarks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).