### PR TITLE
chore: release v0.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.2](https://github.com/azerozero/grob/compare/v0.36.1...v0.36.2) - 2026-04-10
+
+### Added
+
+- *(setup)* valide les credentials par appel API avant acceptation
+
 ## [0.36.1](https://github.com/azerozero/grob/compare/v0.36.0...v0.36.1) - 2026-04-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.1"
+version = "0.36.2"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.1"
+version = "0.36.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.1 -> 0.36.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.2](https://github.com/azerozero/grob/compare/v0.36.1...v0.36.2) - 2026-04-10

### Added

- *(setup)* valide les credentials par appel API avant acceptation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).