### PR TITLE
chore: release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0](https://github.com/azerozero/grob/compare/v0.30.1...v0.31.0) - 2026-03-28
+
+### Added
+
+- *(ci)* add unikernel build pipeline, tests, and documentation
+- *(pledge)* add structural tool filtering for LLM payloads (ADR-005)
+- add universal tool layer v1 (injection, aliasing, capability gating)
+- add unified JSON-RPC 2.0 Control Plane (Phase 1)
+- add unikernel feature flag for single-process deployment
+
+### Fixed
+
+- *(ci)* move --timeout flag before -- separator in cargo-mutants
+- *(ci)* make Codecov gate conditional on token availability
+
+### Other
+
+- add L2 property tests and L1 error snapshots
+- add 5-layer enterprise E2E test scaffolding
+- Merge feat/dlp-dynamic-names into develop
+- add insta snapshots, cargo-mutants CI, and enforce coverage gate
+
 ## [0.30.1](https://github.com/azerozero/grob/compare/v0.30.0...v0.30.1) - 2026-03-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.30.1 -> 0.31.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DlpConfig.names_mode in /tmp/.tmp2FzESJ/grob/src/features/dlp/config.rs:33
  field DlpConfig.auto_detect_cache_limit in /tmp/.tmp2FzESJ/grob/src/features/dlp/config.rs:37
  field AppConfig.tool_layer in /tmp/.tmp2FzESJ/grob/src/cli/mod.rs:76
  field AppConfig.pledge in /tmp/.tmp2FzESJ/grob/src/cli/mod.rs:92
  field SecurityState.tool_layer in /tmp/.tmp2FzESJ/grob/src/server/mod.rs:152

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method grob::traits::SpendTracking::provider_breakdown in file /tmp/.tmp2FzESJ/grob/src/traits.rs:110
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.31.0](https://github.com/azerozero/grob/compare/v0.30.1...v0.31.0) - 2026-03-28

### Added

- *(ci)* add unikernel build pipeline, tests, and documentation
- *(pledge)* add structural tool filtering for LLM payloads (ADR-005)
- add universal tool layer v1 (injection, aliasing, capability gating)
- add unified JSON-RPC 2.0 Control Plane (Phase 1)
- add unikernel feature flag for single-process deployment

### Fixed

- *(ci)* move --timeout flag before -- separator in cargo-mutants
- *(ci)* make Codecov gate conditional on token availability

### Other

- add L2 property tests and L1 error snapshots
- add 5-layer enterprise E2E test scaffolding
- Merge feat/dlp-dynamic-names into develop
- add insta snapshots, cargo-mutants CI, and enforce coverage gate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).