### PR TITLE
fix(dlp): emet les WatchEvents pour les actions DLP de sanitization

### DIFF
--- a/src/commands/bench/mod.rs
+++ b/src/commands/bench/mod.rs
@@ -41,6 +41,28 @@ pub use payloads::{parse_payload_flag, PayloadSize};
 const WARMUP_REQUESTS: usize = 50;
 const CONCURRENT_DURATION_SECS: u64 = 5;
 
+// ── Shared context ──────────────────────────────────────────────────────
+
+/// Groups the shared state threaded through every benchmark function.
+struct BenchContext {
+    backend_url: String,
+    routing_patterns: Arc<Vec<regex::Regex>>,
+    auth_token: Option<String>,
+    auth_key_hash: Option<String>,
+    requests: usize,
+    effective_concurrency: usize,
+    format: String,
+}
+
+impl BenchContext {
+    /// Whether the benchmark runs in concurrent (throughput) mode.
+    fn is_concurrent(&self) -> bool {
+        self.effective_concurrency > 1
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
 /// Builds an HTTP client matching grob's real provider client optimizations.
 fn build_bench_client() -> reqwest::Client {
     reqwest::Client::builder()
@@ -50,6 +72,22 @@ fn build_bench_client() -> reqwest::Client {
         .http2_adaptive_window(true)
         .build()
         .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+/// Polls a proxy health endpoint until it responds (max 500 ms).
+async fn wait_for_proxy_ready(proxy_url: &str) {
+    let client = reqwest::Client::new();
+    for _ in 0..50 {
+        if client
+            .get(format!("{proxy_url}/health"))
+            .send()
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }
 
 // ── Entry point ─────────────────────────────────────────────────────────
@@ -166,19 +204,19 @@ pub async fn cmd_bench(
         .await?;
     anyhow::ensure!(probe_resp.status() == 200, "Mock backend returned non-200");
 
+    let ctx = BenchContext {
+        backend_url: backend_url.clone(),
+        routing_patterns,
+        auth_token,
+        auth_key_hash,
+        requests,
+        effective_concurrency,
+        format: format.to_string(),
+    };
+
     // ── Escalation mode ─────────────────────────────────────────────────
     if escalate {
-        return run_escalation(
-            &backend_url,
-            &routing_patterns,
-            &dlp_patterns,
-            &auth_token,
-            &auth_key_hash,
-            requests,
-            concurrency,
-            format,
-        )
-        .await;
+        return run_escalation(&ctx).await;
     }
 
     let scenarios = build_scenarios(with_auth);
@@ -228,40 +266,18 @@ pub async fn cmd_bench(
                     enable_auth: scenario.enable_auth,
                     enable_rate_limit: scenario.enable_rate_limit,
                     enable_cache: scenario.enable_cache,
-                    auth_key_hash: auth_key_hash.clone(),
-                    routing_patterns: routing_patterns.clone(),
+                    auth_key_hash: ctx.auth_key_hash.clone(),
+                    routing_patterns: ctx.routing_patterns.clone(),
                     dlp_patterns: effective_dlp_patterns,
                     #[cfg(feature = "policies")]
                     policy_matcher,
                 };
                 let (proxy_url, _proxy_handle) = start_proxy(state).await;
-
-                // Wait for proxy to be ready.
-                let client = reqwest::Client::new();
-                for _ in 0..50 {
-                    if client
-                        .get(format!("{proxy_url}/health"))
-                        .send()
-                        .await
-                        .is_ok()
-                    {
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
+                wait_for_proxy_ready(&proxy_url).await;
                 proxy_url
             };
 
-            let (s, rps) = measure(
-                &target_url,
-                &body,
-                &auth_token,
-                scenario.enable_auth,
-                is_concurrent,
-                effective_concurrency,
-                requests,
-            )
-            .await?;
+            let (s, rps) = measure(&ctx, &target_url, &body, scenario.enable_auth).await?;
 
             if is_direct {
                 baseline_p50.insert(psize.label(), s.p50);
@@ -366,14 +382,16 @@ pub async fn cmd_bench(
 ///
 /// Returns `(stats, Option<rps>)`.
 async fn measure(
+    ctx: &BenchContext,
     target_url: &str,
     body: &serde_json::Value,
-    auth_token: &Option<String>,
     enable_auth: bool,
-    is_concurrent: bool,
-    effective_concurrency: usize,
-    requests: usize,
 ) -> Result<(stats::Stats, Option<f64>)> {
+    let auth_token = &ctx.auth_token;
+    let is_concurrent = ctx.is_concurrent();
+    let effective_concurrency = ctx.effective_concurrency;
+    let requests = ctx.requests;
+
     if is_concurrent {
         let warmup_client = reqwest::Client::builder()
             .pool_max_idle_per_host(10)
@@ -441,41 +459,21 @@ async fn measure(
 // ── Escalation mode ─────────────────────────────────────────────────────
 
 /// Runs the escalation staircase benchmark.
-#[allow(clippy::too_many_arguments)]
-async fn run_escalation(
-    backend_url: &str,
-    routing_patterns: &Arc<Vec<regex::Regex>>,
-    _all_dlp_patterns: &Arc<Vec<regex::Regex>>,
-    auth_token: &Option<String>,
-    auth_key_hash: &Option<String>,
-    requests: usize,
-    concurrency: usize,
-    format: &str,
-) -> Result<()> {
-    let cpu_count = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1);
-    let effective_concurrency = if concurrency == 0 {
-        cpu_count
-    } else {
-        concurrency
-    };
-    let is_concurrent = effective_concurrency > 1;
-
+async fn run_escalation(ctx: &BenchContext) -> Result<()> {
     // Escalation always uses medium payload (realistic Claude Code traffic).
     let psize = PayloadSize::Medium;
     let steps = build_escalation_steps();
 
-    if format != "json" {
+    if ctx.format != "json" {
         println!();
         println!("  Feature Escalation ({})", psize.label());
-        if is_concurrent {
+        if ctx.is_concurrent() {
             println!(
                 "  Mode: concurrent (c={}), {} sec/step",
-                effective_concurrency, CONCURRENT_DURATION_SECS
+                ctx.effective_concurrency, CONCURRENT_DURATION_SECS
             );
         } else {
-            println!("  Requests: {} per step", requests);
+            println!("  Requests: {} per step", ctx.requests);
         }
         println!();
     }
@@ -493,54 +491,32 @@ async fn run_escalation(
         };
 
         let target_url = if is_direct {
-            backend_url.to_string()
+            ctx.backend_url.clone()
         } else {
             let dlp_pats = match step.dlp_pattern_set {
                 Some(set) => compile_dlp_patterns(set),
                 None => Arc::new(Vec::new()),
             };
             let state = ProxyState {
-                backend_url: backend_url.to_string(),
+                backend_url: ctx.backend_url.clone(),
                 client: build_bench_client(),
                 enable_routing: step.enable_routing,
                 enable_dlp: step.enable_dlp,
                 enable_auth: step.enable_auth,
                 enable_rate_limit: step.enable_rate_limit,
                 enable_cache: step.enable_cache,
-                auth_key_hash: auth_key_hash.clone(),
-                routing_patterns: routing_patterns.clone(),
+                auth_key_hash: ctx.auth_key_hash.clone(),
+                routing_patterns: ctx.routing_patterns.clone(),
                 dlp_patterns: dlp_pats,
                 #[cfg(feature = "policies")]
                 policy_matcher: None,
             };
             let (proxy_url, _handle) = start_proxy(state).await;
-
-            // Wait for proxy readiness.
-            let client = reqwest::Client::new();
-            for _ in 0..50 {
-                if client
-                    .get(format!("{proxy_url}/health"))
-                    .send()
-                    .await
-                    .is_ok()
-                {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
+            wait_for_proxy_ready(&proxy_url).await;
             proxy_url
         };
 
-        let (s, rps) = measure(
-            &target_url,
-            &body,
-            auth_token,
-            step.enable_auth,
-            is_concurrent,
-            effective_concurrency,
-            requests,
-        )
-        .await?;
+        let (s, rps) = measure(ctx, &target_url, &body, step.enable_auth).await?;
 
         if is_direct {
             baseline_p50 = Some(s.p50);
@@ -567,45 +543,24 @@ async fn run_escalation(
     {
         let all_dlp = compile_dlp_patterns(DlpPatternSet::Full);
         let state = ProxyState {
-            backend_url: backend_url.to_string(),
+            backend_url: ctx.backend_url.clone(),
             client: build_bench_client(),
             enable_routing: true,
             enable_dlp: true,
-            enable_auth: auth_token.is_some(),
+            enable_auth: ctx.auth_token.is_some(),
             enable_rate_limit: true,
             enable_cache: true,
-            auth_key_hash: auth_key_hash.clone(),
-            routing_patterns: routing_patterns.clone(),
+            auth_key_hash: ctx.auth_key_hash.clone(),
+            routing_patterns: ctx.routing_patterns.clone(),
             dlp_patterns: all_dlp,
             #[cfg(feature = "policies")]
             policy_matcher: None,
         };
         let (proxy_url, _handle) = start_proxy(state).await;
-
-        let client = reqwest::Client::new();
-        for _ in 0..50 {
-            if client
-                .get(format!("{proxy_url}/health"))
-                .send()
-                .await
-                .is_ok()
-            {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        wait_for_proxy_ready(&proxy_url).await;
 
         let body = secrets_request_body(psize);
-        let (s, rps) = measure(
-            &proxy_url,
-            &body,
-            auth_token,
-            auth_token.is_some(),
-            is_concurrent,
-            effective_concurrency,
-            requests,
-        )
-        .await?;
+        let (s, rps) = measure(ctx, &proxy_url, &body, ctx.auth_token.is_some()).await?;
 
         let overhead = baseline_p50.map(|b| s.p50.saturating_sub(b));
 
@@ -618,7 +573,7 @@ async fn run_escalation(
     }
 
     // ── Render output ────────────────────────────────────────────────
-    if format == "json" {
+    if ctx.format == "json" {
         let json_rows: Vec<ScenarioResult> = rows
             .iter()
             .map(|r| ScenarioResult {
@@ -640,8 +595,8 @@ async fn run_escalation(
                     .unwrap_or(1),
                 grob_version: env!("CARGO_PKG_VERSION").to_string(),
             },
-            requests_per_scenario: requests,
-            concurrency: effective_concurrency,
+            requests_per_scenario: ctx.requests,
+            concurrency: ctx.effective_concurrency,
             payload_sizes: vec![psize.label().to_string()],
             scenarios: json_rows,
             verdict: "escalation".to_string(),

--- a/src/features/dlp/mod.rs
+++ b/src/features/dlp/mod.rs
@@ -362,7 +362,7 @@ impl DlpEngine {
     pub fn sanitize_request_checked(
         &self,
         request: &mut CanonicalRequest,
-    ) -> Result<(), DlpBlockError> {
+    ) -> Result<Vec<DlpActionReport>, DlpBlockError> {
         let all_text = Self::extract_request_text(request);
 
         // Stage 0: Prompt injection detection (before name anonymization)
@@ -388,8 +388,8 @@ impl DlpEngine {
         }
 
         // Then do normal sanitization (names, secrets, PII)
-        self.sanitize_request(request);
-        Ok(())
+        let reports = self.sanitize_request_reported(request);
+        Ok(reports)
     }
 
     /// Extract all text content from a request for scanning.
@@ -751,7 +751,7 @@ impl crate::traits::DlpPipeline for DlpEngine {
     fn sanitize_request_checked(
         &self,
         request: &mut CanonicalRequest,
-    ) -> Result<(), DlpBlockError> {
+    ) -> Result<Vec<DlpActionReport>, DlpBlockError> {
         self.sanitize_request_checked(request)
     }
 

--- a/src/features/watch/tui.rs
+++ b/src/features/watch/tui.rs
@@ -323,6 +323,14 @@ fn draw_alerts(app: &App, frame: &mut Frame, area: ratatui::layout::Rect) {
     frame.render_widget(para, area);
 }
 
+/// Renders a timestamp column for the event stream.
+fn timestamp_span(ts: &chrono::DateTime<chrono::Utc>) -> Span<'static> {
+    Span::styled(
+        format!("  {}  ", ts.format("%H:%M:%S")),
+        Style::default().fg(Color::DarkGray),
+    )
+}
+
 /// Formats a single event as a colored ListItem.
 fn format_event(event: &WatchEvent) -> ListItem<'static> {
     let line = match event {
@@ -333,10 +341,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             timestamp,
             ..
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled("→ ", Style::default().fg(Color::Cyan)),
             Span::styled(format!("{:<24}", model), Style::default().fg(Color::White)),
             Span::styled(
@@ -355,10 +360,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             timestamp,
             ..
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled("← ", Style::default().fg(Color::Green)),
             Span::styled(format!("{:<24}", model), Style::default().fg(Color::White)),
             Span::styled(
@@ -379,10 +381,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             timestamp,
             ..
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled(
                 format!("✗ {}: {}", provider, error),
                 Style::default().fg(Color::Red),
@@ -396,10 +395,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             timestamp,
             ..
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled(
                 format!("DLP {}: {} ({})", action, rule_type, detail),
                 Style::default()
@@ -415,10 +411,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             timestamp,
             ..
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled(
                 format!("FALLBACK {} → {} ({})", from_provider, to_provider, reason),
                 Style::default()
@@ -432,10 +425,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             state,
             timestamp,
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled(
                 format!("CB {} → {}", provider, state),
                 Style::default().fg(if state == "open" {
@@ -456,10 +446,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             timestamp,
             ..
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled(
                 format!("HIT awaiting approval: {}", tool_name),
                 Style::default()
@@ -474,10 +461,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             timestamp,
             ..
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled(
                 format!(
                     "HIT {} {}",
@@ -494,10 +478,7 @@ fn format_event(event: &WatchEvent) -> ListItem<'static> {
             timestamp,
             ..
         } => Line::from(vec![
-            Span::styled(
-                format!("  {}  ", timestamp.format("%H:%M:%S")),
-                Style::default().fg(Color::DarkGray),
-            ),
+            timestamp_span(timestamp),
             Span::styled(
                 format!("HIT flagged [{pattern}]: {matched_text}"),
                 Style::default()

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -298,68 +298,74 @@ fn scan_dlp_input(
         return Ok(());
     }
 
-    if let Err(block_err) = dlp_engine.sanitize_request_checked(request) {
-        // Emit DLP block event for `grob watch`.
-        let (block_rule_type, block_detail) = match &block_err {
-            crate::features::dlp::DlpBlockError::InjectionBlocked(dets) => {
-                ("injection", format!("{} injection(s) detected", dets.len()))
-            }
-            crate::features::dlp::DlpBlockError::UrlExfilBlocked(dets) => (
-                "url_exfil",
-                format!("{} exfiltration URL(s) detected", dets.len()),
-            ),
-        };
-        ctx.state.event_bus.emit(WatchEvent::DlpAction {
-            request_id: ctx.req_id.to_string(),
-            direction: DlpDirection::Request,
-            action: "block".into(),
-            rule_type: block_rule_type.into(),
-            detail: block_detail,
-            timestamp: chrono::Utc::now(),
-        });
-
-        let had_injection = matches!(
-            &block_err,
-            crate::features::dlp::DlpBlockError::InjectionBlocked(_)
-        );
-        let risk = crate::security::risk::assess_risk(&crate::security::risk::SecurityOutcome {
-            dlp_rules_triggered: 1,
-            was_blocked: true,
-            had_injection,
-            had_pii: false,
-        });
-
-        let compliance = &ctx.inner.config.compliance;
-        if compliance.enabled && compliance.risk_classification {
-            let threshold = crate::security::audit_log::RiskLevel::from_str_threshold(
-                &compliance.escalation_threshold,
-            );
-            crate::security::risk::maybe_escalate(&crate::security::risk::EscalationEvent {
-                risk,
-                threshold,
-                webhook_url: &compliance.escalation_webhook,
-                event_id: ctx.req_id,
-                tenant_id: ctx.tenant_id.as_deref().unwrap_or("anon"),
-                model: &ctx.model,
-            });
+    match dlp_engine.sanitize_request_checked(request) {
+        Ok(reports) => {
+            ctx.emit_dlp_events(&reports, DlpDirection::Request);
+            Ok(())
         }
+        Err(block_err) => {
+            // Emit DLP block event for `grob watch`.
+            let (block_rule_type, block_detail) = match &block_err {
+                crate::features::dlp::DlpBlockError::InjectionBlocked(dets) => {
+                    ("injection", format!("{} injection(s) detected", dets.len()))
+                }
+                crate::features::dlp::DlpBlockError::UrlExfilBlocked(dets) => (
+                    "url_exfil",
+                    format!("{} exfiltration URL(s) detected", dets.len()),
+                ),
+            };
+            ctx.state.event_bus.emit(WatchEvent::DlpAction {
+                request_id: ctx.req_id.to_string(),
+                direction: DlpDirection::Request,
+                action: "block".into(),
+                rule_type: block_rule_type.into(),
+                detail: block_detail,
+                timestamp: chrono::Utc::now(),
+            });
 
-        ctx.log_audit_if_enabled(AuditEntry {
-            action: crate::security::audit_log::AuditEvent::DlpBlock,
-            backend: "BLOCKED",
-            dlp_rules: vec![block_err.to_string()],
-            duration_ms: ctx.start_time.elapsed().as_millis() as u64,
-            model_name: Some(&ctx.model),
-            token_counts: None,
-            risk_level: Some(risk),
-            dlp_blocked: true,
-            dlp_had_injection: had_injection,
-            dlp_had_pii: false,
-            dlp_had_redact_or_warn: false,
-        });
-        return Err(AppError::DlpBlocked(format!("{}", block_err)));
+            let had_injection = matches!(
+                &block_err,
+                crate::features::dlp::DlpBlockError::InjectionBlocked(_)
+            );
+            let risk =
+                crate::security::risk::assess_risk(&crate::security::risk::SecurityOutcome {
+                    dlp_rules_triggered: 1,
+                    was_blocked: true,
+                    had_injection,
+                    had_pii: false,
+                });
+
+            let compliance = &ctx.inner.config.compliance;
+            if compliance.enabled && compliance.risk_classification {
+                let threshold = crate::security::audit_log::RiskLevel::from_str_threshold(
+                    &compliance.escalation_threshold,
+                );
+                crate::security::risk::maybe_escalate(&crate::security::risk::EscalationEvent {
+                    risk,
+                    threshold,
+                    webhook_url: &compliance.escalation_webhook,
+                    event_id: ctx.req_id,
+                    tenant_id: ctx.tenant_id.as_deref().unwrap_or("anon"),
+                    model: &ctx.model,
+                });
+            }
+
+            ctx.log_audit_if_enabled(AuditEntry {
+                action: crate::security::audit_log::AuditEvent::DlpBlock,
+                backend: "BLOCKED",
+                dlp_rules: vec![block_err.to_string()],
+                duration_ms: ctx.start_time.elapsed().as_millis() as u64,
+                model_name: Some(&ctx.model),
+                token_counts: None,
+                risk_level: Some(risk),
+                dlp_blocked: true,
+                dlp_had_injection: had_injection,
+                dlp_had_pii: false,
+                dlp_had_redact_or_warn: false,
+            });
+            Err(AppError::DlpBlocked(format!("{}", block_err)))
+        }
     }
-    Ok(())
 }
 
 /// Handle fan-out strategy (dispatch to multiple providers in parallel).

--- a/src/server/responses_compat/transform.rs
+++ b/src/server/responses_compat/transform.rs
@@ -63,6 +63,55 @@ fn convert_tools(tools: &[serde_json::Value]) -> Vec<Tool> {
         .collect()
 }
 
+/// Merges a tool-use block into the last assistant message if possible.
+///
+/// Returns `None` if merged, or `Some(block)` if a new message is needed.
+fn merge_tool_use_into_assistant(
+    messages: &mut [Message],
+    block: ContentBlock,
+) -> Option<ContentBlock> {
+    if let Some(last) = messages.last_mut() {
+        if last.role == "assistant" {
+            match &mut last.content {
+                MessageContent::Blocks(blocks) => {
+                    blocks.push(block);
+                    return None;
+                }
+                MessageContent::Text(text) => {
+                    let mut blocks = Vec::new();
+                    if !text.is_empty() {
+                        blocks.push(ContentBlock::text(std::mem::take(text), None));
+                    }
+                    blocks.push(block);
+                    last.content = MessageContent::Blocks(blocks);
+                    return None;
+                }
+            }
+        }
+    }
+    Some(block)
+}
+
+/// Merges a tool-result block into the last user message if it only contains tool results.
+///
+/// Returns `None` if merged, or `Some(block)` if a new message is needed.
+fn merge_tool_result_into_user(
+    messages: &mut [Message],
+    block: ContentBlock,
+) -> Option<ContentBlock> {
+    if let Some(last) = messages.last_mut() {
+        if last.role == "user" {
+            if let MessageContent::Blocks(ref mut existing) = &mut last.content {
+                if existing.iter().all(|b| b.is_tool_result()) {
+                    existing.push(block);
+                    return None;
+                }
+            }
+        }
+    }
+    Some(block)
+}
+
 /// Transforms a [`ResponsesRequest`] into a [`CanonicalRequest`].
 ///
 /// # Errors
@@ -121,34 +170,13 @@ pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<Canonic
                             serde_json::from_str(arguments).unwrap_or_default();
                         let block = ContentBlock::tool_use(tool_id, name.clone(), input);
 
-                        // Merge into previous assistant message if possible
-                        if let Some(last) = messages.last_mut() {
-                            if last.role == "assistant" {
-                                match &mut last.content {
-                                    MessageContent::Blocks(blocks) => {
-                                        blocks.push(block);
-                                        continue;
-                                    }
-                                    MessageContent::Text(text) => {
-                                        let mut blocks = Vec::new();
-                                        if !text.is_empty() {
-                                            blocks.push(ContentBlock::text(
-                                                std::mem::take(text),
-                                                None,
-                                            ));
-                                        }
-                                        blocks.push(block);
-                                        last.content = MessageContent::Blocks(blocks);
-                                        continue;
-                                    }
-                                }
-                            }
+                        if let Some(remaining) = merge_tool_use_into_assistant(&mut messages, block)
+                        {
+                            messages.push(Message {
+                                role: "assistant".to_string(),
+                                content: MessageContent::Blocks(vec![remaining]),
+                            });
                         }
-
-                        messages.push(Message {
-                            role: "assistant".to_string(),
-                            content: MessageContent::Blocks(vec![block]),
-                        });
                     }
                     InputItem::FunctionCallOutput { call_id, output } => {
                         // function_call_output → user message with tool_result block
@@ -159,23 +187,12 @@ pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<Canonic
                             cache_control: None,
                         });
 
-                        // Merge into previous user message with tool results
-                        if let Some(last) = messages.last_mut() {
-                            if last.role == "user" {
-                                if let MessageContent::Blocks(ref mut existing) = &mut last.content
-                                {
-                                    if existing.iter().all(|b| b.is_tool_result()) {
-                                        existing.push(block);
-                                        continue;
-                                    }
-                                }
-                            }
+                        if let Some(remaining) = merge_tool_result_into_user(&mut messages, block) {
+                            messages.push(Message {
+                                role: "user".to_string(),
+                                content: MessageContent::Blocks(vec![remaining]),
+                            });
                         }
-
-                        messages.push(Message {
-                            role: "user".to_string(),
-                            content: MessageContent::Blocks(vec![block]),
-                        });
                     }
                 }
             }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -23,7 +23,10 @@ pub trait DlpPipeline: Send + Sync {
     fn sanitize_request_checked(
         &self,
         request: &mut CanonicalRequest,
-    ) -> std::result::Result<(), crate::features::dlp::DlpBlockError>;
+    ) -> std::result::Result<
+        Vec<crate::features::dlp::DlpActionReport>,
+        crate::features::dlp::DlpBlockError,
+    >;
 
     /// Sanitizes response text (de-anonymize + secret scan).
     fn sanitize_response_text<'a>(&self, text: &'a str) -> std::borrow::Cow<'a, str>;
@@ -265,8 +268,11 @@ pub mod mocks {
         fn sanitize_request_checked(
             &self,
             _request: &mut CanonicalRequest,
-        ) -> std::result::Result<(), crate::features::dlp::DlpBlockError> {
-            Ok(())
+        ) -> std::result::Result<
+            Vec<crate::features::dlp::DlpActionReport>,
+            crate::features::dlp::DlpBlockError,
+        > {
+            Ok(vec![])
         }
         fn sanitize_response_text<'a>(&self, text: &'a str) -> std::borrow::Cow<'a, str> {
             std::borrow::Cow::Borrowed(text)


### PR DESCRIPTION
Corrige la derive contractuelle : sanitize_request_checked retourne Vec<DlpActionReport>, scan_dlp_input emet les WatchEvents pour les actions non-bloquantes (redact, canary, warn). 728 tests verts.