### PR TITLE
chore: release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0](https://github.com/azerozero/grob/compare/v0.33.0...v0.34.0) - 2026-03-31
+
+### Fixed
+
+- *(ci)* remove audit-wire path dep (breaks CI), fix shellcheck SC2086
+- *(ci+dlp+docs)* actionlint args, URL exfil request blocking, doc sync
+
+### Other
+
+- *(ci)* decouple test jobs from slow quality checks
+- *(server)* extract god functions, fix CI duplication, add spend tracking
+
 ## [0.33.0](https://github.com/azerozero/grob/compare/v0.32.0...v0.33.0) - 2026-03-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.33.0 -> 0.34.0 (⚠ API breaking changes)

### ⚠ `grob` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SpendData.by_provider_count in /tmp/.tmpdlZb40/grob/src/models/spend_data.rs:19
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.34.0](https://github.com/azerozero/grob/compare/v0.33.0...v0.34.0) - 2026-03-31

### Fixed

- *(ci)* remove audit-wire path dep (breaks CI), fix shellcheck SC2086
- *(ci+dlp+docs)* actionlint args, URL exfil request blocking, doc sync

### Other

- *(ci)* decouple test jobs from slow quality checks
- *(server)* extract god functions, fix CI duplication, add spend tracking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).