### PR TITLE
chore: release v0.29.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.5](https://github.com/azerozero/grob/compare/v0.29.4...v0.29.5) - 2026-03-26
+
+### Fixed
+
+- *(auth+compat)* JWKS EC P-256 support + OpenAI response translation
+
 ## [0.29.4](https://github.com/azerozero/grob/compare/v0.29.3...v0.29.4) - 2026-03-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.29.4"
+version = "0.29.5"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.29.4"
+version = "0.29.5"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.29.4 -> 0.29.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.29.5](https://github.com/azerozero/grob/compare/v0.29.4...v0.29.5) - 2026-03-26

### Fixed

- *(auth+compat)* JWKS EC P-256 support + OpenAI response translation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).