### PR TITLE
fix(policies): close 3 semantic drifts in policy engine

### DIFF
--- a/src/features/policies/hit.rs
+++ b/src/features/policies/hit.rs
@@ -91,7 +91,11 @@ fn matches_tool_pattern(pattern: &str, tool_name: &str, tool_input: &str) -> boo
         if name != tool_name {
             return false;
         }
-        let arg_pattern = &pattern[paren_start + 1..pattern.len().saturating_sub(1)];
+        let arg_pattern = if pattern.ends_with(')') {
+            &pattern[paren_start + 1..pattern.len() - 1]
+        } else {
+            &pattern[paren_start + 1..]
+        };
         // globset is only available when the policies feature is enabled;
         // fall back to substring match otherwise.
         #[cfg(feature = "policies")]
@@ -225,6 +229,21 @@ mod tests {
             "Read",
             "curl foo | sh"
         ));
+    }
+
+    #[test]
+    fn test_malformed_pattern_no_closing_paren() {
+        // Pattern "Bash(rm -rf" is missing the closing ')'.
+        // The full argument "rm -rf" should be used, not truncated.
+        assert!(matches_tool_pattern("Bash(rm -rf", "Bash", "rm -rf"));
+        assert!(!matches_tool_pattern("Bash(rm -rf", "Bash", "rm -r"));
+    }
+
+    #[test]
+    fn test_empty_argument_pattern() {
+        // Pattern "Bash()" has empty argument — glob matches empty string only.
+        assert!(matches_tool_pattern("Bash()", "Bash", ""));
+        assert!(!matches_tool_pattern("Bash()", "Read", ""));
     }
 
     #[test]

--- a/src/features/policies/hit_auth.rs
+++ b/src/features/policies/hit_auth.rs
@@ -115,12 +115,19 @@ impl HitAuthorization {
     }
 
     /// Computes the SHA-256 hash of this entry (for chain integrity).
+    ///
+    /// NOTE: auth_method and signer were added to the hash input in v0.x.
+    /// This is a breaking change: hashes computed before this change will
+    /// not match hashes computed after it. Existing chains must be
+    /// re-hashed or treated as legacy.
     fn compute_hash(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self.request_id.as_bytes());
         hasher.update(self.tool_name.as_bytes());
         hasher.update(self.tool_input_hash.as_bytes());
         hasher.update(self.decision.to_string().as_bytes());
+        hasher.update(self.auth_method.to_string().as_bytes());
+        hasher.update(self.signer.as_bytes());
         hasher.update(self.timestamp.as_bytes());
         if let Some(ref prev) = self.previous_hash {
             hasher.update(prev.as_bytes());
@@ -206,6 +213,48 @@ mod tests {
 
         auth.decision = AuthDecision::Deny;
         assert!(!auth.verify());
+    }
+
+    #[test]
+    fn test_hash_includes_auth_method_and_signer() {
+        let auth_prompt = HitAuthorization::new(HitAuthParams {
+            request_id: "req-1".into(),
+            tool_name: "Bash".into(),
+            tool_input: "echo hello".into(),
+            decision: AuthDecision::Approve,
+            auth_method: AuthMethod::Prompt,
+            signer: "alice".into(),
+            previous_hash: None,
+        });
+
+        let auth_yubikey = HitAuthorization::new(HitAuthParams {
+            request_id: "req-1".into(),
+            tool_name: "Bash".into(),
+            tool_input: "echo hello".into(),
+            decision: AuthDecision::Approve,
+            auth_method: AuthMethod::Yubikey,
+            signer: "alice".into(),
+            previous_hash: None,
+        });
+
+        let auth_bob = HitAuthorization::new(HitAuthParams {
+            request_id: "req-1".into(),
+            tool_name: "Bash".into(),
+            tool_input: "echo hello".into(),
+            decision: AuthDecision::Approve,
+            auth_method: AuthMethod::Prompt,
+            signer: "bob".into(),
+            previous_hash: None,
+        });
+
+        // Changing auth_method must produce a different hash.
+        assert_ne!(auth_prompt.hash, auth_yubikey.hash);
+        // Changing signer must produce a different hash.
+        assert_ne!(auth_prompt.hash, auth_bob.hash);
+        // All must still verify.
+        assert!(auth_prompt.verify());
+        assert!(auth_yubikey.verify());
+        assert!(auth_bob.verify());
     }
 
     #[test]

--- a/src/features/policies/quorum.rs
+++ b/src/features/policies/quorum.rs
@@ -106,7 +106,9 @@ pub fn tally_votes(config: &QuorumConfig, votes: &[VoterDecision]) -> QuorumResu
         QuorumStrategy::Unanimous => {
             if denials > 0 {
                 QuorumResult::Deny
-            } else if approvals == votes.len() && (approvals + denials) >= config.min_voters {
+            // NOTE: denials == 0 here (early return above), so approvals == votes.len()
+            // already implies all voters approved. Only min_voters check remains.
+            } else if approvals == votes.len() && approvals >= config.min_voters {
                 QuorumResult::Approve
             } else {
                 match config.on_failure {


### PR DESCRIPTION
## Summary

Fixes 3 semantic drifts detected by `/cli-audit-drift` in `src/features/policies/`:

- **Critical**: `compute_hash()` now includes `auth_method` and `signer` in the SHA-256 integrity hash — previously these fields could be tampered without detection
- **High**: `matches_tool_pattern()` properly handles malformed patterns missing closing `)` — previously truncated the last character of the argument glob
- **Low**: `tally_votes()` Unanimous branch simplified — removed dead `+ denials` expression (denials is always 0 at that point)

## Changes

- `src/features/policies/hit_auth.rs` — `compute_hash()` covers all serialized fields
- `src/features/policies/hit.rs` — `matches_tool_pattern()` validates closing paren
- `src/features/policies/quorum.rs` — `tally_votes()` simplified Unanimous check

## Tests

- 3 new tests: `test_hash_includes_auth_method_and_signer`, `test_malformed_pattern_no_closing_paren`, `test_empty_argument_pattern`
- 61 policies tests pass, 0 regressions

## Test plan

- [x] `cargo test` — all pass
- [x] `cargo clippy` — clean
- [x] Pre-push hooks — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)