### PR TITLE
feat(mcp): ajouter le tool grob_hint + header X-Grob-Hint

### DIFF
--- a/src/features/mcp/server/types.rs
+++ b/src/features/mcp/server/types.rs
@@ -193,6 +193,43 @@ impl std::fmt::Display for CalibrateParams {
     }
 }
 
+/// Client-declared task complexity for routing heuristics.
+///
+/// Consumed once by the dispatch pipeline (stateless, single-request scope).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComplexityHint {
+    /// Fast-path: simple lookup, short answer.
+    Trivial,
+    /// Default: standard reasoning task.
+    Medium,
+    /// Deep reasoning, multi-step, or creative task.
+    Complex,
+}
+
+impl std::fmt::Display for ComplexityHint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ComplexityHint::Trivial => f.write_str("trivial"),
+            ComplexityHint::Medium => f.write_str("medium"),
+            ComplexityHint::Complex => f.write_str("complex"),
+        }
+    }
+}
+
+/// Parameters for `grob_hint`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HintParams {
+    /// Task complexity declared by the client.
+    pub complexity: ComplexityHint,
+}
+
+impl std::fmt::Display for HintParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "hint complexity={}", self.complexity)
+    }
+}
+
 /// Configurable sections exposed by the `grob_configure` self-tuning tool.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -311,5 +348,32 @@ mod tests {
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("-32601"));
         assert!(json.contains("foo/bar"));
+    }
+
+    #[test]
+    fn test_complexity_hint_deserialize() {
+        let cases = [
+            ("\"trivial\"", ComplexityHint::Trivial),
+            ("\"medium\"", ComplexityHint::Medium),
+            ("\"complex\"", ComplexityHint::Complex),
+        ];
+        for (json, expected) in cases {
+            let hint: ComplexityHint = serde_json::from_str(json).unwrap();
+            assert_eq!(hint, expected);
+        }
+    }
+
+    #[test]
+    fn test_complexity_hint_display() {
+        assert_eq!(ComplexityHint::Trivial.to_string(), "trivial");
+        assert_eq!(ComplexityHint::Medium.to_string(), "medium");
+        assert_eq!(ComplexityHint::Complex.to_string(), "complex");
+    }
+
+    #[test]
+    fn test_hint_params_deserialize() {
+        let json = serde_json::json!({"complexity": "complex"});
+        let p: HintParams = serde_json::from_value(json).unwrap();
+        assert_eq!(p.complexity, ComplexityHint::Complex);
     }
 }

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -9,6 +9,7 @@ mod telemetry;
 
 use crate::cli::ModelStrategy;
 use crate::features::dlp::DlpEngine;
+#[cfg(feature = "mcp")]
 use crate::features::mcp::server::types::ComplexityHint;
 use crate::models::CanonicalRequest;
 use crate::providers::ProviderResponse;
