### PR TITLE
fix(ci): debloque pipeline mutants et ajoute shim docs

### DIFF
--- a/.github/workflows/ci-docs-shim.yml
+++ b/.github/workflows/ci-docs-shim.yml
@@ -1,0 +1,84 @@
+# Workflow "shim" pour debloquer les PR/push docs-only.
+#
+# CONTEXTE
+# --------
+# Le workflow principal `ci.yml` ignore les changements docs via `paths-ignore:
+# docs/**, **.md, ...` → sur une PR docs-only, aucun des required checks
+# declares dans le ruleset develop ("Rustfmt", "Clippy (ubuntu-latest)",
+# "Test (ubuntu-latest)") n'est rapporte → le `statusCheckRollup` reste vide
+# et GitHub bloque le merge (deadlock).
+#
+# Ce fichier declare les MEMES nom de workflow et memes job names que le
+# workflow principal, mais avec des steps triviaux. Il se declenche
+# exactement sur les chemins que `ci.yml` ignore, donc les deux workflows
+# sont mutuellement exclusifs pour les commits docs-purs.
+#
+# Pour les commits mixtes (docs + code), les deux workflows tournent
+# en parallele. GitHub resout le statut par derniere mise a jour par
+# nom ; le workflow principal (plus lent mais realiste) ecrase le shim
+# (instantane), donc le statut final reflete la realite du code.
+#
+# Refs : T-CI-0e sprint grob-rebuild-2026-04.
+
+name: CI
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "docs/**"
+      - "**.md"
+      - "LICENSE*"
+      - ".editorconfig"
+      - ".gitignore"
+      - ".gitattributes"
+      - "**.txt"
+      - "CODEOWNERS"
+      - ".vscode/**"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "docs/**"
+      - "**.md"
+      - "LICENSE*"
+      - ".editorconfig"
+      - ".gitignore"
+      - ".gitattributes"
+      - "**.txt"
+      - "CODEOWNERS"
+      - ".vscode/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-docs-shim-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Nom identique au job `fmt:` de ci.yml (L127-128).
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Docs-only change — Rustfmt shim
+        run: echo "Docs-only change, no Rust to format."
+
+  # Nom identique a la cellule matrice ubuntu-latest du job `clippy:` (L143-144).
+  clippy:
+    name: Clippy (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Docs-only change — Clippy shim
+        run: echo "Docs-only change, no Rust to lint."
+
+  # Nom identique au job gate `test-ubuntu-gate:` de ci.yml (L376-377).
+  test-ubuntu-gate:
+    name: Test (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Docs-only change — Test shim
+        run: echo "Docs-only change, no code to test."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,14 +440,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard: 1
+          - shard: "1"
             file: src/router/mod.rs
-          - shard: 2
+            mutants_shard: ""
+          - shard: "2"
             file: src/features/dlp/mod.rs
-          - shard: 3
+            mutants_shard: ""
+          # pii.rs depasse le budget 60min sur un seul job — split natif
+          # cargo-mutants `--shard K/N` sans toucher au code prod.
+          - shard: "3a"
             file: src/features/dlp/pii.rs
-          - shard: 4
+            mutants_shard: "0/2"
+          - shard: "3b"
+            file: src/features/dlp/pii.rs
+            mutants_shard: "1/2"
+          - shard: "4"
             file: src/features/dlp/dfa.rs
+            mutants_shard: ""
     steps:
       - uses: step-security/harden-runner@v2
         with:
@@ -462,7 +471,12 @@ jobs:
         run: cargo install cargo-mutants@24.11.2 --locked  # pinned — update manually
       - name: Run mutation testing on ${{ matrix.file }}
         run: |
+          SHARD_ARG=""
+          if [ -n "${{ matrix.mutants_shard }}" ]; then
+            SHARD_ARG="--shard ${{ matrix.mutants_shard }}"
+          fi
           cargo mutants --package grob --timeout 120 -j 2 \
+            $SHARD_ARG \
             --file ${{ matrix.file }} \
             -- --lib
       - name: Upload mutation testing results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,12 +471,12 @@ jobs:
         run: cargo install cargo-mutants@24.11.2 --locked  # pinned — update manually
       - name: Run mutation testing on ${{ matrix.file }}
         run: |
-          SHARD_ARG=""
+          SHARD_ARGS=()
           if [ -n "${{ matrix.mutants_shard }}" ]; then
-            SHARD_ARG="--shard ${{ matrix.mutants_shard }}"
+            SHARD_ARGS+=(--shard "${{ matrix.mutants_shard }}")
           fi
           cargo mutants --package grob --timeout 120 -j 2 \
-            $SHARD_ARG \
+            "${SHARD_ARGS[@]}" \
             --file ${{ matrix.file }} \
             -- --lib
       - name: Upload mutation testing results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -998,7 +998,9 @@ jobs:
       - feature-check
       - test-ubuntu
       - test-other
-      - mutants
+      # mutants retire du needs (T-CI-0d): le job a deja continue-on-error: true,
+      # le garder ici ne faisait que propager ses cancellations dans le statut
+      # global de la pipeline sans ajouter de signal utile.
       - build
       - container
       - e2e
@@ -1022,7 +1024,7 @@ jobs:
             const jobs = [
               'changes', 'fmt', 'clippy', 'audit', 'gitleaks', 'deny',
               'docs', 'machete', 'coverage', 'feature-check',
-              'test-ubuntu', 'test-other', 'mutants', 'build', 'container',
+              'test-ubuntu', 'test-other', 'build', 'container',
               'e2e', 'load', 'release', 'homebrew', 'homebrew-test',
               'validate-yaml', 'required'
             ];


### PR DESCRIPTION
## Resume

Bundle T-CI-0c + T-CI-0d + T-CI-0e pour finaliser la reparation du pipeline CI mutants et debloquer les PRs docs-only. Vote 3/3 APPROVE zone sensible.

## Commits

1. **T-CI-0c** (`0169d86`) — split shard 3 mutation testing sur dlp/pii.rs en deux jobs paralleles (3a/3b). Evite le timeout 60min du shard 3 unique.
2. **T-CI-0d** (`0beb479`) — retire mutants du `needs[]` du summary required (continue-on-error deja actif). Fix le statut pipeline "cancelled" qui polluait tous les runs depuis PR #95.
3. **T-CI-0e** (`bfd7b85`) — ajoute `.github/workflows/ci-docs-shim.yml` qui declare les 3 required checks (Rustfmt, Clippy ubuntu-latest, Test ubuntu-latest) en success sur paths docs-only. Debloque le dead-lock ruleset + paths-ignore.

## Pourquoi

Apres T-CI-0a + T-CI-0b mergees, le job mutants etait encore dans `needs[]` du summary. T-CI-0d l'enleve pour que les PRs a venir aient un statut "success" propre. T-CI-0c elimine en plus la cause racine du timeout sur pii.rs. T-CI-0e est le complement indispensable pour que les PRs docs-only (comme #101) puissent enfin merger.

## Scope

`.github/workflows/ci.yml` + `.github/workflows/ci-docs-shim.yml`. Zone sensible 3/3 approuvee.

## Validation pre-merge (vote)

- **Scope** APPROVE : uniquement workflows, shim legitime
- **Secu** APPROVE : match byte-pour-byte shim paths vs ci.yml paths-ignore, `continue-on-error` preserve, merge gate required inchange
- **Qualite** APPROVE : YAML valide, 3 commits distincts, commentaires POURQUOI presents

## Post-merge verifications

- [ ] Workflow CI reporte success (plus cancelled)
- [ ] Job mutants tourne avec les shards 1, 2, 3a, 3b, 4 (5 shards au lieu de 4)
- [ ] Summary job n'inclut plus mutants dans needs[]