### PR TITLE
feat(auth): auto-detect and setup missing credentials on start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,19 @@ Grob accepts requests in Anthropic (`/v1/messages`) and OpenAI (`/v1/chat/comple
 - **Default host is IPv6**: `::1` (not `127.0.0.1`). Container mode uses `0.0.0.0`.
 - **Per-project config overlay**: `.grob.toml` in project root merges with global config (router, budget, preset overrides).
 
+## Git Flow
+
+```
+feature/* or fix/* ──► PR ──► develop ──► (release-plz PR) ──► main ──► tag v*
+```
+
+- **Never commit or push directly to `main`**. Only release-plz merges into `main`.
+- **Never create a PR with `develop` as the head targeting `main`**. This risks `develop` being deleted by GitHub's auto-delete-head-branch. Only release-plz creates PRs to `main` via temporary `release-plz-*` branches.
+- **Both `main` and `develop` are protected** (GitHub rulesets: no deletion, no force push).
+- **Always work on a feature branch** from `develop`: `feature/<topic>` or `fix/<topic>`.
+- **Conventional commits**: `feat:`, `fix:`, `refactor:`, `perf:` trigger version bumps via release-plz. Use `chore:`, `docs:`, `test:`, `style:` for non-release changes.
+- **Pre-commit hooks** via [prek](https://github.com/j178/prek): run `prek install` after cloning. Hooks run `cargo fmt`, `clippy`, `gitleaks` on commit and tests, audit, deny on push.
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,14 @@ feature/* ──► develop ──► (release-plz PR) ──► main ──► 
 3. **Release**: When CI passes on `develop`, release-plz automatically opens a PR to `main` (version bump, changelog, git tag).
 4. **`main`**: Production branch. Only receives merges from release-plz PRs. Tag push (`v*`) triggers cross-builds, container image, and Homebrew formula update.
 
+### Critical Rules
+
+- **Never commit or push directly to `main`**. All changes go through `develop` or feature branches.
+- **Never create a PR with `develop` as the head branch targeting `main`**. Only release-plz creates PRs to `main` (via temporary `release-plz-*` branches). Creating a manual PR from `develop` to `main` risks `develop` being deleted by GitHub's auto-delete-head-branch setting.
+- **Both `main` and `develop` are protected** by GitHub rulesets (no deletion, no force push).
+- **Conventional commits required**: `feat:`, `fix:`, `refactor:`, `perf:` with scopes trigger release-plz version bumps. Use `chore:`, `docs:`, `test:`, `style:` for non-release changes.
+- **release-plz `release_commits` filter**: only `feat|fix|refactor|perf` with allowed scopes (`auth`, `cache`, `server`, `dispatch`, `providers`, `router`, `dlp`, `security`, `storage`, `preset`, `cli`, `commands`, `compat`) or no scope trigger a version bump.
+
 ### CI Pipeline Stages (`.github/workflows/ci.yml`)
 
 | Stage | Trigger | Jobs |

--- a/src/auth/auto_flow.rs
+++ b/src/auth/auto_flow.rs
@@ -1,0 +1,336 @@
+//! Automatic credential setup at startup.
+//!
+//! Detects missing OAuth tokens and API keys, then interactively
+//! walks the user through setup. Providers that are already configured
+//! are silently skipped.
+
+use anyhow::Result;
+use secrecy::ExposeSecret;
+use std::io::{self, BufRead, Write};
+
+use crate::auth::oauth::{OAuthClient, OAuthConfig};
+use crate::auth::token_store::TokenStore;
+use crate::providers::{AuthType, ProviderConfig};
+
+/// Status of a single provider's credentials.
+pub enum CredentialStatus {
+    /// Provider is fully configured and ready.
+    Ready,
+    /// OAuth token is missing for this provider.
+    MissingOAuth {
+        provider_name: String,
+        oauth_provider_id: String,
+        oauth_type: String,
+    },
+    /// API key environment variable is not set.
+    MissingApiKey {
+        provider_name: String,
+        env_var: String,
+    },
+}
+
+/// Mapping from oauth_provider_id to the oauth_type string used by OAuthConfig.
+fn oauth_type_for_provider_id(oauth_provider_id: &str) -> Option<&'static str> {
+    match oauth_provider_id {
+        "anthropic-max" => Some("max"),
+        "openai-codex" => Some("openai-codex"),
+        "gemini" => Some("gemini"),
+        _ => None,
+    }
+}
+
+/// Build an OAuthConfig for a given oauth_type string.
+fn oauth_config_for_type(oauth_type: &str) -> Option<OAuthConfig> {
+    match oauth_type {
+        "max" => Some(OAuthConfig::anthropic()),
+        "openai-codex" => Some(OAuthConfig::openai_codex()),
+        "gemini" => Some(OAuthConfig::gemini()),
+        _ => None,
+    }
+}
+
+/// Checks all providers and returns their credential status.
+pub fn detect_credentials(
+    providers: &[ProviderConfig],
+    token_store: &TokenStore,
+) -> Vec<CredentialStatus> {
+    let mut statuses = Vec::new();
+
+    for provider in providers {
+        if provider.enabled == Some(false) {
+            continue;
+        }
+
+        match provider.auth_type {
+            AuthType::OAuth => {
+                if let Some(ref oauth_id) = provider.oauth_provider {
+                    let token = token_store.get(oauth_id);
+                    let has_valid_token = token.as_ref().is_some_and(|t| !t.is_expired());
+                    if has_valid_token {
+                        statuses.push(CredentialStatus::Ready);
+                    } else {
+                        let oauth_type = oauth_type_for_provider_id(oauth_id)
+                            .unwrap_or("max")
+                            .to_string();
+                        statuses.push(CredentialStatus::MissingOAuth {
+                            provider_name: provider.name.clone(),
+                            oauth_provider_id: oauth_id.clone(),
+                            oauth_type,
+                        });
+                    }
+                }
+            }
+            AuthType::ApiKey => {
+                if let Some(ref key) = provider.api_key {
+                    let key_str = key.expose_secret();
+                    if let Some(var) = key_str.strip_prefix('$') {
+                        if std::env::var(var).is_ok() {
+                            statuses.push(CredentialStatus::Ready);
+                        } else {
+                            statuses.push(CredentialStatus::MissingApiKey {
+                                provider_name: provider.name.clone(),
+                                env_var: var.to_string(),
+                            });
+                        }
+                    } else {
+                        // Inline key, always ready.
+                        statuses.push(CredentialStatus::Ready);
+                    }
+                }
+            }
+        }
+    }
+
+    statuses
+}
+
+/// Runs the interactive credential setup flow.
+///
+/// Returns the number of providers that were successfully configured.
+/// Providers the user skips are left unconfigured (they will be
+/// disabled at runtime).
+pub async fn run_interactive_flow(
+    statuses: Vec<CredentialStatus>,
+    token_store: &TokenStore,
+) -> Result<usize> {
+    let missing: Vec<_> = statuses
+        .into_iter()
+        .filter(|s| !matches!(s, CredentialStatus::Ready))
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(0);
+    }
+
+    let total = missing.len();
+    eprintln!();
+    eprintln!("  Missing credentials ({}):", total);
+    for status in &missing {
+        match status {
+            CredentialStatus::MissingOAuth {
+                provider_name,
+                oauth_provider_id,
+                ..
+            } => {
+                eprintln!(
+                    "    ⚠️  {} — OAuth token missing ({})",
+                    provider_name, oauth_provider_id
+                );
+            }
+            CredentialStatus::MissingApiKey {
+                provider_name,
+                env_var,
+            } => {
+                eprintln!("    ⚠️  {} — ${} not set", provider_name, env_var);
+            }
+            CredentialStatus::Ready => {}
+        }
+    }
+    eprintln!();
+
+    let mut configured = 0;
+    let stdin = io::stdin();
+
+    for status in missing {
+        match status {
+            CredentialStatus::MissingOAuth {
+                provider_name,
+                oauth_provider_id,
+                oauth_type,
+            } => {
+                if setup_oauth_interactive(
+                    &provider_name,
+                    &oauth_provider_id,
+                    &oauth_type,
+                    token_store,
+                    &stdin,
+                )
+                .await?
+                {
+                    configured += 1;
+                }
+            }
+            CredentialStatus::MissingApiKey {
+                provider_name,
+                env_var,
+            } => {
+                if setup_api_key_interactive(&provider_name, &env_var, &stdin)? {
+                    configured += 1;
+                }
+            }
+            CredentialStatus::Ready => {}
+        }
+    }
+
+    if configured > 0 {
+        eprintln!("  ✅ Configured {}/{} providers", configured, total);
+    }
+    eprintln!();
+
+    Ok(configured)
+}
+
+/// Interactive OAuth setup: print URL, wait for code, exchange.
+async fn setup_oauth_interactive(
+    provider_name: &str,
+    oauth_provider_id: &str,
+    oauth_type: &str,
+    token_store: &TokenStore,
+    stdin: &io::Stdin,
+) -> Result<bool> {
+    eprintln!("  {} (OAuth):", provider_name);
+    eprintln!("    [1] Authenticate now");
+    eprintln!("    [2] Skip (provider disabled until configured)");
+    eprint!("    > ");
+    io::stderr().flush()?;
+
+    let mut input = String::new();
+    stdin.lock().read_line(&mut input)?;
+    let choice = input.trim();
+
+    if choice != "1" {
+        eprintln!("    Skipped — run `grob connect` later");
+        eprintln!();
+        return Ok(false);
+    }
+
+    let config = match oauth_config_for_type(oauth_type) {
+        Some(c) => c,
+        None => {
+            eprintln!("    ❌ Unknown OAuth type: {}", oauth_type);
+            return Ok(false);
+        }
+    };
+
+    let client = OAuthClient::new(config, token_store.clone());
+    let auth_url = client.authorization_url()?;
+
+    eprintln!();
+    eprintln!("    Open this URL in your browser:");
+    eprintln!();
+    eprintln!("    {}", auth_url.url);
+    eprintln!();
+    eprintln!("    After authorizing, paste the code below.");
+    eprint!("    Code: ");
+    io::stderr().flush()?;
+
+    let mut code = String::new();
+    stdin.lock().read_line(&mut code)?;
+    let code = code.trim();
+
+    if code.is_empty() {
+        eprintln!("    ❌ No code entered, skipping");
+        return Ok(false);
+    }
+
+    match client
+        .exchange_code(code, auth_url.verifier.verifier(), oauth_provider_id)
+        .await
+    {
+        Ok(mut token) => {
+            // For Gemini, try to get project ID.
+            if oauth_type == "gemini" {
+                match client
+                    .load_code_assist(token.access_token.expose_secret())
+                    .await
+                {
+                    Ok(project_id) => {
+                        token.project_id = Some(project_id);
+                        token_store.save(token)?;
+                    }
+                    Err(_) => {
+                        // Optional for individual accounts.
+                    }
+                }
+            }
+            eprintln!("    ✅ {} authenticated", provider_name);
+            eprintln!();
+            Ok(true)
+        }
+        Err(e) => {
+            eprintln!("    ❌ Authentication failed: {}", e);
+            eprintln!("    Run `grob connect` to try again");
+            eprintln!();
+            Ok(false)
+        }
+    }
+}
+
+/// Interactive API key setup: prompt for key or skip.
+fn setup_api_key_interactive(
+    provider_name: &str,
+    env_var: &str,
+    stdin: &io::Stdin,
+) -> Result<bool> {
+    eprintln!("  {} (${})", provider_name, env_var);
+    eprintln!("    [1] Enter API key now");
+    eprintln!("    [2] Skip (provider disabled until configured)");
+    eprint!("    > ");
+    io::stderr().flush()?;
+
+    let mut input = String::new();
+    stdin.lock().read_line(&mut input)?;
+    let choice = input.trim();
+
+    if choice != "1" {
+        eprintln!("    Skipped — set ${} and restart", env_var);
+        eprintln!();
+        return Ok(false);
+    }
+
+    eprint!("    API key: ");
+    io::stderr().flush()?;
+
+    let mut key = String::new();
+    stdin.lock().read_line(&mut key)?;
+    let key = key.trim();
+
+    if key.is_empty() {
+        eprintln!("    ❌ No key entered, skipping");
+        return Ok(false);
+    }
+
+    // Store the key in ~/.grob/config.toml by updating the provider's api_key
+    // field from "$ENV_VAR" to the actual value.
+    let grob_dir = crate::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+        .join(".grob");
+    let config_path = grob_dir.join("config.toml");
+    if config_path.exists() {
+        let content = std::fs::read_to_string(&config_path)?;
+        // Replace the env var reference with the actual key.
+        let replaced = content.replace(&format!("\"${}\"", env_var), &format!("\"{}\"", key));
+        if replaced != content {
+            std::fs::write(&config_path, &replaced)?;
+            eprintln!("    ✅ API key saved to config.toml");
+            eprintln!();
+            return Ok(true);
+        }
+    }
+
+    // Fallback: tell the user to set the env var.
+    eprintln!("    Set the env var and restart:");
+    eprintln!("    export {}={}", env_var, key);
+    eprintln!();
+    Ok(true)
+}

--- a/src/auth/auto_flow.rs
+++ b/src/auth/auto_flow.rs
@@ -18,13 +18,18 @@ pub enum CredentialStatus {
     Ready,
     /// OAuth token is missing for this provider.
     MissingOAuth {
+        /// Human-readable provider name from config.
         provider_name: String,
+        /// Token store key (e.g. "anthropic-max", "openai-codex").
         oauth_provider_id: String,
+        /// OAuth type string for [`OAuthConfig`] lookup.
         oauth_type: String,
     },
     /// API key environment variable is not set.
     MissingApiKey {
+        /// Human-readable provider name from config.
         provider_name: String,
+        /// Environment variable name that should hold the key.
         env_var: String,
     },
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,5 +1,7 @@
 //! Authentication: JWT validation, OAuth flows, and token storage.
 
+/// Automatic credential setup at startup.
+pub mod auto_flow;
 /// JWT validation and claims extraction.
 pub mod jwt;
 /// OAuth PKCE flows for Anthropic, OpenAI, and Gemini.

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -16,6 +16,27 @@ pub async fn cmd_exec(
     let already_running = instance::is_instance_running(&config.server.host, effective_port).await;
 
     if !already_running {
+        // Pre-flight credential check before spawning background service.
+        if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+            if let Ok(store) =
+                crate::storage::GrobStore::open(&crate::storage::GrobStore::default_path())
+            {
+                let store = std::sync::Arc::new(store);
+                if let Ok(token_store) = crate::auth::TokenStore::with_store(store) {
+                    let statuses =
+                        crate::auth::auto_flow::detect_credentials(&config.providers, &token_store);
+                    let has_missing = statuses
+                        .iter()
+                        .any(|s| !matches!(s, crate::auth::auto_flow::CredentialStatus::Ready));
+                    if has_missing {
+                        let _ =
+                            crate::auth::auto_flow::run_interactive_flow(statuses, &token_store)
+                                .await;
+                    }
+                }
+            }
+        }
+
         eprintln!("Starting Grob on port {}...", effective_port);
         spawn_background_service(Some(effective_port), cli_config)?;
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -86,6 +86,26 @@ pub async fn cmd_start(
     }
     instance::cleanup_legacy_pid();
 
+    // Pre-flight credential check (interactive, only when TTY is available).
+    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        if let Ok(store) =
+            crate::storage::GrobStore::open(&crate::storage::GrobStore::default_path())
+        {
+            let store = std::sync::Arc::new(store);
+            if let Ok(token_store) = crate::auth::TokenStore::with_store(store) {
+                let statuses =
+                    crate::auth::auto_flow::detect_credentials(&config.providers, &token_store);
+                let has_missing = statuses
+                    .iter()
+                    .any(|s| !matches!(s, crate::auth::auto_flow::CredentialStatus::Ready));
+                if has_missing {
+                    let _ =
+                        crate::auth::auto_flow::run_interactive_flow(statuses, &token_store).await;
+                }
+            }
+        }
+    }
+
     start_foreground(config, config_source).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- On `grob start` or `grob exec`, detect providers with missing OAuth tokens or API keys
- If everything is configured: start immediately, zero prompts
- For each missing provider: offer to authenticate now or skip
- OAuth providers (anthropic-max, openai-codex, gemini): print auth URL, user pastes code
- API key providers (openrouter, etc.): prompt for key, save directly to config.toml
- TTY detection: non-interactive sessions skip all prompts

Fixes the broken UX where `grob setup` promised "OAuth will trigger automatically on first start" but never did.

## Test plan
- [ ] `grob start` with no OAuth token — should prompt for auth
- [ ] `grob start` with valid token — should start without prompting
- [ ] `grob exec -- claude` with missing creds — should prompt before launching
- [ ] Skip option works for each provider individually
- [ ] API key entry saves to config.toml
- [ ] Non-TTY (piped stdin) skips prompts entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)