### PR TITLE
chore: release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0](https://github.com/azerozero/grob/compare/v0.29.13...v0.30.0) - 2026-03-26
+
+### Added
+
+- *(dlp)* PiiAction::Canary + fix deny.toml + clippy
+
+### Fixed
+
+- *(e2e)* restore clean grob-test.toml (remove config-swap pollution)
+
+### Other
+
+- *(demo)* 4-pane tmux — Claude Code + grob watch + logs + audit
+- *(demo)* 2-pane real demo — grob exec claude + grob watch
+- *(demo)* 4-pane tmux demo + Claude Code takeover at end
+- *(demo)* auto-play demo + gitleaks ignore for fake AWS keys
+- *(ci)* fix push race — scope pre-push hooks + release-plz paths filter
+- *(e2e)* gitignore .bak files, remove tracked backup
+- *(deps)* remove resolved advisories from deny.toml ignore list
+- *(e2e)* S5 HIT flow script + fix config corruption
+- *(e2e)* 100% feature coverage — output DLP + HIT + 3 VidaiMock instances
+- *(e2e)* advanced audit/compliance tests + fix key leak in git
+- *(e2e)* 98 hurl + fan-out/audit/compliance scripts — 90%+ coverage
+- *(e2e)* 94 hurl tests + 12 audit scripts — full feature matrix
+
 ## [0.29.13](https://github.com/azerozero/grob/compare/v0.29.12...v0.29.13) - 2026-03-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.29.13"
+version = "0.30.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.29.13"
+version = "0.30.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.29.13 -> 0.30.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant PiiAction::Redact 0 -> 1 in /tmp/.tmp354cVv/grob/src/features/dlp/config.rs:158
  variant PiiAction::Log 1 -> 2 in /tmp/.tmp354cVv/grob/src/features/dlp/config.rs:160

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant PiiAction:Canary in /tmp/.tmp354cVv/grob/src/features/dlp/config.rs:156
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.30.0](https://github.com/azerozero/grob/compare/v0.29.13...v0.30.0) - 2026-03-26

### Added

- *(dlp)* PiiAction::Canary + fix deny.toml + clippy

### Fixed

- *(e2e)* restore clean grob-test.toml (remove config-swap pollution)

### Other

- *(demo)* 4-pane tmux — Claude Code + grob watch + logs + audit
- *(demo)* 2-pane real demo — grob exec claude + grob watch
- *(demo)* 4-pane tmux demo + Claude Code takeover at end
- *(demo)* auto-play demo + gitleaks ignore for fake AWS keys
- *(ci)* fix push race — scope pre-push hooks + release-plz paths filter
- *(e2e)* gitignore .bak files, remove tracked backup
- *(deps)* remove resolved advisories from deny.toml ignore list
- *(e2e)* S5 HIT flow script + fix config corruption
- *(e2e)* 100% feature coverage — output DLP + HIT + 3 VidaiMock instances
- *(e2e)* advanced audit/compliance tests + fix key leak in git
- *(e2e)* 98 hurl + fan-out/audit/compliance scripts — 90%+ coverage
- *(e2e)* 94 hurl tests + 12 audit scripts — full feature matrix
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).