### PR TITLE
fix(exec): vérifier la santé avant spawn pour éviter le faux-démarrage

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -37,15 +37,21 @@ pub async fn cmd_exec(
             }
         }
 
-        eprintln!("Starting Grob on port {}...", effective_port);
-        spawn_background_service(Some(effective_port), cli_config)?;
+        // Re-check: another process may have started Grob while the
+        // credential flow was running (interactive prompt, OAuth redirect…).
+        if instance::is_instance_running(&config.server.host, effective_port).await {
+            eprintln!("✅ Grob already running on port {}", effective_port);
+        } else {
+            eprintln!("Starting Grob on port {}...", effective_port);
+            spawn_background_service(Some(effective_port), cli_config)?;
 
-        if !poll_health(&base_url, HEALTH_POLL_MAX_ATTEMPTS, HEALTH_POLL_INTERVAL_MS).await {
-            eprintln!("❌ Grob failed to start within 5 seconds");
-            std::process::exit(1);
+            if !poll_health(&base_url, HEALTH_POLL_MAX_ATTEMPTS, HEALTH_POLL_INTERVAL_MS).await {
+                eprintln!("❌ Grob failed to start within 5 seconds");
+                std::process::exit(1);
+            }
+            we_started = true;
+            eprintln!("✅ Grob ready on port {}", effective_port);
         }
-        we_started = true;
-        eprintln!("✅ Grob ready on port {}", effective_port);
     }
 
     let child_status = {


### PR DESCRIPTION
## Summary

- Re-vérifie `is_instance_running` avant `spawn_background_service` pour éviter le faux-démarrage quand le flow credentials interactif prend du temps

## Test plan

- [x] Hooks pre-commit verts (fmt, clippy, gitleaks)
- [x] Changement ciblé : `src/commands/exec.rs` seulement (+13/-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)