### PR TITLE
chore: release v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1](https://github.com/azerozero/grob/compare/v0.35.0...v0.35.1) - 2026-04-01
+
+### Added
+
+- *(auth)* auto-detect and setup missing credentials on start
+
+### Fixed
+
+- *(ci)* split release-plz into release-pr and release-tag jobs
+
+### Other
+
+- *(claude,agents)* document git flow rules and branch protection
+- *(auth)* add doc comments to CredentialStatus fields
+- disable semver_check in release-plz (binary, not a crate)
+
 ## [0.34.0](https://github.com/azerozero/grob/compare/v0.33.0...v0.34.0) - 2026-03-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.35.0"
+version = "0.35.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.35.0 -> 0.35.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.35.1](https://github.com/azerozero/grob/compare/v0.35.0...v0.35.1) - 2026-04-01

### Added

- *(auth)* auto-detect and setup missing credentials on start

### Fixed

- *(ci)* split release-plz into release-pr and release-tag jobs

### Other

- *(claude,agents)* document git flow rules and branch protection
- *(auth)* add doc comments to CredentialStatus fields
- disable semver_check in release-plz (binary, not a crate)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).