@@ -185,6 +186,7 @@ pub(crate) enum DispatchResult {
 ///
 /// Priority: `X-Grob-Hint` header → `metadata.grob_hint` body field →
 /// one-shot MCP `grob_hint` slot (consumed on read).
+#[cfg(feature = "mcp")]
 pub(crate) fn resolve_grob_hint(
     ctx: &DispatchContext<'_>,
     request: &CanonicalRequest,
@@ -226,12 +228,15 @@ pub(crate) async fn dispatch(
     request: &mut CanonicalRequest,
 ) -> Result<DispatchResult, AppError> {
     // ── Step 0: Resolve complexity hint ──
-    let grob_hint = resolve_grob_hint(ctx, request);
-    if let Some(ref hint) = grob_hint {
-        tracing::debug!(hint = %hint, "dispatch: grob_hint resolved");
+    #[cfg(feature = "mcp")]
+    {
+        let grob_hint = resolve_grob_hint(ctx, request);
+        if let Some(ref hint) = grob_hint {
+            tracing::debug!(hint = %hint, "dispatch: grob_hint resolved");
+        }
+        // NOTE: `grob_hint` will be consumed by T-P1 scoring heuristics.
+        let _ = grob_hint;
     }
-    // NOTE: `grob_hint` will be consumed by T-P1 scoring heuristics.
-    let _ = grob_hint;
 
     // ── Step 1: DLP input scanning ──
     scan_dlp_input(ctx, request)?;

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -9,6 +9,7 @@ mod telemetry;
 
 use crate::cli::ModelStrategy;
 use crate::features::dlp::DlpEngine;
+use crate::features::mcp::server::types::ComplexityHint;
 use crate::models::CanonicalRequest;
 use crate::providers::ProviderResponse;
 use axum::http::HeaderMap;
@@ -180,6 +181,42 @@ pub(crate) enum DispatchResult {
     FanOut { response: ProviderResponse },
 }
 
+/// Resolves the client complexity hint from available sources.
+///
+/// Priority: `X-Grob-Hint` header → `metadata.grob_hint` body field →
+/// one-shot MCP `grob_hint` slot (consumed on read).
+pub(crate) fn resolve_grob_hint(
+    ctx: &DispatchContext<'_>,
+    request: &CanonicalRequest,
+) -> Option<ComplexityHint> {
+    // 1. Header: X-Grob-Hint
+    if let Some(hint) = ctx
+        .headers
+        .get("x-grob-hint")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_string())).ok())
+    {
+        return Some(hint);
+    }
+
+    // 2. Body: metadata.grob_hint
+    if let Some(hint) = request
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("grob_hint"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+    {
+        return Some(hint);
+    }
+
+    // 3. MCP one-shot slot (consume on read)
+    ctx.state
+        .grob_hint
+        .lock()
+        .ok()
+        .and_then(|mut slot| slot.take())
+}
+
 /// Run the full dispatch pipeline: DLP → cache → route → provider loop.
 ///
 /// Returns a `DispatchResult` that the handler transforms into the appropriate
@@ -188,6 +225,14 @@ pub(crate) async fn dispatch(
     ctx: &DispatchContext<'_>,
     request: &mut CanonicalRequest,
 ) -> Result<DispatchResult, AppError> {
+    // ── Step 0: Resolve complexity hint ──
+    let grob_hint = resolve_grob_hint(ctx, request);
+    if let Some(ref hint) = grob_hint {
+        tracing::debug!(hint = %hint, "dispatch: grob_hint resolved");
+    }
+    // NOTE: `grob_hint` will be consumed by T-P1 scoring heuristics.
+    let _ = grob_hint;
+
     // ── Step 1: DLP input scanning ──
     scan_dlp_input(ctx, request)?;
 

--- a/src/server/mcp_handlers.rs
+++ b/src/server/mcp_handlers.rs
@@ -12,7 +12,9 @@ use crate::features::mcp::server::types::{
 use axum::{extract::State, response::IntoResponse, Json};
 use std::sync::Arc;
 
-use crate::features::mcp::server::types::{ConfigSection, ConfigureAction, ConfigureParams};
+use crate::features::mcp::server::types::{
+    ConfigSection, ConfigureAction, ConfigureParams, HintParams,
+};
 
 // ── Axum HTTP handlers ──────────────────────────────────────────────────────
 
@@ -37,7 +39,14 @@ pub async fn handle_mcp_rpc(
         "tool_matrix/calibrate" => methods::handle_calibrate(mcp, req.params, req.id.clone()).await,
         "tool_matrix/report" => methods::handle_report(mcp, req.id.clone()).await,
         "grob_configure" => handle_configure(&state, req.params, req.id.clone()).await,
-        "tools/list" => methods::handle_tools_list(mcp, req.id.clone()).await,
+        "grob_hint" => handle_hint(&state, req.params, req.id.clone()).await,
+        "tools/list" => match methods::handle_tools_list(mcp, req.id.clone()).await {
+            Ok(mut resp) => {
+                inject_builtin_tools(&mut resp);
+                Ok(resp)
+            }
+            Err(e) => Err(e),
+        },
         _ => Err(JsonRpcError::method_not_found(req.id.clone(), &req.method)),
     };
 
@@ -75,6 +84,79 @@ fn to_json_value(result: Result<JsonRpcResponse, JsonRpcError>) -> serde_json::V
     match result {
         Ok(resp) => serde_json::to_value(resp).unwrap_or_else(fallback),
         Err(err) => serde_json::to_value(err).unwrap_or_else(fallback),
+    }
+}
+
+// ── grob_hint ──────────────────────────────────────────────────────────────
+
+/// Handles `grob_hint` — stores a one-shot complexity hint for the next dispatch.
+///
+/// The hint is consumed (taken) by the next dispatch call, then cleared.
+/// Clients may also pass the hint inline via `X-Grob-Hint` header or
+/// `metadata.grob_hint` in the request body — this MCP tool is the third
+/// pathway, for MCP-native agents that cannot set custom HTTP headers.
+async fn handle_hint(
+    state: &Arc<AppState>,
+    params: serde_json::Value,
+    id: serde_json::Value,
+) -> Result<JsonRpcResponse, JsonRpcError> {
+    let p: HintParams = serde_json::from_value(params)
+        .map_err(|e| JsonRpcError::invalid_params(id.clone(), &e.to_string()))?;
+
+    // Store the hint for the next dispatch (one-shot).
+    if let Ok(mut slot) = state.grob_hint.lock() {
+        *slot = Some(p.complexity);
+    }
+
+    tracing::info!(complexity = %p.complexity, "MCP: grob_hint stored");
+
+    Ok(JsonRpcResponse::ok(
+        id,
+        serde_json::json!({
+            "status": "accepted",
+            "complexity": p.complexity.to_string(),
+        }),
+    ))
+}
+
+/// Appends built-in tools (`grob_configure`, `grob_hint`) to the `tools/list` response.
+fn inject_builtin_tools(resp: &mut JsonRpcResponse) {
+    if let Some(tools) = resp.result.get_mut("tools").and_then(|v| v.as_array_mut()) {
+        tools.push(serde_json::json!({
+            "name": "grob_hint",
+            "description": "Declare task complexity for routing heuristics (trivial/medium/complex). Stateless: consumed by the next request.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "complexity": {
+                        "type": "string",
+                        "enum": ["trivial", "medium", "complex"],
+                        "description": "Task complexity level"
+                    }
+                },
+                "required": ["complexity"]
+            }
+        }));
+        tools.push(serde_json::json!({
+            "name": "grob_configure",
+            "description": "Read or update safe configuration sections (router, budget, cache). Credentials and security settings are denied.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["read", "update"]
+                    },
+                    "section": {
+                        "type": "string",
+                        "enum": ["router", "budget", "dlp", "cache"]
+                    },
+                    "key": { "type": "string" },
+                    "value": {}
+                },
+                "required": ["action", "section"]
+            }
+        }));
     }
 }
 
