### PR TITLE
fix(ci): raise mutation testing timeout to 60 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     needs: [test-ubuntu, test-other]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     continue-on-error: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Raise mutation testing shard `timeout-minutes` from 20 to 60. All 4 shards were cancelled — GitHub hosted runners need ~253s per mutant for a cold Rust build, which exceeds 20min for shards with many mutants.

## Test plan

- [x] YAML valid
- [ ] Mutation shards complete without cancellation on next develop push

🤖 Generated with [Claude Code](https://claude.com/claude-code)