### PR TITLE
chore: release v0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.1](https://github.com/azerozero/grob/compare/v0.31.0...v0.31.1) - 2026-03-28
+
+### Fixed
+
+- guard dirs usage on feature flag instead of unikernel
+- *(test)* set GROB_HOME in preset test for unikernel compatibility
+- *(test)* serialize env-var-dependent DLP tests with mutex
+- *(ci)* disable jemalloc on Windows CI and add default impl for SpendTracking::provider_breakdown
+
 ## [0.31.0](https://github.com/azerozero/grob/compare/v0.30.1...v0.31.0) - 2026-03-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.31.0 -> 0.31.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.31.1](https://github.com/azerozero/grob/compare/v0.31.0...v0.31.1) - 2026-03-28

### Fixed

- guard dirs usage on feature flag instead of unikernel
- *(test)* set GROB_HOME in preset test for unikernel compatibility
- *(test)* serialize env-var-dependent DLP tests with mutex
- *(ci)* disable jemalloc on Windows CI and add default impl for SpendTracking::provider_breakdown
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).