### PR TITLE
chore: release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0](https://github.com/azerozero/grob/compare/v0.25.3...v0.26.0) - 2026-03-22
+
+### Added
+
+- *(policies)* WI-5/6 quorum voting + multi-sig co-signing
+- *(log-export)* WI-3 wire encrypted content emit in dispatch
+- *(policies)* WI-2 wire policy evaluation into dispatch handlers
+- *(policies)* WI-1 wire config + init for policy engine and HIT
+
+### Other
+
+- gitignore docs/reviews/ (generated audit reports)
+- add key pool configuration to CONFIGURATION.md
+- sync code→docs gaps (policies, encrypted audit, CLI commands)
+
 ## [0.25.3](https://github.com/azerozero/grob/compare/v0.25.2...v0.25.3) - 2026-03-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.25.3"
+version = "0.26.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.25.3 -> 0.26.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SecurityState.policy_matcher in /tmp/.tmppSHdo8/grob/src/server/mod.rs:138
  field AppConfig.policies in /tmp/.tmppSHdo8/grob/src/cli/mod.rs:85
  field PolicyConfig.hit in /tmp/.tmppSHdo8/grob/src/features/policies/config.rs:120
  field ResolvedPolicy.hit in /tmp/.tmppSHdo8/grob/src/features/policies/resolved.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.0](https://github.com/azerozero/grob/compare/v0.25.3...v0.26.0) - 2026-03-22

### Added

- *(policies)* WI-5/6 quorum voting + multi-sig co-signing
- *(log-export)* WI-3 wire encrypted content emit in dispatch
- *(policies)* WI-2 wire policy evaluation into dispatch handlers
- *(policies)* WI-1 wire config + init for policy engine and HIT

### Other

- gitignore docs/reviews/ (generated audit reports)
- add key pool configuration to CONFIGURATION.md
- sync code→docs gaps (policies, encrypted audit, CLI commands)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).