### PR TITLE
chore: release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0](https://github.com/azerozero/grob/compare/v0.27.0...v0.28.0) - 2026-03-22
+
+### Added
+
+- *(tooling)* policy benchmark, test-util mocks, EventBus no-op, HarnessConfig, otel cfg fix
+- *(policies)* WI-7 HIT Gateway — BufferingInput, arg-pattern deny, flag_patterns, receipts, multisig/quorum, approval endpoint
+
+### Other
+
+- update ADRs, benchmarks v0.26.0, OpenAPI spec, README, add policies explanation
+
 ## [0.27.0](https://github.com/azerozero/grob/compare/v0.26.0...v0.27.0) - 2026-03-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.27.0 -> 0.28.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field HitOverride.webhook_url in /tmp/.tmp4uMAyv/grob/src/features/policies/hit.rs:28
  field HitOverride.required_signatures in /tmp/.tmp4uMAyv/grob/src/features/policies/hit.rs:32
  field HitOverride.quorum in /tmp/.tmp4uMAyv/grob/src/features/policies/hit.rs:35
  field ReloadableState.policy_matcher in /tmp/.tmp4uMAyv/grob/src/server/mod.rs:80
  field AppConfig.harness in /tmp/.tmp4uMAyv/grob/src/cli/mod.rs:91

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuditEvent:HitApproval in /tmp/.tmp4uMAyv/grob/src/security/audit_log.rs:86
  variant WatchEvent:HitApprovalRequest in /tmp/.tmp4uMAyv/grob/src/features/watch/events.rs:106
  variant WatchEvent:HitFlaggedContent in /tmp/.tmp4uMAyv/grob/src/features/watch/events.rs:121
  variant WatchEvent:HitApprovalResponse in /tmp/.tmp4uMAyv/grob/src/features/watch/events.rs:132

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field policy_matcher of struct SecurityState, previously in file /tmp/release-plz-grob-foAXMt/worktree/target/package/grob-0.27.0/src/server/mod.rs:138
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.28.0](https://github.com/azerozero/grob/compare/v0.27.0...v0.28.0) - 2026-03-22

### Added

- *(tooling)* policy benchmark, test-util mocks, EventBus no-op, HarnessConfig, otel cfg fix
- *(policies)* WI-7 HIT Gateway — BufferingInput, arg-pattern deny, flag_patterns, receipts, multisig/quorum, approval endpoint

### Other

- update ADRs, benchmarks v0.26.0, OpenAPI spec, README, add policies explanation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).