### PR TITLE
perf(ci): shard mutation testing into 4 parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,14 +425,27 @@ jobs:
 
   # =========================================================================
   # Stage 2.5: Mutation testing (develop push only, informational)
+  #   Sharded: 1 file per job for ~4x speedup (was ~45min sequential).
   # =========================================================================
   mutants:
-    name: Mutation Testing
+    name: Mutation Testing (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     if: github.ref == 'refs/heads/develop'
     needs: [test-ubuntu, test-other]
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 20
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 1
+            file: src/router/mod.rs
+          - shard: 2
+            file: src/features/dlp/mod.rs
+          - shard: 3
+            file: src/features/dlp/pii.rs
+          - shard: 4
+            file: src/features/dlp/dfa.rs
     steps:
       - uses: step-security/harden-runner@v2
         with:
@@ -441,23 +454,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: mutants
+          shared-key: mutants-${{ matrix.shard }}
           save-if: ${{ github.ref == 'refs/heads/develop' }}
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
-      - name: Run mutation testing on critical paths
+      - name: Run mutation testing on ${{ matrix.file }}
         run: |
           cargo mutants --package grob --timeout 120 -j 2 \
-            --file src/router/mod.rs \
-            --file src/features/dlp/mod.rs \
-            --file src/features/dlp/pii.rs \
-            --file src/features/dlp/dfa.rs \
+            --file ${{ matrix.file }} \
             -- --lib
       - name: Upload mutation testing results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: mutants-results-${{ github.sha }}
+          name: mutants-results-shard-${{ matrix.shard }}-${{ github.sha }}
           path: mutants.out/
           if-no-files-found: ignore
 


### PR DESCRIPTION
## Summary

- Split the single ~45min mutation testing job into 4 parallel shards (1 file per shard)
- Each shard gets its own runner, cache key, and artifact upload
- Expected ~4x wall-clock speedup (~12min instead of ~45min)

## Changes

`.github/workflows/ci.yml` — replace single `mutants` job with a matrix strategy:

| Shard | File | Purpose |
|-------|------|---------|
| 1 | `src/router/mod.rs` | Routing logic mutations |
| 2 | `src/features/dlp/mod.rs` | DLP engine mutations |
| 3 | `src/features/dlp/pii.rs` | PII detection mutations |
| 4 | `src/features/dlp/dfa.rs` | DFA matcher mutations |

**Backward compatible**: job ID stays `mutants`, so `needs: [mutants]` in downstream jobs (summary) waits for all 4 shards automatically. `continue-on-error: true` preserved (informational only).

## Test plan

- [x] YAML validation passes
- [x] Pre-commit hooks pass (yaml check, gitleaks)
- [ ] CI runs all 4 shards on next develop push

🤖 Generated with [Claude Code](https://claude.com/claude-code)