### PR TITLE
refactor(arch): supprime 4 fonctions pub mortes

### DIFF
--- a/src/features/mcp/matrix.rs
+++ b/src/features/mcp/matrix.rs
@@ -316,11 +316,6 @@ impl ToolMatrix {
         self.runtime_scores.insert(tool, provider, score).await;
     }
 
-    /// Returns a snapshot of all runtime scores as (tool, provider, score) triples.
-    pub async fn all_runtime_scores(&self) -> Vec<(String, String, ToolScore)> {
-        self.runtime_scores.snapshot().await
-    }
-
     /// Returns a cloned handle to the runtime scores.
     ///
     /// Used internally by the bench engine to update scores directly.

--- a/src/features/mcp/mod.rs
+++ b/src/features/mcp/mod.rs
@@ -63,11 +63,6 @@ impl McpState {
         self.scorer.read().await
     }
 
-    /// Returns a write-locked reference to the scorer.
-    pub async fn write_scorer(&self) -> tokio::sync::RwLockWriteGuard<'_, ToolScorer> {
-        self.scorer.write().await
-    }
-
     /// Returns a handle to the runtime scores for the bench engine.
     pub(crate) fn matrix_handle(&self) -> matrix::RuntimeScores {
         self.matrix.scores_handle()

--- a/src/features/tool_layer/catalog.rs
+++ b/src/features/tool_layer/catalog.rs
@@ -42,11 +42,6 @@ pub fn lookup(name: &str) -> Option<&'static CatalogEntry> {
     CATALOG.get(name)
 }
 
-/// Returns all canonical tool names in the catalog.
-pub fn all_names() -> impl Iterator<Item = &'static str> {
-    CATALOG.keys().map(String::as_str)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -24,23 +24,6 @@ pub fn write_pid() -> io::Result<()> {
     Ok(())
 }
 
-/// Atomically write PID file (write to .tmp then rename).
-/// Prevents partial reads during hot restarts.
-pub fn write_pid_atomic() -> io::Result<()> {
-    let pid_file = pid_file_path();
-
-    if let Some(parent) = pid_file.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    let tmp_file = pid_file.with_extension("pid.tmp");
-    let pid = std::process::id();
-    fs::write(&tmp_file, pid.to_string())?;
-    fs::rename(&tmp_file, &pid_file)?;
-    tracing::info!("PID {} written atomically to {:?}", pid, pid_file);
-    Ok(())
-}
-
 /// Read the PID from the PID file
 pub fn read_pid() -> io::Result<u32> {
     let pid_file = pid_file_path();


### PR DESCRIPTION
## Contexte

CM-3 du plan cli-cycle : 75 fonctions pub potentiellement mortes (12.9%).
Investigation : le compilateur Rust confirme seulement 4 fonctions reellement mortes
(les 71 autres sont des faux positifs de l'analyse statique grep — appelees via
dispatch, traits, tests d'integration, ou cfg conditionnel).

## Fonctions supprimees

- `ToolMatrix::all_runtime_scores` (mcp/matrix.rs) — zero appelant
- `McpState::write_scorer` (mcp/mod.rs) — zero appelant
- `catalog::all_names` (tool_layer/catalog.rs) — zero appelant
- `write_pid_atomic` (pid.rs) — zero appelant

## Tests

672 tests passent. cargo clippy clean.