### PR TITLE
chore: release v0.29.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.12](https://github.com/azerozero/grob/compare/v0.29.11...v0.29.12) - 2026-03-26
+
+### Fixed
+
+- *(ci)* e2e tests use binary artifact from test job, not GHCR
+- *(ci)* build grob from current commit via rust-cache, not GHCR latest
+
+### Other
+
+- *(deps)* update aws-lc-sys 0.39.0, aws-lc-rs 1.16.2, rustls 0.23.37
+
 ## [0.29.11](https://github.com/azerozero/grob/compare/v0.29.10...v0.29.11) - 2026-03-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.29.11"
+version = "0.29.12"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.29.11"
+version = "0.29.12"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.29.11 -> 0.29.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.29.12](https://github.com/azerozero/grob/compare/v0.29.11...v0.29.12) - 2026-03-26

### Fixed

- *(ci)* e2e tests use binary artifact from test job, not GHCR
- *(ci)* build grob from current commit via rust-cache, not GHCR latest

### Other

- *(deps)* update aws-lc-sys 0.39.0, aws-lc-rs 1.16.2, rustls 0.23.37
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).