### PR TITLE
chore: release v0.24.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5](https://github.com/azerozero/grob/compare/v0.24.4...v0.24.5) - 2026-03-21
+
+### Added
+
+- add brew install to README + CI homebrew test job
+
+### Other
+
+- *(release)* auto-update Homebrew tap on release
+- *(readme)* add benchmarks link, contributing section, trim badges
+- *(bench)* use req/s header and readable numbers in benchmark tables
+- translate French to English + deduplicate diagrams
+- convert 17 ASCII diagrams to Mermaid across 9 files
+
 ## [0.24.4](https://github.com/azerozero/grob/compare/v0.24.3...v0.24.4) - 2026-03-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grob"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.24.4"
+version = "0.24.5"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.24.4 -> 0.24.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.24.5](https://github.com/azerozero/grob/compare/v0.24.4...v0.24.5) - 2026-03-21

### Added

- add brew install to README + CI homebrew test job

### Other

- *(release)* auto-update Homebrew tap on release
- *(readme)* add benchmarks link, contributing section, trim badges
- *(bench)* use req/s header and readable numbers in benchmark tables
- translate French to English + deduplicate diagrams
- convert 17 ASCII diagrams to Mermaid across 9 files
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).