### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0](https://github.com/azerozero/grob/compare/v0.26.0...v0.27.0) - 2026-03-22
+
+### Other
+
+- *(policies)* simplify merge, use enums, builder pattern
+
 ## [0.26.0](https://github.com/azerozero/grob/compare/v0.25.3...v0.26.0) - 2026-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.26.0 -> 0.27.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  grob::features::policies::hit_auth::HitAuthorization::new now takes 1 parameters instead of 7, in /tmp/.tmpVjukl4/grob/src/features/policies/hit_auth.rs:100
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.27.0](https://github.com/azerozero/grob/compare/v0.26.0...v0.27.0) - 2026-03-22

### Other

- *(policies)* simplify merge, use enums, builder pattern
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).