### PR TITLE
chore: release v0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1](https://github.com/azerozero/grob/compare/v0.30.0...v0.30.1) - 2026-03-27
+
+### Added
+
+- *(ci)* 48/48 pipeline score — all 12 dimensions maxed
+- *(ci+dlp)* 85% pipeline score + code audit fixes
+- *(ci)* unified pipeline — build→test→push→e2e→release (biomimetic)
+
+### Fixed
+
+- remove wrong crates.io badge, update doc versions to v0.30.0, add property-based DLP tests
+- *(ci)* pin cosign-installer to v4.1.1 (no v4 major tag yet)
+- *(ci)* bump powerset timeout 5→8 min to cover setup overhead
+- *(ci)* remove deprecated rust-cache inputs and fix shellcheck warnings
+- *(ci)* bump GitHub Actions to latest major versions
+- *(ci)* use rhysd/actionlint@v1 action instead of manual curl
+- *(ci)* cargo hack group-features (not partition) + actionlint URL
+
+### Other
+
+- *(ci)* aggressive feature grouping to fix powerset timeout
+- *(ci)* shard feature powerset into 4 parallel jobs
+- *(ci)* use crane pull from GHCR instead of musl build in e2e
+- *(demo)* grob foreground debug in logs pane + fresh audit tail
+- *(demo)* grob foreground debug in logs pane + fresh audit tail
+
 ## [0.30.0](https://github.com/azerozero/grob/compare/v0.29.13...v0.30.0) - 2026-03-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.30.0 -> 0.30.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.30.1](https://github.com/azerozero/grob/compare/v0.30.0...v0.30.1) - 2026-03-27

### Added

- *(ci)* 48/48 pipeline score — all 12 dimensions maxed
- *(ci+dlp)* 85% pipeline score + code audit fixes
- *(ci)* unified pipeline — build→test→push→e2e→release (biomimetic)

### Fixed

- remove wrong crates.io badge, update doc versions to v0.30.0, add property-based DLP tests
- *(ci)* pin cosign-installer to v4.1.1 (no v4 major tag yet)
- *(ci)* bump powerset timeout 5→8 min to cover setup overhead
- *(ci)* remove deprecated rust-cache inputs and fix shellcheck warnings
- *(ci)* bump GitHub Actions to latest major versions
- *(ci)* use rhysd/actionlint@v1 action instead of manual curl
- *(ci)* cargo hack group-features (not partition) + actionlint URL

### Other

- *(ci)* aggressive feature grouping to fix powerset timeout
- *(ci)* shard feature powerset into 4 parallel jobs
- *(ci)* use crane pull from GHCR instead of musl build in e2e
- *(demo)* grob foreground debug in logs pane + fresh audit tail
- *(demo)* grob foreground debug in logs pane + fresh audit tail
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).