@@ -521,5 +603,31 @@ mod tests {
             }
             _ => panic!("expected Update action"),
         }
+    }
+
+    #[test]
+    fn test_inject_builtin_tools_adds_grob_hint() {
+        let mut resp =
+            JsonRpcResponse::ok(serde_json::json!(1), serde_json::json!({ "tools": [] }));
+        inject_builtin_tools(&mut resp);
+        let tools = resp.result["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["name"], "grob_hint");
+        assert_eq!(tools[1]["name"], "grob_configure");
+    }
+
+    #[test]
+    fn test_inject_builtin_tools_preserves_existing() {
+        let mut resp = JsonRpcResponse::ok(
+            serde_json::json!(1),
+            serde_json::json!({
+                "tools": [{"name": "web_search"}]
+            }),
+        );
+        inject_builtin_tools(&mut resp);
+        let tools = resp.result["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 3);
+        assert_eq!(tools[0]["name"], "web_search");
+        assert_eq!(tools[1]["name"], "grob_hint");
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -184,6 +184,7 @@ pub struct AppState {
     /// One-shot complexity hint set by the `grob_hint` MCP tool.
     ///
     /// Consumed (taken) by the next dispatch call, then reset to `None`.
+    #[cfg(feature = "mcp")]
     pub grob_hint: std::sync::Mutex<Option<crate::features::mcp::server::types::ComplexityHint>>,
     /// Pending HIT approval channels keyed by `"{request_id}:{tool_name}"`.
     #[cfg(feature = "policies")]
@@ -275,6 +276,7 @@ pub async fn start_server(
         started_at: chrono::Utc::now(),
         event_bus,
         log_exporter,
+        #[cfg(feature = "mcp")]
         grob_hint: std::sync::Mutex::new(None),
         #[cfg(feature = "policies")]
         hit_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -181,6 +181,10 @@ pub struct AppState {
     pub event_bus: crate::features::watch::EventBus,
     /// External log exporter for structured request/response logs.
     pub log_exporter: Option<Arc<crate::features::log_export::LogExporter>>,
+    /// One-shot complexity hint set by the `grob_hint` MCP tool.
+    ///
+    /// Consumed (taken) by the next dispatch call, then reset to `None`.
+    pub grob_hint: std::sync::Mutex<Option<crate::features::mcp::server::types::ComplexityHint>>,
     /// Pending HIT approval channels keyed by `"{request_id}:{tool_name}"`.
     #[cfg(feature = "policies")]
     pub hit_pending: Arc<crate::features::policies::stream::HitPendingApprovals>,
@@ -271,6 +275,7 @@ pub async fn start_server(
         started_at: chrono::Utc::now(),
         event_bus,
         log_exporter,
+        grob_hint: std::sync::Mutex::new(None),
         #[cfg(feature = "policies")]
         hit_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         observability: ObservabilityState {


### PR DESCRIPTION
## Summary

- Ajoute `ComplexityHint` enum (trivial/medium/complex) dans les types MCP
- Implémente le tool MCP `grob_hint` (one-shot slot pour routing heuristics)
- Résolution multi-source dans dispatch : `X-Grob-Hint` header → `metadata.grob_hint` body → MCP slot
- Injection des tools built-in (`grob_hint`, `grob_configure`) dans `tools/list`

## Test plan

- [x] Tests ComplexityHint deserialize/display
- [x] Tests HintParams deserialize
- [x] Tests inject_builtin_tools (ajout + préservation existants)
- [x] 4 fichiers modifiés, +226 lignes

🤖 Generated with [Claude Code](https://claude.com/claude-code)