### PR TITLE
fix(ci): ajoute rust-cache au workflow CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: codeql
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
Corrige la regression pipeline (-12 pts) identifiee par cli-cycle. Le job CodeQL buildait a froid (~15 min par run). Ajoute Swatinem/rust-cache avec shared-key codeql.