### PR TITLE
docs: ajoute 16 doc-tests executables aux fonctions publiques cles

### DIFF
--- a/src/features/dlp/dfa.rs
+++ b/src/features/dlp/dfa.rs
@@ -63,6 +63,21 @@ impl SecretScanner {
     ///
     /// Uses `regex_syntax::parse` for fast AST-only validation. Full DFA
     /// compilation is deferred to the first `scan()` call via `OnceLock`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::features::dlp::config::{SecretRule, SecretAction};
+    ///
+    /// let rules = vec![SecretRule {
+    ///     name: "github_token".into(),
+    ///     prefix: "ghp_".into(),
+    ///     pattern: "ghp_[A-Za-z0-9]{36}".into(),
+    ///     action: SecretAction::Canary,
+    /// }];
+    /// let scanner = grob::features::dlp::dfa::SecretScanner::new(&rules, &[]);
+    /// assert!(!scanner.is_empty());
+    /// ```
     pub fn new(secrets: &[SecretRule], custom_prefixes: &[CustomPrefixRule]) -> Self {
         let mut patterns = Vec::new();
         let mut rules = Vec::new();
@@ -126,6 +141,15 @@ impl SecretScanner {
     }
 
     /// Returns true if there are no rules loaded.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::features::dlp::dfa::SecretScanner;
+    ///
+    /// let scanner = SecretScanner::new(&[], &[]);
+    /// assert!(scanner.is_empty());
+    /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.rules.is_empty()
@@ -166,6 +190,15 @@ impl SecretScanner {
     }
 
     /// Returns the length of the longest pattern *string* (not max match length).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::features::dlp::dfa::SecretScanner;
+    ///
+    /// let empty = SecretScanner::new(&[], &[]);
+    /// assert_eq!(empty.max_pattern_str_len(), 0);
+    /// ```
     pub fn max_pattern_str_len(&self) -> usize {
         self.patterns.iter().map(|p| p.len()).max().unwrap_or(0)
     }
@@ -177,8 +210,28 @@ impl SecretScanner {
             .get_or_init(|| regex::Regex::new(&self.patterns[idx]).expect("pre-validated regex"))
     }
 
-    /// Scan text and return all matches with positions.
-    /// Caller should check `might_contain_secret()` first for fast rejection.
+    /// Scans text and returns all matches with positions.
+    ///
+    /// Caller should check [`might_contain_secret`](Self::might_contain_secret)
+    /// first for fast rejection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::features::dlp::config::{SecretRule, SecretAction};
+    /// use grob::features::dlp::dfa::SecretScanner;
+    ///
+    /// let rules = vec![SecretRule {
+    ///     name: "aws_key".into(),
+    ///     prefix: "AKIA".into(),
+    ///     pattern: "AKIA[0-9A-Z]{16}".into(),
+    ///     action: SecretAction::Redact,
+    /// }];
+    /// let scanner = SecretScanner::new(&rules, &[]);
+    /// let matches = scanner.scan("key=AKIAIOSFODNN7EXAMPLE done");
+    /// assert_eq!(matches.len(), 1);
+    /// assert_eq!(matches[0].matched_len, 20);
+    /// ```
     pub fn scan(&self, text: &str) -> Vec<SecretMatch> {
         if self.rules.is_empty() {
             return Vec::new();

--- a/src/features/dlp/mod.rs
+++ b/src/features/dlp/mod.rs
@@ -198,6 +198,16 @@ impl DlpEngine {
     /// observe the arithmetic directly — otherwise the addition lives only
     /// inside a `tracing::info!` / `metrics::gauge!` call and mutation tests
     /// cannot kill mutants on the `+` operator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::features::dlp::config::DlpConfig;
+    /// use grob::features::dlp::DlpEngine;
+    ///
+    /// let config = DlpConfig::default();
+    /// assert_eq!(DlpEngine::count_secret_rules(&config), 0);
+    /// ```
     pub fn count_secret_rules(config: &DlpConfig) -> usize {
         config.secrets.len() + config.custom_prefixes.len()
     }

--- a/src/features/dlp/pii.rs
+++ b/src/features/dlp/pii.rs
@@ -52,7 +52,22 @@ pub struct PiiScanner {
 }
 
 impl PiiScanner {
-    /// Build a PII scanner from config. Returns `None` if all detectors are disabled.
+    /// Builds a PII scanner from config. Returns `None` if all detectors are disabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::features::dlp::config::PiiConfig;
+    /// use grob::features::dlp::pii::PiiScanner;
+    ///
+    /// // Default config enables credit_cards + IBAN
+    /// let config = PiiConfig::default();
+    /// assert!(PiiScanner::from_config(&config).is_some());
+    ///
+    /// // Everything disabled => None
+    /// let off = PiiConfig { credit_cards: false, iban: false, bic: false, ..Default::default() };
+    /// assert!(PiiScanner::from_config(&off).is_none());
+    /// ```
     pub fn from_config(config: &PiiConfig) -> Option<Self> {
         let any_enabled = config.credit_cards || config.iban || config.bic;
         if !any_enabled {
@@ -81,8 +96,23 @@ impl PiiScanner {
         })
     }
 
-    /// Fast pre-filter: check if text could plausibly contain PII.
-    /// Returns false if there aren't enough consecutive digits or uppercase letters.
+    /// Fast pre-filter: returns false when no PII is plausible.
+    ///
+    /// Rejects text lacking enough consecutive digits or uppercase letters
+    /// to form a credit card, IBAN, or BIC.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::features::dlp::config::PiiConfig;
+    /// use grob::features::dlp::pii::PiiScanner;
+    ///
+    /// let scanner = PiiScanner::from_config(&PiiConfig::default()).unwrap();
+    /// // Digit run >= 8 → might contain a card number
+    /// assert!(scanner.might_contain_pii("card 4111111111111111 here"));
+    /// // Pure prose → rejected
+    /// assert!(!scanner.might_contain_pii("hello world, no numbers"));
+    /// ```
     #[inline]
     pub fn might_contain_pii(&self, text: &str) -> bool {
         let bytes = text.as_bytes();
@@ -204,9 +234,22 @@ impl PiiScanner {
     }
 }
 
-/// Luhn algorithm: validates credit card numbers.
-/// Sum of alternating doubled digits mod 10 == 0.
-fn luhn_check(digits: &str) -> bool {
+/// Validates a credit card number using the Luhn algorithm.
+///
+/// Expects a digit-only string (no spaces or dashes). Returns true
+/// when the sum of alternating doubled digits mod 10 equals 0.
+///
+/// # Examples
+///
+/// ```
+/// use grob::features::dlp::pii::luhn_check;
+///
+/// // Valid Visa test number
+/// assert!(luhn_check("4111111111111111"));
+/// // Invalid (last digit changed)
+/// assert!(!luhn_check("4111111111111112"));
+/// ```
+pub fn luhn_check(digits: &str) -> bool {
     let mut sum: u32 = 0;
     let mut double = false;
 
@@ -227,10 +270,25 @@ fn luhn_check(digits: &str) -> bool {
     sum.is_multiple_of(10)
 }
 
-/// IBAN mod97 validation (ISO 7064).
-/// Rearranges country+check to end, converts letters to digits, checks mod 97 == 1.
-/// Uses chunked arithmetic to avoid u64 overflow.
-fn iban_mod97_check(iban: &str) -> bool {
+/// Validates an IBAN using ISO 7064 mod-97 arithmetic.
+///
+/// Rearranges country+check to end, converts letters to digits, then
+/// verifies the remainder equals 1. Returns false for strings shorter
+/// than 15 characters or containing non-alphanumeric characters.
+///
+/// # Examples
+///
+/// ```
+/// use grob::features::dlp::pii::iban_mod97_check;
+///
+/// // Valid French IBAN
+/// assert!(iban_mod97_check("FR7630006000011234567890189"));
+/// // Invalid (modified check digits)
+/// assert!(!iban_mod97_check("FR0030006000011234567890189"));
+/// // Too short
+/// assert!(!iban_mod97_check("FR76300060"));
+/// ```
+pub fn iban_mod97_check(iban: &str) -> bool {
     if iban.len() < 15 {
         return false;
     }
@@ -255,10 +313,26 @@ fn iban_mod97_check(iban: &str) -> bool {
     remainder == 1
 }
 
-/// BIC/SWIFT format validation.
-/// Format: 4 letters (bank) + 2 letters (ISO 3166 country) + 2 alphanum (location)
-/// + optional 3 alphanum (branch).
-fn bic_format_check(bic: &str) -> bool {
+/// Validates a BIC/SWIFT code format.
+///
+/// Checks 4-letter bank code, 2-letter ISO 3166 country code, 2-character
+/// alphanumeric location, and optional 3-character branch code.
+///
+/// # Examples
+///
+/// ```
+/// use grob::features::dlp::pii::bic_format_check;
+///
+/// // Valid 8-char BIC (BNP Paribas, France)
+/// assert!(bic_format_check("BNPAFRPP"));
+/// // Valid 11-char BIC with branch
+/// assert!(bic_format_check("BNPAFRPP123"));
+/// // Invalid: wrong length
+/// assert!(!bic_format_check("BNPA"));
+/// // Invalid: lowercase
+/// assert!(!bic_format_check("bnpafrpp"));
+/// ```
+pub fn bic_format_check(bic: &str) -> bool {
     let len = bic.len();
     if len != 8 && len != 11 {
         return false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,19 @@ pub fn home_dir() -> Option<PathBuf> {
     }
 }
 
-/// Expand a leading `~` to the user home directory.
+/// Expands a leading `~` to the user home directory.
+///
+/// # Examples
+///
+/// ```
+/// use grob::expand_tilde;
+///
+/// // Absolute paths pass through unchanged.
+/// assert_eq!(grob::expand_tilde("/etc/grob.toml").to_str().unwrap(), "/etc/grob.toml");
+///
+/// // Non-tilde relative paths pass through unchanged.
+/// assert_eq!(grob::expand_tilde("relative/path").to_str().unwrap(), "relative/path");
+/// ```
 pub fn expand_tilde(path: &str) -> PathBuf {
     if let Some(rest) = path.strip_prefix("~/") {
         if let Some(home) = home_dir() {

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -19,6 +19,15 @@ pub struct ModelPricing {
 
 impl ModelPricing {
     /// Calculates cost for a given number of tokens.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::pricing::ModelPricing;
+    /// let p = ModelPricing { model: "test", input_per_million: 3.0, output_per_million: 15.0 };
+    /// let cost = p.calculate(1_000_000, 0);
+    /// assert!((cost - 3.0).abs() < 1e-9);
+    /// ```
     pub fn calculate(&self, input_tokens: u32, output_tokens: u32) -> f64 {
         (input_tokens as f64 * self.input_per_million
             + output_tokens as f64 * self.output_per_million)
@@ -162,6 +171,14 @@ static PRICING_MAP: std::sync::LazyLock<
 > = std::sync::LazyLock::new(|| KNOWN_PRICING.iter().map(|p| (p.model, p)).collect());
 
 /// Looks up static pricing for a model (case-insensitive, fuzzy).
+/// # Examples
+///
+/// ```
+/// use grob::pricing::pricing;
+/// let p = pricing("claude-opus-4-6").unwrap();
+/// assert!(p.input_per_million > 0.0);
+/// assert!(pricing("unknown-model-xyz").is_none());
+/// ```
 pub fn pricing(model: &str) -> Option<&'static ModelPricing> {
     // Try exact match first (O(1), no allocation)
     PRICING_MAP.get(model).copied().or_else(|| {


### PR DESCRIPTION
Item majeur #5 cli-cycle : cargo test --doc tournait a vide (0 doc-tests). Ajoute 16 exemples executables dans pii.rs, dfa.rs, dlp/mod.rs, pricing.rs, lib.rs. Promeut luhn_check/iban_mod97_check/bic_format_check en pub pour testabilite doc.