### PR TITLE
test: add property-based tests for DLP and router + feat(mcp): self-tuning tool

### DIFF
--- a/src/features/dlp/tests.rs
+++ b/src/features/dlp/tests.rs
@@ -288,6 +288,137 @@ proptest! {
         prop_assert!(matches!(result, Cow::Borrowed(_)),
             "Clean text should be zero-copy, got Owned");
     }
+
+    /// Arbitrary UTF-8 input never causes DFA scanner to panic.
+    #[test]
+    fn prop_dfa_no_panic(text in "\\PC{0,500}") {
+        let config = DlpConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let engine = DlpEngine::from_config(config).unwrap();
+        let _ = engine.scanner.might_contain_secret(&text);
+        let _ = engine.scanner.scan(&text);
+    }
+
+    /// Any Luhn-valid 16-digit number embedded in text is detected by the PII scanner.
+    #[test]
+    fn prop_pii_credit_card_luhn_detected(digits in proptest::collection::vec(0u8..10, 15..=15)) {
+        let check = {
+            let mut sum: u32 = 0;
+            for (i, &d) in digits.iter().rev().enumerate() {
+                let mut val = d as u32;
+                if i % 2 == 0 { val *= 2; if val > 9 { val -= 9; } }
+                sum += val;
+            }
+            ((10 - (sum % 10)) % 10) as u8
+        };
+        let mut full: Vec<u8> = digits;
+        full.push(check);
+        let cc: String = full.iter().map(|d| (b'0' + d) as char).collect();
+
+        let scanner = pii::PiiScanner::from_config(&PiiConfig {
+            credit_cards: true,
+            iban: false,
+            bic: false,
+            action: PiiAction::Redact,
+        }).unwrap();
+
+        let text = format!("pay {} now", cc);
+        if scanner.might_contain_pii(&text) {
+            if let Some((_, detections)) = scanner.redact(&text) {
+                let has_cc = detections.iter().any(|d| d.pii_type == pii::PiiType::CreditCard);
+                prop_assert!(has_cc, "Luhn-valid CC {} should be detected", cc);
+            }
+        }
+    }
+
+    /// Any mod97-valid IBAN embedded in text is detected by the PII scanner.
+    #[test]
+    fn prop_pii_iban_mod97_detected(body_digits in proptest::collection::vec(0u8..10, 18..=18)) {
+        let body: String = body_digits.iter().map(|d| (b'0' + d) as char).collect();
+        let rearranged = format!("{}FR00", body);
+        let mut remainder: u64 = 0;
+        for ch in rearranged.chars() {
+            let val = if ch.is_ascii_uppercase() {
+                (ch as u64) - 55
+            } else {
+                ch.to_digit(10).unwrap_or(0) as u64
+            };
+            if val >= 10 {
+                remainder = (remainder * 100 + val) % 97;
+            } else {
+                remainder = (remainder * 10 + val) % 97;
+            }
+        }
+        let check = 98 - remainder;
+        let iban = format!("FR{:02}{}", check, body);
+
+        let scanner = pii::PiiScanner::from_config(&PiiConfig {
+            credit_cards: false,
+            iban: true,
+            bic: false,
+            action: PiiAction::Redact,
+        }).unwrap();
+
+        let text = format!("transfer {} done", iban);
+        if scanner.might_contain_pii(&text) {
+            if let Some((_, detections)) = scanner.redact(&text) {
+                let has_iban = detections.iter().any(|d| d.pii_type == pii::PiiType::Iban);
+                prop_assert!(has_iban, "Valid IBAN {} should be detected", iban);
+            }
+        }
+    }
+
+    /// Sanitize output is always valid UTF-8 (no corruption).
+    #[test]
+    fn prop_dlp_utf8_roundtrip(text in "\\PC{0,500}") {
+        let config = DlpConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let engine = DlpEngine::from_config(config).unwrap();
+        let result = engine.sanitize_text(&text);
+        prop_assert!(result.len() <= text.len() + 1024,
+            "Output should not grow unboundedly");
+        let response = engine.sanitize_response_text(&result);
+        prop_assert!(response.len() <= result.len() + 1024);
+    }
+
+    /// Sanitize is idempotent: sanitize(sanitize(x)) == sanitize(x).
+    #[test]
+    fn prop_sanitize_idempotent(text in ".{0,200}") {
+        let config = test_config();
+        let engine = DlpEngine::from_config(config).unwrap();
+        let once = engine.sanitize_text(&text).into_owned();
+        let twice = engine.sanitize_text(&once).into_owned();
+        prop_assert_eq!(&once, &twice,
+            "Sanitize must be idempotent: second pass changed the text");
+    }
+
+    /// Sanitized output length is bounded: never more than input + a constant
+    /// (redaction markers like [REDACTED] or canary tokens have bounded size).
+    #[test]
+    fn prop_sanitize_length_bounded(text in ".{0,500}") {
+        let config = test_config();
+        let engine = DlpEngine::from_config(config).unwrap();
+        let result = engine.sanitize_text(&text);
+        // Canary tokens and pseudonyms can expand, but by at most ~200 bytes.
+        prop_assert!(result.len() <= text.len() + 200,
+            "Output {} bytes exceeds input {} + 200", result.len(), text.len());
+    }
+
+    /// If text contains a known secret prefix, sanitize must not preserve it.
+    #[test]
+    fn prop_secret_never_leaks(suffix in "[A-Za-z0-9]{36}") {
+        let secret = format!("ghp_{suffix}");
+        let config = test_config();
+        let engine = DlpEngine::from_config(config).unwrap();
+        let text = format!("My token is {secret} ok?");
+        let result = engine.sanitize_text(&text);
+        prop_assert!(!result.contains(&secret),
+            "Secret '{}' leaked through sanitize", &secret[..10]);
+    }
 }
 
 // ---------- DlpBlockError Display ----------

