### PR TITLE
chore: release v0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.1](https://github.com/azerozero/grob/compare/v0.29.0...v0.29.1) - 2026-03-23
+
+### Added
+
+- *(bench)* proxy+policy scenarios + fix --no-default-features CI failure
+
+### Other
+
+- *(adr)* WI-9 federated multi-enterprise HIT authorization
+
 ## [0.29.0](https://github.com/azerozero/grob/compare/v0.28.0...v0.29.0) - 2026-03-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.29.0 -> 0.29.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.29.1](https://github.com/azerozero/grob/compare/v0.29.0...v0.29.1) - 2026-03-23

### Added

- *(bench)* proxy+policy scenarios + fix --no-default-features CI failure

### Other

- *(adr)* WI-9 federated multi-enterprise HIT authorization
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).