### PR TITLE
chore: release v0.24.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.7](https://github.com/azerozero/grob/compare/v0.24.6...v0.24.7) - 2026-03-22
+
+### Added
+
+- *(policies)* implement P1 policy engine with glob-based matching
+
+### Other
+
+- *(adr)* update 0006 with HIT tool interception, auth methods, risk matrix
+- *(adr)* 0006 unified policy engine + encrypted audit + HIT gateway
+
 ## [0.24.6](https://github.com/azerozero/grob/compare/v0.24.5...v0.24.6) - 2026-03-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.24.6"
+version = "0.24.7"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.24.6"
+version = "0.24.7"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.24.6 -> 0.24.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.24.7](https://github.com/azerozero/grob/compare/v0.24.6...v0.24.7) - 2026-03-22

### Added

- *(policies)* implement P1 policy engine with glob-based matching

### Other

- *(adr)* update 0006 with HIT tool interception, auth methods, risk matrix
- *(adr)* 0006 unified policy engine + encrypted audit + HIT gateway
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).