--- a/src/router/tests.rs
+++ b/src/router/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::cli::{RouterConfig, ServerConfig};
 use crate::models::{Message, MessageContent, ThinkingConfig};
+use proptest::prelude::*;
 
 fn create_test_config() -> AppConfig {
     AppConfig {
@@ -633,4 +634,62 @@ fn trailing_literal_alpha_run_with_digit_boundary() {
     assert_eq!(extract_trailing_literal_byte("foo123bar"), Some(b'b'));
     // "foo1ab" — last alpha run is "ab" (2 chars) → None.
     assert_eq!(extract_trailing_literal_byte("foo1ab"), None);
+}
+
+// ── Property-based tests ─────────────────────────────────────
+
+proptest! {
+    /// extract_trailing_literal_byte never panics on arbitrary input.
+    #[test]
+    fn prop_extract_trailing_never_panics(pattern in ".{0,200}") {
+        let _ = extract_trailing_literal_byte(&pattern);
+    }
+
+    /// Result is deterministic: same input always produces same output.
+    #[test]
+    fn prop_extract_trailing_deterministic(pattern in ".{0,100}") {
+        let a = extract_trailing_literal_byte(&pattern);
+        let b = extract_trailing_literal_byte(&pattern);
+        prop_assert_eq!(a, b);
+    }
+
+    /// If a result is returned, it must be a lowercase ASCII alphabetic byte.
+    #[test]
+    fn prop_extract_trailing_result_is_lowercase_alpha(pattern in ".{0,200}") {
+        if let Some(byte) = extract_trailing_literal_byte(&pattern) {
+            prop_assert!(byte.is_ascii_lowercase(),
+                "Returned byte {:?} is not lowercase ASCII alpha", byte as char);
+        }
+    }
+
+    /// Patterns containing '|' always return None (alternation bail).
+    #[test]
+    fn prop_alternation_always_none(
+        left in "[a-z]{3,10}",
+        right in "[a-z]{3,10}"
+    ) {
+        let pattern = format!("{left}|{right}");
+        prop_assert_eq!(extract_trailing_literal_byte(&pattern), None);
+    }
+
+    /// Router::new + route never panics on arbitrary model names.
+    #[test]
+    fn prop_router_classify_no_panic(model_name in "[a-zA-Z0-9._-]{0,80}") {
+        let config = create_test_config();
+        let router = Router::new(config);
+        let mut request = create_simple_request("hello world");
+        request.model = model_name;
+        let result = router.route(&mut request);
+        prop_assert!(result.is_ok(), "route() must not panic or error");
+    }
+
+    /// Route with arbitrary user text never panics.
+    #[test]
+    fn prop_route_arbitrary_text_no_panic(text in "\\PC{0,200}") {
+        let config = create_test_config();
+        let router = Router::new(config);
+        let mut request = create_simple_request(&text);
+        let result = router.route(&mut request);
+        prop_assert!(result.is_ok(), "route() must not panic on arbitrary text");
+    }
 }


### PR DESCRIPTION
## Summary

### Property-based tests (7 new proptests)
- DLP: sanitize idempotence, output length bounded, known secrets never leak
- Router: extract_trailing_literal_byte never panics, deterministic, result is lowercase alpha, alternation always None

### Self-tuning MCP tool (12 unit tests)
- New \`src/features/mcp/self_tuning.rs\` — \`grob_configure\` tool
- Whitelisted params: default_model, timeout_seconds, max_tokens, temperature, batch_size, retry_count
- Security params (budget, DLP, auth, policies, TLS) permanently denied
- Range validation, type checking, audit trail

## Test plan

- [x] 13/13 proptest pass
- [x] 12/12 self-tuning tests pass
- [x] All pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)