### PR TITLE
chore: release v0.29.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.9](https://github.com/azerozero/grob/compare/v0.29.8...v0.29.9) - 2026-03-26
+
+### Fixed
+
+- *(e2e)* jwks_refresh_interval=5s for fast JWKS retry in CI
+
 ## [0.29.8](https://github.com/azerozero/grob/compare/v0.29.7...v0.29.8) - 2026-03-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.29.8"
+version = "0.29.9"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.29.8"
+version = "0.29.9"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.29.8 -> 0.29.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.29.9](https://github.com/azerozero/grob/compare/v0.29.8...v0.29.9) - 2026-03-26

### Fixed

- *(e2e)* jwks_refresh_interval=5s for fast JWKS retry in CI
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).