### PR TITLE
fix(ci): gitleaks gere les tag pushes (before=0000000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,15 @@ jobs:
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
             | sudo tar xz -C /usr/local/bin gitleaks
       - name: Run gitleaks
-        run: gitleaks detect --source . --log-opts "${{ github.event.before }}..${{ github.sha }}" --verbose
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+            # Tag push or new branch — no valid range, scan last 1 commit
+            echo "Tag/new-branch push detected — scanning HEAD~1..HEAD"
+            gitleaks detect --source . --log-opts "HEAD~1..HEAD" --verbose
+          else
+            gitleaks detect --source . --log-opts "${BEFORE}..${{ github.sha }}" --verbose
+          fi
 
   deny:
     name: Cargo Deny


### PR DESCRIPTION
Tag push → github.event.before=0000000 → gitleaks range invalide → fail → Required checks fail → release bloquee. Fix: detecte le zero SHA et scan HEAD~1..HEAD.