### PR TITLE
fix(ci): release-tag ecoute develop pour creer les tags

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,16 +12,18 @@ on:
       - "src/**"
       - "Cargo.toml"
       - "Cargo.lock"
-  # Trigger when a release-plz PR is merged into main.
-  # PAT pushes don't trigger `push` events, so we use pull_request instead.
+  # Trigger when a release-plz PR (label: release) is merged.
+  # release-plz creates PRs targeting develop (the working branch),
+  # so we must listen on develop, not just main.
   pull_request:
     types: [closed]
     branches:
+      - develop
       - main
 
 jobs:
-  # On develop push: create/update the release PR targeting main,
-  # then tag any unreleased versions.
+  # On develop push: create/update the release PR targeting develop,
+  # with version bump + changelog.
   release-pr:
     name: Create Release PR
     if: github.event_name == 'push'
@@ -43,7 +45,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
-  # On release PR merged into main: create git tag.
+  # On release PR merged into develop (or main): create git tag.
+  # The tag push then triggers sync-main.yml which promotes develop → main via PR.
   release-tag:
     name: Tag Release
     if: >-
@@ -58,7 +61,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: main
+          ref: develop
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Root cause

Cercle vicieux dans le pipeline release :
1. release-pr crée des PR vers **develop** (correct — c'est la branche de travail)
2. release-tag ne fire que sur PR merged to **main** (incorrect)
3. sync-main ne fire que sur **tag push**
4. → Pas de tag → pas de sync → pas de release

## Fix

- `pull_request.branches` : `[main]` → `[develop, main]`
- `release-tag` checkout `ref` : `main` → `develop`

## New flow

```
push develop → release-pr → PR develop → merge → release-tag → tag v0.36.0
                                                      ↓
                                            sync-main.yml → PR main
                                                      ↓
                                            container + homebrew
```