### PR TITLE
fix(ci): sync-main ouvre une PR au lieu de pusher directement sur main

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -11,21 +11,62 @@ permissions:
 
 jobs:
   sync:
-    name: Merge develop into main
+    name: Open sync PR develop → main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: main
+          ref: develop
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
-      - name: Fast-forward main to develop
+      - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git merge origin/develop --ff-only || {
-            echo "::warning::Fast-forward failed, falling back to merge"
-            git merge origin/develop --no-edit -X theirs
-          }
-          git push origin main
+
+      # Branch protection on `main` requires all changes to go through a PR.
+      # We therefore create a short-lived sync branch, push it, and open a PR
+      # that can be auto-merged once CI passes. This replaces the previous
+      # direct `git push origin main` which was rejected by the ruleset.
+      - name: Create sync branch from develop
+        id: branch
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          BRANCH="sync-main-${TAG}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          git checkout -B "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
+
+      - name: Open PR from sync branch to main
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          TAG="${{ steps.branch.outputs.tag }}"
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          # Idempotent: reuse existing open PR if one exists.
+          EXISTING=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number' || true)
+          if [ -n "$EXISTING" ]; then
+            echo "Reusing existing PR #$EXISTING"
+            PR_NUMBER="$EXISTING"
+          else
+            PR_NUMBER=$(gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(sync): develop → main (${TAG})" \
+              --body "Automated sync triggered by tag \`${TAG}\`. This PR promotes the develop branch to main so the tag can be released. Safe to auto-merge once CI passes." \
+              --label sync-main \
+              | grep -oE '[0-9]+$')
+            echo "Opened PR #$PR_NUMBER"
+          fi
+          echo "pr=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge on PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          # Try auto-merge; if it fails (e.g. branch protection disables it),
+          # leave the PR open for manual merge. We don't fail the job.
+          gh pr merge "${{ steps.branch.outputs.branch }}" --auto --squash --delete-branch \
+            || echo "::warning::Auto-merge could not be enabled — merge the PR manually."


### PR DESCRIPTION
## Context

Issue #82 items #27, #28, #37 — le workflow `Sync develop to main` echoue systematiquement depuis 2026-03-31 (3 runs en echec : v0.34.0, v0.35.0, v0.35.1). Consequence : `main` reste stuck a une version ancienne et les tags pointent sur des Cargo.toml desaccordes.

## Root cause

`sync-main.yml` faisait un `git push origin main` direct apres un fast-forward merge depuis develop. La ruleset de branch protection sur `main` exige que **tout changement passe par une PR** :

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Fix

Le workflow cree maintenant une branche courte `sync-main-<tag>`, la pousse, et ouvre une PR vers main avec label \`sync-main\`. L'auto-merge squash est active pour que la PR se merge automatiquement des que la CI passe (fallback sur merge manuel si l'auto-merge est bloque).

## What this unblocks

- Les futures tags (v0.35.2+) declencheront une sync propre develop → main
- Les releases GitHub pourront etre publiees (issue #82 #28)
- Le container ghcr.io/azerozero/grob:latest sera mis a jour
- Le formula Homebrew pourra se rafraichir (#82 #34)

## What this does NOT fix (hors scope de cette PR)

- **Main est actuellement en retard** (v0.35.0 alors que develop est en v0.35.1+). Une PR manuelle one-shot \`chore(sync): rattrapage main à develop\` sera necessaire pour ramener main a niveau. Ce fix assure que les prochains tags n'auront plus ce probleme.
- Les GitHub Releases manquantes v0.31-v0.34 devront etre recreees manuellement avec \`gh release create\`.

## Test plan

- [ ] CI verte sur cette PR (lint, yaml, actionlint integre)
- [ ] Apres merge : simuler un tag push sur develop (ou attendre la prochaine release) et verifier que le workflow ouvre bien une PR au lieu de pusher directement

## Notes

Branche poussee via SSH parce que le token gh en place n'a pas le scope \`workflow\` (necessaire pour modifier \`.github/workflows/*\`). A noter dans la dette technique si le workflow CI lui-meme tente de pusher des fichiers workflow a l'avenir.