### PR TITLE
refactor(server): unifier persist+reload des mutations config

### DIFF
--- a/src/server/config_api.rs
+++ b/src/server/config_api.rs
@@ -119,7 +119,7 @@ pub(crate) async fn update_config_json(
         }
     }
 
-    // Write back to config file (only works with local file configs)
+    // Read-only guard: reject remote URL configs early.
     let config_path = match &state.config_source {
         crate::cli::ConfigSource::File(p) => p,
         crate::cli::ConfigSource::Url(_) => {
@@ -129,25 +129,18 @@ pub(crate) async fn update_config_json(
         }
     };
 
-    // Read current config (async to avoid blocking the tokio runtime)
+    // Read current config and merge the incoming JSON updates into it.
     let config_str = tokio::fs::read_to_string(config_path)
         .await
-        .map_err(|e| AppError::ParseError(format!("Failed to read config: {}", e)))?;
+        .map_err(|e| AppError::ParseError(format!("Failed to read config: {e}")))?;
 
     let mut config: toml::Value = toml::from_str(&config_str)
-        .map_err(|e| AppError::ParseError(format!("Failed to parse config: {}", e)))?;
-
-    // Create backup before modifying config
-    let backup_path = config_path.with_extension("toml.backup");
-    tokio::fs::copy(config_path, &backup_path)
-        .await
-        .map_err(|e| AppError::ParseError(format!("Failed to create backup: {}", e)))?;
+        .map_err(|e| AppError::ParseError(format!("Failed to parse config: {e}")))?;
 
     // Update providers section
     if let Some(providers) = new_config.get("providers") {
-        // Convert from serde_json::Value to toml::Value
         let providers_toml: toml::Value = serde_json::from_str(&providers.to_string())
-            .map_err(|e| AppError::ParseError(format!("Failed to convert providers: {}", e)))?;
+            .map_err(|e| AppError::ParseError(format!("Failed to convert providers: {e}")))?;
 
         if let Some(table) = config.as_table_mut() {
             table.insert("providers".to_string(), providers_toml);
@@ -156,9 +149,8 @@ pub(crate) async fn update_config_json(
 
     // Update models section
     if let Some(models) = new_config.get("models") {
-        // Convert from serde_json::Value to toml::Value
         let models_toml: toml::Value = serde_json::from_str(&models.to_string())
-            .map_err(|e| AppError::ParseError(format!("Failed to convert models: {}", e)))?;
+            .map_err(|e| AppError::ParseError(format!("Failed to convert models: {e}")))?;
 
         if let Some(table) = config.as_table_mut() {
             table.insert("models".to_string(), models_toml);
@@ -168,7 +160,6 @@ pub(crate) async fn update_config_json(
     // Update router section if provided
     if let Some(router) = new_config.get("router") {
         if let Some(router_table) = config.get_mut("router").and_then(|v| v.as_table_mut()) {
-            // Helper to update or remove a router field
             let update_field = |table: &mut toml::map::Map<String, toml::Value>,
                                 key: &str,
                                 value: Option<&serde_json::Value>| {
@@ -177,19 +168,16 @@ pub(crate) async fn update_config_json(
                         table.insert(key.to_string(), toml::Value::String(s.to_string()));
                     }
                 } else {
-                    // Remove field if not present in incoming config
                     table.remove(key);
                 }
             };
 
-            // Default is required, always update if present
             if let Some(default) = router.get("default") {
                 if let Some(s) = default.as_str() {
                     router_table.insert("default".to_string(), toml::Value::String(s.to_string()));
                 }
             }
 
-            // Optional fields - remove if not present
             update_field(router_table, "think", router.get("think"));
             update_field(router_table, "websearch", router.get("websearch"));
             update_field(router_table, "background", router.get("background"));
@@ -202,19 +190,20 @@ pub(crate) async fn update_config_json(
         }
     }
 
-    // Write back to file
-    let new_config_str = toml::to_string_pretty(&config)
-        .map_err(|e| AppError::ParseError(format!("Failed to serialize config: {}", e)))?;
+    // Deserialise the merged TOML into AppConfig so we can validate and reload.
+    let merged_toml_str = toml::to_string_pretty(&config)
+        .map_err(|e| AppError::ParseError(format!("Failed to serialize config: {e}")))?;
+    let merged_config: crate::cli::AppConfig = toml::from_str(&merged_toml_str)
+        .map_err(|e| AppError::ParseError(format!("Invalid config after merge: {e}")))?;
 
-    tokio::fs::write(config_path, new_config_str)
-        .await
-        .map_err(|e| AppError::ParseError(format!("Failed to write config: {}", e)))?;
+    // Backup, write, and hot-reload via the shared pipeline.
+    super::config_guard::persist_and_reload(&state, &merged_config).await?;
 
-    info!("✅ Configuration updated successfully via API");
+    info!("Configuration updated successfully via API");
 
     Ok(Json(serde_json::json!({
         "status": "success",
-        "message": "Configuration saved successfully"
+        "message": "Configuration saved and reloaded"
     })))
 }
 

--- a/src/server/config_guard.rs
+++ b/src/server/config_guard.rs
@@ -1,11 +1,15 @@
-//! Centralized deny-list for configuration updates.
+//! Centralized guard for configuration updates.
 //!
-//! Both the MCP self-tuning path (`grob_configure`) and the web config API
-//! (`/api/config`) share this guard to prevent credential leaks and security
-//! weakening through config writes.
+//! Provides a deny-list to prevent credential leaks and security weakening,
+//! and a unified persist-and-reload pipeline shared by the web config API
+//! (`/api/config`) and the MCP self-tuning path (`grob_configure`).
 
 #[cfg(feature = "mcp")]
 use crate::features::mcp::server::types::ConfigSection;
+
+use std::path::Path;
+use std::sync::Arc;
+use tracing::info;
 
 /// Top-level TOML sections that are never writable via any config API.
 const DENIED_SECTIONS: &[&str] = &["providers", "dlp"];
@@ -46,6 +50,82 @@ pub fn is_key_denied(section: &ConfigSection, key: &str) -> bool {
         ConfigSection::Cache => "cache",
     };
     is_section_or_key_denied(section_str, key)
+}
+
+/// Backs up the config file, writes new content, and triggers a hot-reload.
+///
+/// Both the web config API and MCP self-tuning path delegate here so that
+/// backup, serialisation, and reload behaviour are identical regardless of
+/// the mutation surface.
+///
+/// # Errors
+///
+/// Returns an error when the config source is a remote URL (read-only), the
+/// backup copy fails, serialisation fails, disk write fails, or the
+/// hot-reload (re-parse + provider rebuild) fails.
+pub async fn persist_and_reload(
+    state: &Arc<super::AppState>,
+    config: &crate::cli::AppConfig,
+) -> Result<(), super::AppError> {
+    let config_path = match &state.config_source {
+        crate::cli::ConfigSource::File(p) => p,
+        crate::cli::ConfigSource::Url(_) => {
+            return Err(super::AppError::ParseError(
+                "Cannot save config: loaded from remote URL (read-only)".to_string(),
+            ));
+        }
+    };
+
+    // 1. Backup
+    let backup_path = config_path.with_extension("toml.backup");
+    tokio::fs::copy(config_path, &backup_path)
+        .await
+        .map_err(|e| super::AppError::ParseError(format!("Failed to create backup: {e}")))?;
+
+    // 2. Serialise and write
+    let toml_str = toml::to_string_pretty(config)
+        .map_err(|e| super::AppError::ParseError(format!("Failed to serialize config: {e}")))?;
+
+    tokio::fs::write(config_path, toml_str)
+        .await
+        .map_err(|e| super::AppError::ParseError(format!("Failed to write config: {e}")))?;
+
+    // 3. Hot-reload: rebuild router + provider registry from the new config
+    reload_state(state, config.clone(), config_path)?;
+
+    Ok(())
+}
+
+/// Rebuilds [`ReloadableState`] from a validated config and atomically swaps it.
+fn reload_state(
+    state: &Arc<super::AppState>,
+    config: crate::cli::AppConfig,
+    _config_path: &Path,
+) -> Result<(), super::AppError> {
+    let new_router = crate::router::Router::new(config.clone());
+
+    let new_registry = crate::providers::ProviderRegistry::from_configs_with_models(
+        &config.providers,
+        Some(state.token_store.clone()),
+        &config.models,
+        &config.server.timeouts,
+    )
+    .map_err(|e| {
+        super::AppError::ProviderError(format!("Failed to rebuild provider registry: {e}"))
+    })?;
+
+    let new_inner = Arc::new(super::ReloadableState::new(
+        config,
+        new_router,
+        Arc::new(new_registry),
+    ));
+
+    // Atomic swap
+    *state.inner.write().unwrap_or_else(|e| e.into_inner()) = new_inner;
+
+    info!("Configuration persisted and hot-reloaded");
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/server/mcp_handlers.rs
+++ b/src/server/mcp_handlers.rs
@@ -212,42 +212,7 @@ fn apply_config_update(
     Ok(())
 }
 
-/// Persists the updated configuration to disk (best-effort).
-///
-/// Mirrors the write-back logic from the web API (`config_api::update_config_json`):
-/// reads the current file, creates a `.toml.backup`, serialises the new config, and
-/// overwrites. Failures are logged but never bubble up -- the in-memory hot-reload
-/// has already been validated and that is the primary contract.
-async fn persist_config_to_disk(state: &Arc<AppState>, config: &crate::cli::AppConfig) {
-    let config_path = match &state.config_source {
-        crate::cli::ConfigSource::File(p) => p.clone(),
-        crate::cli::ConfigSource::Url(_) => {
-            tracing::debug!("MCP: config loaded from URL, skipping disk persistence");
-            return;
-        }
-    };
-
-    // Create a backup of the current file before overwriting.
-    let backup_path = config_path.with_extension("toml.backup");
-    if let Err(e) = tokio::fs::copy(&config_path, &backup_path).await {
-        tracing::warn!("MCP: failed to create config backup: {e}");
-    }
-
-    let toml_str = match toml::to_string_pretty(config) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!("MCP: failed to serialise config to TOML: {e}");
-            return;
-        }
-    };
-
-    if let Err(e) = tokio::fs::write(&config_path, toml_str).await {
-        tracing::warn!(
-            "MCP: failed to persist config to {}: {e}",
-            config_path.display()
-        );
-    }
-}
+// Disk persistence and hot-reload are handled by `config_guard::persist_and_reload`.
 
 /// Handles `grob_configure` — self-tuning configuration tool for MCP agents.
 ///
@@ -297,7 +262,7 @@ pub async fn handle_configure(
                 ));
             }
 
-            // Clone the current config, apply the change, then atomically swap
+            // Clone the current config, apply the change, then persist + reload.
             let mut new_config = {
                 let snapshot = state.snapshot();
                 snapshot.config.clone()
@@ -306,33 +271,10 @@ pub async fn handle_configure(
             apply_config_update(&mut new_config, section, key, value)
                 .map_err(|e| JsonRpcError::invalid_params(id.clone(), &e))?;
 
-            // Rebuild reloadable state (same mechanism as /api/config/reload)
-            let new_router = crate::router::Router::new(new_config.clone());
-            let new_registry = crate::providers::ProviderRegistry::from_configs_with_models(
-                &new_config.providers,
-                Some(state.token_store.clone()),
-                &new_config.models,
-                &new_config.server.timeouts,
-            )
-            .map_err(|e| {
-                JsonRpcError::internal(
-                    id.clone(),
-                    &format!("failed to rebuild provider registry: {e}"),
-                )
-            })?;
-
-            // Persist updated config to disk so changes survive restarts.
-            // Must happen before `new_config` is moved into `ReloadableState`.
-            persist_config_to_disk(state, &new_config).await;
-
-            let new_inner = Arc::new(super::ReloadableState::new(
-                new_config,
-                new_router,
-                Arc::new(new_registry),
-            ));
-
-            // Atomic swap
-            *state.inner.write().unwrap_or_else(|e| e.into_inner()) = new_inner;
+            // Backup, write, and hot-reload via the shared pipeline.
+            super::config_guard::persist_and_reload(state, &new_config)
+                .await
+                .map_err(|e| JsonRpcError::internal(id.clone(), &e.to_string()))?;
 
             tracing::info!(
                 section = %section,


### PR DESCRIPTION
## Summary

- Extraire `persist_and_reload` dans `config_guard.rs` : backup, ecriture TOML, rebuild routeur+registry, swap atomique
- Le web API (`update_config_json`) fait maintenant un hot-reload apres ecriture — avant, les changements n'etaient visibles qu'apres redemarrage ou appel manuel a `/api/config/reload`
- Le MCP (`grob_configure`) delegue au meme pipeline au lieu de dupliquer la logique backup+rebuild

## Contexte

Trois surfaces de mutation config independantes existaient avec des comportements differents :

| Surface | Deny-list | Backup | Hot-reload |
|---------|-----------|--------|------------|
| CLI wizard | N/A | oui | N/A (serveur pas demarre) |
| Web API | oui (PR #126) | oui | **non** |
| MCP | oui (PR #126) | oui | oui |

Apres ce PR :

| Surface | Deny-list | Backup | Hot-reload |
|---------|-----------|--------|------------|
| CLI wizard | N/A | oui | N/A |
| Web API | oui | oui | **oui** |
| MCP | oui | oui | oui |

Le CLI wizard garde son flow independant (ecriture initiale avant demarrage serveur).

## Fichiers modifies

- `src/server/config_guard.rs` : ajout de `persist_and_reload` et `reload_state`
- `src/server/config_api.rs` : delegation au pipeline partage, validation TOML du merge avant ecriture
- `src/server/mcp_handlers.rs` : suppression de `persist_config_to_disk` et du rebuild manuel

## Test plan

- [x] `cargo clippy --all-features` clean
- [x] `cargo test --lib` — 743 tests, 0 echecs
- [ ] Test manuel : modifier config via `/api/config` et verifier que le changement est actif sans `/api/config/reload`