### PR TITLE
chore: release v0.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.2](https://github.com/azerozero/grob/compare/v0.29.1...v0.29.2) - 2026-03-24
+
+### Fixed
+
+- *(bench)* gate policy_rule_count behind #[cfg(feature = "policies")]
+
 ## [0.29.1](https://github.com/azerozero/grob/compare/v0.29.0...v0.29.1) - 2026-03-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.29.1"
+version = "0.29.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.29.1 -> 0.29.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.29.2](https://github.com/azerozero/grob/compare/v0.29.1...v0.29.2) - 2026-03-24

### Fixed

- *(bench)* gate policy_rule_count behind #[cfg(feature = "policies")]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).