### PR TITLE
fix(security): ignore RUSTSEC-2025-0134 in cargo audit config

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,8 @@ ignore = [
     # rsa: Marvin Attack (timing sidechannel on PKCS#1 v1.5 decryption).
     # No impact: grob only uses RSA for JWT signature verification, not decryption.
     "RUSTSEC-2023-0071",
+    # rustls-pemfile: unmaintained, pulled transitively by axum-server 0.7.
+    # axum-server 0.8 migrates to rustls-pki-types, but rustls-acme 0.12 pins 0.7.
+    # Track: https://github.com/tokio-rs/axum/issues — bump when rustls-acme supports 0.8.
+    "RUSTSEC-2025-0134",
 ]

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -1,4 +1,8 @@
 //! Server lifecycle: bind, serve, drain, and OAuth callback spawning.
+//!
+//! TLS uses axum-server with rustls. The `rustls-pemfile` transitive dep
+//! is tracked under RUSTSEC-2025-0134 until axum-server migrates to
+//! `rustls-pki-types`.
 
 use super::{oauth_handlers, AppState};
 use crate::cli::AppConfig;


### PR DESCRIPTION
## Summary

- Add `RUSTSEC-2025-0134` (rustls-pemfile unmaintained) to `.cargo/audit.toml` so the Security Audit CI job passes
- Already ignored in `deny.toml` but was missing from `.cargo/audit.toml` used by `rustsec/audit-check`

## Root cause

`rustls-pemfile` is a transitive dependency of `axum-server 0.7` (used for TLS). `axum-server 0.8` migrates to `rustls-pki-types`, but `rustls-acme 0.12` still pins `axum-server 0.7` — so we cannot upgrade yet. The direct dep in `Cargo.toml` is also kept because `axum-server` re-exports it.

## Test plan

- [x] `cargo audit` returns 0 locally
- [x] Pre-push hooks pass
- [ ] CI Security Audit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)