### PR TITLE
fix(security): résoudre 6 alertes CodeQL/Semgrep cleartext logging

### DIFF
--- a/src/commands/credential_check.rs
+++ b/src/commands/credential_check.rs
@@ -69,7 +69,8 @@ pub async fn validate_api_key(provider_name: &str, api_key: &str) -> bool {
 
     let mut request = client.get(&url);
     if !header_name.is_empty() {
-        request = request.header(&header_name, &header_value);
+        // All validation URLs are HTTPS (see validation_request above).
+        request = request.header(&header_name, &header_value); // lgtm[rs/cleartext-transmission]
     }
     // NOTE: Anthropic requires an anthropic-version header.
     if provider_name == "anthropic" {

--- a/src/features/dlp/pii.rs
+++ b/src/features/dlp/pii.rs
@@ -686,7 +686,7 @@ mod tests {
     fn test_canary_credit_card_is_luhn_valid() {
         let fake = generate_pii_canary(&PiiType::CreditCard, "4532015112830366");
         assert_eq!(fake.len(), 16, "Canary CC must be 16 digits");
-        assert!(luhn_check(&fake), "Canary CC must pass Luhn: {fake}");
+        assert!(luhn_check(&fake), "Canary CC must pass Luhn check");
         assert_ne!(fake, "4532015112830366", "Canary must differ from original");
     }
 
@@ -1150,7 +1150,7 @@ mod tests {
             assert_eq!(canary.len(), 27);
             assert!(
                 iban_mod97_check(&canary),
-                "Canary IBAN id={id} doit etre mod97-valide : {canary}"
+                "Canary IBAN id={id} doit etre mod97-valide"
             );
         }
     }
@@ -1171,7 +1171,7 @@ mod tests {
         assert!(canary.starts_with("GB"));
         assert!(
             iban_mod97_check(&canary),
-            "Canary GB doit etre mod97-valide : {canary}"
+            "Canary GB doit etre mod97-valide"
         );
     }
 
@@ -1182,7 +1182,7 @@ mod tests {
         let canary = generate_canary_iban("DE89370400440532013000", 7);
         assert!(
             iban_mod97_check(&canary),
-            "Canary DE doit etre mod97-valide : {canary}"
+            "Canary DE doit etre mod97-valide"
         );
     }
 

--- a/src/features/dlp/tests.rs
+++ b/src/features/dlp/tests.rs
@@ -57,7 +57,7 @@ fn test_sanitize_text_secrets() {
     let config = test_config();
     let engine = DlpEngine::from_config(config).unwrap();
     // Fake token assembled at runtime to avoid Semgrep literal detection.
-    let fake_token = format!("ghp_{}", "abcdefghijklmnopqrstuvwxyz1234567890");
+    let fake_token = format!("ghp_{}", "abcdefghijklmnopqrstuvwxyz1234567890"); // nosemgrep: generic.secrets.security.detected-github-token
     let input = format!("token: {fake_token}");
     let result = engine.sanitize_text(&input);
     assert!(!result.contains(&fake_token));


### PR DESCRIPTION
## Summary

- Supprime le logging en cleartext de valeurs canary PII dans 4 assertions de test (`pii.rs`)
- Annote le faux positif HTTPS dans `credential_check.rs` (`lgtm[rs/cleartext-transmission]`)
- Ajoute `nosemgrep` sur le token de test assemblé dynamiquement (`tests.rs`)

Résout: 4 alertes HIGH CodeQL (pii.rs L689/L1151/L1172/L1183), 1 alerte HIGH CodeQL (credential_check.rs L70), 1 faux positif Semgrep (tests.rs L58).

## Test plan

- [x] 251 DLP tests pass
- [x] 8 credential_check tests pass
- [x] 944 total tests pass (nextest CI profile)
- [x] clippy clean
- [x] Quality gate CQI 8.3/10 (seuil 7.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)