### PR TITLE
ci: add nightly/beta toolchain schedule workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,49 @@
+name: Nightly Toolchain Check
+
+on:
+  schedule:
+    # Every day at 03:00 UTC.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+
+jobs:
+  check:
+    name: ${{ matrix.toolchain }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # Nightly may break — allow failure. Beta must pass.
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [beta, nightly]
+        os: [ubuntu-latest]
+    steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly-${{ matrix.toolchain }}
+          save-if: true
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Tests
+        run: cargo test --lib --bins
+      - name: Doc tests
+        run: cargo test --doc


### PR DESCRIPTION
## Summary

- New `.github/workflows/nightly.yml` — runs clippy + tests on Rust beta and nightly every day at 03:00 UTC
- Beta must pass, nightly is `continue-on-error: true` (allow failure)
- Manually triggerable via `workflow_dispatch`

## Test plan

- [x] YAML validates
- [ ] Schedule triggers correctly (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)