### PR TITLE
fix(security): ajoute le guard is_key_denied a la web config API

### DIFF
--- a/src/server/config_api.rs
+++ b/src/server/config_api.rs
@@ -7,8 +7,9 @@ use axum::{
     Json,
 };
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
+use super::config_guard::is_section_or_key_denied;
 use super::{AppError, AppState, ReloadableState};
 
 /// Redact an API key for safe display (show first 4 + last 4 chars)
@@ -91,6 +92,32 @@ pub(crate) async fn update_config_json(
 ) -> Result<Json<serde_json::Value>, AppError> {
     // Remove null values (TOML doesn't support null)
     remove_null_values(&mut new_config);
+
+    // Reject writes to denied sections or keys before touching disk.
+    if let Some(obj) = new_config.as_object() {
+        for (section, value) in obj {
+            // Whole-section deny check (providers, dlp).
+            if is_section_or_key_denied(section, "") {
+                warn!(section = %section, "config API: denied write to protected section");
+                return Err(AppError::ParseError(format!(
+                    "denied: section '{}' cannot be modified via the config API",
+                    section
+                )));
+            }
+            // Per-key deny check within allowed sections.
+            if let Some(inner) = value.as_object() {
+                for key in inner.keys() {
+                    if is_section_or_key_denied(section, key) {
+                        warn!(section = %section, key = %key, "config API: denied write to protected key");
+                        return Err(AppError::ParseError(format!(
+                            "denied: {}.{} cannot be modified via the config API",
+                            section, key
+                        )));
+                    }
+                }
+            }
+        }
+    }
 
     // Write back to config file (only works with local file configs)
     let config_path = match &state.config_source {

--- a/src/server/config_guard.rs
+++ b/src/server/config_guard.rs
@@ -1,0 +1,111 @@
+//! Centralized deny-list for configuration updates.
+//!
+//! Both the MCP self-tuning path (`grob_configure`) and the web config API
+//! (`/api/config`) share this guard to prevent credential leaks and security
+//! weakening through config writes.
+
+#[cfg(feature = "mcp")]
+use crate::features::mcp::server::types::ConfigSection;
+
+/// Top-level TOML sections that are never writable via any config API.
+const DENIED_SECTIONS: &[&str] = &["providers", "dlp"];
+
+/// Per-section keys that are never writable via any config API.
+const DENIED_KEYS: &[(&str, &str)] = &[
+    ("router", "api_key"),
+    ("budget", "api_key"),
+    ("cache", "api_key"),
+];
+
+/// Checks whether a (section, key) pair is blocked by the deny-list.
+///
+/// Returns `true` when the write must be rejected:
+/// - The entire `providers` section (contains API keys).
+/// - The entire `dlp` section (security must not be weakened).
+/// - Any `api_key` field in any section.
+pub fn is_section_or_key_denied(section: &str, key: &str) -> bool {
+    if DENIED_SECTIONS.contains(&section) {
+        return true;
+    }
+    if key == "api_key" {
+        return true;
+    }
+    DENIED_KEYS.iter().any(|(s, k)| *s == section && *k == key)
+}
+
+/// Validates a key update against the deny-list using [`ConfigSection`].
+///
+/// Delegates to [`is_section_or_key_denied`] after converting the enum to a
+/// string. This keeps the MCP path backward-compatible.
+#[cfg(feature = "mcp")]
+pub fn is_key_denied(section: &ConfigSection, key: &str) -> bool {
+    let section_str = match section {
+        ConfigSection::Router => "router",
+        ConfigSection::Budget => "budget",
+        ConfigSection::Dlp => "dlp",
+        ConfigSection::Cache => "cache",
+    };
+    is_section_or_key_denied(section_str, key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deny_providers_section() {
+        assert!(is_section_or_key_denied("providers", "anything"));
+        assert!(is_section_or_key_denied("providers", "api_key"));
+        assert!(is_section_or_key_denied("providers", "name"));
+    }
+
+    #[test]
+    fn deny_dlp_section() {
+        assert!(is_section_or_key_denied("dlp", "enabled"));
+        assert!(is_section_or_key_denied("dlp", "scan_input"));
+        assert!(is_section_or_key_denied("dlp", "scan_output"));
+        assert!(is_section_or_key_denied("dlp", "no_builtins"));
+        assert!(is_section_or_key_denied("dlp", "anything"));
+    }
+
+    #[test]
+    fn deny_api_key_anywhere() {
+        assert!(is_section_or_key_denied("router", "api_key"));
+        assert!(is_section_or_key_denied("budget", "api_key"));
+        assert!(is_section_or_key_denied("cache", "api_key"));
+        assert!(is_section_or_key_denied("server", "api_key"));
+    }
+
+    #[test]
+    fn allow_safe_keys() {
+        assert!(!is_section_or_key_denied("router", "default"));
+        assert!(!is_section_or_key_denied("router", "think"));
+        assert!(!is_section_or_key_denied("budget", "monthly_limit_usd"));
+        assert!(!is_section_or_key_denied("cache", "enabled"));
+        assert!(!is_section_or_key_denied("cache", "ttl_secs"));
+    }
+
+    #[cfg(feature = "mcp")]
+    mod mcp_compat {
+        use super::*;
+        use crate::features::mcp::server::types::ConfigSection;
+
+        #[test]
+        fn deny_dlp_via_enum() {
+            assert!(is_key_denied(&ConfigSection::Dlp, "enabled"));
+            assert!(is_key_denied(&ConfigSection::Dlp, "scan_input"));
+        }
+
+        #[test]
+        fn deny_credentials_via_enum() {
+            assert!(is_key_denied(&ConfigSection::Router, "api_key"));
+            assert!(is_key_denied(&ConfigSection::Budget, "api_key"));
+        }
+
+        #[test]
+        fn allow_safe_via_enum() {
+            assert!(!is_key_denied(&ConfigSection::Router, "default"));
+            assert!(!is_key_denied(&ConfigSection::Cache, "ttl_secs"));
+        }
+    }
+}

--- a/src/server/mcp_handlers.rs
+++ b/src/server/mcp_handlers.rs
@@ -80,34 +80,7 @@ fn to_json_value(result: Result<JsonRpcResponse, JsonRpcError>) -> serde_json::V
 
 // ── grob_configure self-tuning ──────────────────────────────────────────────
 
-/// Keys that agents are never allowed to modify via `grob_configure`.
-///
-/// Covers credentials, security core switches, and audit — any field whose
-/// modification could weaken the security posture or expose secrets.
-const DENIED_KEYS: &[(&str, &str)] = &[
-    ("router", "api_key"),
-    ("budget", "api_key"),
-    ("cache", "api_key"),
-];
-
-/// Validates that a key update is not on the deny-list.
-fn is_key_denied(section: &ConfigSection, key: &str) -> bool {
-    let section_str = match section {
-        ConfigSection::Router => "router",
-        ConfigSection::Budget => "budget",
-        ConfigSection::Dlp => "dlp",
-        ConfigSection::Cache => "cache",
-    };
-
-    // DLP section is fully read-only (security cannot be weakened via self-tuning)
-    if section_str == "dlp" {
-        return true;
-    }
-
-    DENIED_KEYS
-        .iter()
-        .any(|(s, k)| *s == section_str && *k == key)
-}
+use super::config_guard::is_key_denied;
 
 /// Returns a safe JSON view of the requested config section (no secrets).
 fn read_config_section(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,6 +4,8 @@
 pub(crate) mod audit;
 mod budget;
 mod config_api;
+/// Centralized deny-list for configuration updates.
+pub(crate) mod config_guard;
 /// Core dispatch pipeline: DLP, cache, route, provider loop.
 pub(crate) mod dispatch;
 mod endpoints;


### PR DESCRIPTION
Item critique #1 cli-cycle : la web config API acceptait des ecritures sans deny-list. Centralise is_key_denied et l'applique dans update_config_json. 735 tests.