### PR TITLE
chore: release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0](https://github.com/azerozero/grob/compare/v0.32.0...v0.33.0) - 2026-03-30
+
+### Fixed
+
+- *(ci)* replace archived CLA action with github-script workflow
+- *(ci)* add Claude to CLA allowlist and force Node.js 24
+
+### Other
+
+- remove unikernel feature flag and related infrastructure
+- add automatic stale branch cleanup workflow
+- release v0.32.0 ([#77](https://github.com/azerozero/grob/pull/77))
+
 ## [0.32.0](https://github.com/azerozero/grob/compare/v0.31.1...v0.32.0) - 2026-03-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.32.0 -> 0.33.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_missing.ron

Failed in:
  feature unikernel in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.33.0](https://github.com/azerozero/grob/compare/v0.32.0...v0.33.0) - 2026-03-30

### Fixed

- *(ci)* replace archived CLA action with github-script workflow
- *(ci)* add Claude to CLA allowlist and force Node.js 24

### Other

- remove unikernel feature flag and related infrastructure
- add automatic stale branch cleanup workflow
- release v0.32.0 ([#77](https://github.com/azerozero/grob/pull/77))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).