### PR TITLE
chore: release v0.36.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.5](https://github.com/azerozero/grob/compare/v0.36.4...v0.36.5) - 2026-04-11
+
+### Added
+
+- *(mcp)* ajouter le tool grob_hint + header X-Grob-Hint
+
+### Fixed
+
+- *(mcp)* gater grob_hint derrière cfg(feature = "mcp")
+
 ## [0.36.4](https://github.com/azerozero/grob/compare/v0.36.3...v0.36.4) - 2026-04-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.4"
+version = "0.36.5"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.4"
+version = "0.36.5"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.4 -> 0.36.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.5](https://github.com/azerozero/grob/compare/v0.36.4...v0.36.5) - 2026-04-11

### Added

- *(mcp)* ajouter le tool grob_hint + header X-Grob-Hint

### Fixed

- *(mcp)* gater grob_hint derrière cfg(feature = "mcp")
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).