### PR TITLE
chore: release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0](https://github.com/azerozero/grob/compare/v0.28.0...v0.29.0) - 2026-03-23
+
+### Other
+
+- *(policies)* remove touchid (not cross-platform), scope WI-8 to yubikey + openbao
+
 ## [0.28.0](https://github.com/azerozero/grob/compare/v0.27.0...v0.28.0) - 2026-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.28.0 -> 0.29.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant AuthMethod::Yubikey 2 -> 1 in /tmp/.tmpEUAckp/grob/src/features/policies/hit_auth.rs:32
  variant AuthMethod::Multisig 3 -> 2 in /tmp/.tmpEUAckp/grob/src/features/policies/hit_auth.rs:34
  variant AuthMethod::MachineKey 4 -> 3 in /tmp/.tmpEUAckp/grob/src/features/policies/hit_auth.rs:36
  variant AuthMethod::Webhook 5 -> 4 in /tmp/.tmpEUAckp/grob/src/features/policies/hit_auth.rs:38

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AuthMethod::Touchid, previously in file /tmp/release-plz-grob-XH9Wfi/worktree/target/package/grob-0.28.0/src/features/policies/hit_auth.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.29.0](https://github.com/azerozero/grob/compare/v0.28.0...v0.29.0) - 2026-03-23

### Other

- *(policies)* remove touchid (not cross-platform), scope WI-8 to yubikey + openbao
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).