### PR TITLE
chore: release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/azerozero/grob/compare/v0.24.7...v0.25.0) - 2026-03-22
+
+### Added
+
+- *(hit)* P4 HIT tool authorization engine + hash-chained receipts
+- *(policies)* P3 wire policy engine into dispatch pipeline
+- *(log-export)* P2 encrypted audit export with age envelope encryption
+
+### Other
+
+- P5 HIT quorum voting + multi-sig co-signing design spec
+
 ## [0.24.7](https://github.com/azerozero/grob/compare/v0.24.6...v0.24.7) - 2026-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.24.7"
+version = "0.25.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.24.7"
+version = "0.25.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.24.7 -> 0.25.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LogEntry.encrypted_content in /tmp/.tmpCIIJTe/grob/src/features/log_export/mod.rs:43
  field LogEntry.content_recipients in /tmp/.tmpCIIJTe/grob/src/features/log_export/mod.rs:46
  field LogExportConfig.content in /tmp/.tmpCIIJTe/grob/src/features/log_export/mod.rs:73
  field LogExportConfig.auditors in /tmp/.tmpCIIJTe/grob/src/features/log_export/mod.rs:76
  field LogExportConfig.access_policies in /tmp/.tmpCIIJTe/grob/src/features/log_export/mod.rs:79
  field LogExportConfig.content in /tmp/.tmpCIIJTe/grob/src/features/log_export/mod.rs:73
  field LogExportConfig.auditors in /tmp/.tmpCIIJTe/grob/src/features/log_export/mod.rs:76
  field LogExportConfig.access_policies in /tmp/.tmpCIIJTe/grob/src/features/log_export/mod.rs:79
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.25.0](https://github.com/azerozero/grob/compare/v0.24.7...v0.25.0) - 2026-03-22

### Added

- *(hit)* P4 HIT tool authorization engine + hash-chained receipts
- *(policies)* P3 wire policy engine into dispatch pipeline
- *(log-export)* P2 encrypted audit export with age envelope encryption

### Other

- P5 HIT quorum voting + multi-sig co-signing design spec
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).