### PR TITLE
feat(tracing): ajouter rotation par taille et compression zstd des traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
 dependencies = [
  "clap",
 ]
@@ -1932,6 +1932,7 @@ dependencies = [
  "url",
  "uuid",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]
@@ -2640,7 +2641,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
@@ -2944,7 +2945,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2990,7 +2991,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -3763,7 +3764,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.10",
@@ -3845,7 +3846,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -3905,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6637,3 +6638,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,9 @@ rustls-pemfile = { version = "2", optional = true }
 rustls-acme = { version = "0.12", features = ["axum"], optional = true }
 regex-syntax = "0.8.10"
 
+# Trace log compression (zstd for rotated trace files)
+zstd = "0.13"
+
 # Allocator (jemalloc replaces musl's slow malloc for ~20% better throughput)
 tikv-jemallocator = { version = "0.6", optional = true }
 # Unix signals (SIGTERM, SIGUSR1) for graceful shutdown and hot restart

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -417,6 +417,15 @@ pub struct TracingConfig {
     /// Omit system prompt from traces (default: true, since system prompts are huge)
     #[serde(default = "default_true")]
     pub omit_system_prompt: bool,
+    /// Maximum trace file size in MB before rotation (default: 50)
+    #[serde(default = "default_max_size_mb")]
+    pub max_size_mb: u64,
+    /// Number of rotated files to keep (default: 3)
+    #[serde(default = "default_max_files")]
+    pub max_files: usize,
+    /// Compress rotated files with zstd (default: false)
+    #[serde(default)]
+    pub compress: bool,
 }
 
 impl Default for TracingConfig {
@@ -425,8 +434,19 @@ impl Default for TracingConfig {
             enabled: false,
             path: default_tracing_path(),
             omit_system_prompt: true,
+            max_size_mb: default_max_size_mb(),
+            max_files: default_max_files(),
+            compress: false,
         }
     }
+}
+
+fn default_max_size_mb() -> u64 {
+    50
+}
+
+fn default_max_files() -> usize {
+    3
 }
 
 fn default_tracing_path() -> String {

--- a/src/message_tracing/mod.rs
+++ b/src/message_tracing/mod.rs
@@ -314,9 +314,11 @@ fn rotated_path(base: &Path, index: usize, compressed: bool) -> PathBuf {
 
 /// Compresses a file to zstd format.
 fn compress_to_zstd(src: &Path, dst: &Path) -> std::io::Result<()> {
-    let input = fs::read(src)?;
-    let compressed = zstd::encode_all(input.as_slice(), 3)?;
-    fs::write(dst, compressed)?;
+    let input = std::fs::File::open(src)?;
+    let output = std::fs::File::create(dst)?;
+    let mut encoder = zstd::Encoder::new(output, 3)?;
+    std::io::copy(&mut std::io::BufReader::new(input), &mut encoder)?;
+    encoder.finish()?;
     Ok(())
 }
 

--- a/src/message_tracing/mod.rs
+++ b/src/message_tracing/mod.rs
@@ -1,21 +1,24 @@
 //! Message tracing for debugging
 //!
-//! Logs full request/response messages to a JSONL file for debugging purposes.
+//! Logs full request/response messages to a JSONL file with size-based rotation
+//! and optional zstd compression of rotated files.
 
 use crate::cli::TracingConfig;
 use crate::models::{CanonicalRequest, RouteType};
 use crate::providers::ProviderResponse;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use uuid::Uuid;
 
-/// Message tracer that writes to JSONL file
+/// Message tracer that writes to JSONL file with rotation support.
 pub struct MessageTracer {
     config: TracingConfig,
+    /// Expanded absolute path to the trace file.
+    trace_path: PathBuf,
     file: Option<Mutex<File>>,
 }
 
@@ -56,40 +59,52 @@ struct ErrorTrace {
 }
 
 impl MessageTracer {
-    /// Create a new tracer from config
+    /// Creates a new tracer from config.
     pub fn new(config: TracingConfig) -> Self {
+        let trace_path = expand_tilde(&config.path);
+
         if !config.enabled {
-            return Self { config, file: None };
+            return Self {
+                config,
+                trace_path,
+                file: None,
+            };
         }
 
-        // Expand ~ in path
-        let path = expand_tilde(&config.path);
-
         // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
+        if let Some(parent) = trace_path.parent() {
+            if let Err(e) = fs::create_dir_all(parent) {
                 tracing::error!("Failed to create tracing directory: {}", e);
-                return Self { config, file: None };
+                return Self {
+                    config,
+                    trace_path,
+                    file: None,
+                };
             }
         }
 
         // Open file for appending
-        match OpenOptions::new().create(true).append(true).open(&path) {
+        match open_append(&trace_path) {
             Ok(file) => {
-                tracing::info!("📝 Message tracing enabled: {}", path.display());
+                tracing::info!("Message tracing enabled: {}", trace_path.display());
                 Self {
                     config,
+                    trace_path,
                     file: Some(Mutex::new(file)),
                 }
             }
             Err(e) => {
                 tracing::error!("Failed to open trace file: {}", e);
-                Self { config, file: None }
+                Self {
+                    config,
+                    trace_path,
+                    file: None,
+                }
             }
         }
     }
 
-    /// Generate a new trace ID
+    /// Generates a new trace ID.
     pub fn new_trace_id(&self) -> String {
         if self.file.is_some() {
             Uuid::new_v4().to_string()[..8].to_string()
@@ -98,7 +113,7 @@ impl MessageTracer {
         }
     }
 
-    /// Trace an incoming request
+    /// Traces an incoming request.
     pub fn trace_request(
         &self,
         id: &str,
@@ -113,7 +128,6 @@ impl MessageTracer {
 
         // Build messages JSON, optionally omitting system prompt
         let messages = if self.config.omit_system_prompt {
-            // Clone request and clear system prompt
             let mut req_clone = request.clone();
             req_clone.system = None;
             serde_json::to_value(&req_clone.messages).unwrap_or_default()
@@ -136,7 +150,7 @@ impl MessageTracer {
         self.write_trace(&trace, file_mutex);
     }
 
-    /// Trace a response
+    /// Traces a response.
     pub fn trace_response(&self, id: &str, response: &ProviderResponse, latency_ms: u64) {
         let Some(ref file_mutex) = self.file else {
             return;
@@ -156,7 +170,7 @@ impl MessageTracer {
         self.write_trace(&trace, file_mutex);
     }
 
-    /// Trace an error
+    /// Traces an error.
     pub fn trace_error(&self, id: &str, error: &str) {
         let Some(ref file_mutex) = self.file else {
             return;
@@ -177,9 +191,27 @@ impl MessageTracer {
             return;
         };
 
-        if let Ok(mut file) = file_mutex.lock() {
-            let _ = writeln!(file, "{}", json);
+        let Ok(mut file) = file_mutex.lock() else {
+            return;
+        };
+
+        // Check size before writing; rotate if over limit
+        let max_bytes = self.config.max_size_mb * 1024 * 1024;
+        if max_bytes > 0 {
+            if let Ok(meta) = file.metadata() {
+                if meta.len() >= max_bytes {
+                    if let Ok(new_file) = rotate_file(
+                        &self.trace_path,
+                        self.config.max_files,
+                        self.config.compress,
+                    ) {
+                        *file = new_file;
+                    }
+                }
+            }
         }
+
+        let _ = writeln!(file, "{}", json);
     }
 }
 
@@ -215,7 +247,80 @@ impl crate::traits::Tracer for MessageTracer {
     }
 }
 
-/// Expand ~ to home directory
+// ── File helpers ──
+
+/// Opens a file for appending, creating it if needed.
+fn open_append(path: &Path) -> std::io::Result<File> {
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
+/// Rotates trace files and returns a fresh file handle for the main path.
+///
+/// Naming scheme: `trace.jsonl` -> `trace.1.jsonl` (or `.1.jsonl.zst`),
+/// `trace.1.jsonl` -> `trace.2.jsonl`, etc.
+fn rotate_file(base: &Path, max_files: usize, compress: bool) -> std::io::Result<File> {
+    // Delete the oldest if it exists
+    let oldest = rotated_path(base, max_files, compress);
+    if oldest.exists() {
+        fs::remove_file(&oldest)?;
+    }
+
+    // Shift existing rotated files up by one
+    for i in (1..max_files).rev() {
+        let src = rotated_path(base, i, compress);
+        let dst = rotated_path(base, i + 1, compress);
+        if src.exists() {
+            fs::rename(&src, &dst)?;
+        }
+    }
+
+    // Move current file to slot 1
+    let slot1 = rotated_path(base, 1, compress);
+    if base.exists() {
+        if compress {
+            compress_to_zstd(base, &slot1)?;
+            fs::remove_file(base)?;
+        } else {
+            fs::rename(base, &slot1)?;
+        }
+    }
+
+    open_append(base)
+}
+
+/// Builds the path for a rotated file at a given index.
+///
+/// For `trace.jsonl` with index 2: `trace.2.jsonl` (or `trace.2.jsonl.zst`).
+fn rotated_path(base: &Path, index: usize, compressed: bool) -> PathBuf {
+    let stem = base
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let ext = base
+        .extension()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let parent = base.parent().unwrap_or(base);
+    let name = if compressed {
+        format!("{stem}.{index}.{ext}.zst")
+    } else {
+        format!("{stem}.{index}.{ext}")
+    };
+    parent.join(name)
+}
+
+/// Compresses a file to zstd format.
+fn compress_to_zstd(src: &Path, dst: &Path) -> std::io::Result<()> {
+    let input = fs::read(src)?;
+    let compressed = zstd::encode_all(input.as_slice(), 3)?;
+    fs::write(dst, compressed)?;
+    Ok(())
+}
+
+/// Expands ~ to home directory.
 fn expand_tilde(path: &str) -> PathBuf {
     if let Some(rest) = path.strip_prefix("~/") {
         if let Some(home) = crate::home_dir() {
@@ -223,4 +328,168 @@ fn expand_tilde(path: &str) -> PathBuf {
         }
     }
     PathBuf::from(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn make_config(
+        dir: &Path,
+        max_size_mb: u64,
+        max_files: usize,
+        compress: bool,
+    ) -> TracingConfig {
+        TracingConfig {
+            enabled: true,
+            path: dir.join("trace.jsonl").to_string_lossy().to_string(),
+            omit_system_prompt: true,
+            max_size_mb,
+            max_files,
+            compress,
+        }
+    }
+
+    #[test]
+    fn rotation_triggers_when_file_exceeds_max_size() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace_path = tmp.path().join("trace.jsonl");
+
+        {
+            let mut f = File::create(&trace_path).unwrap();
+            writeln!(f, "{}", "x".repeat(100)).unwrap();
+        }
+
+        let new_file = rotate_file(&trace_path, 3, false).unwrap();
+        drop(new_file);
+
+        let meta = fs::metadata(&trace_path).unwrap();
+        assert_eq!(meta.len(), 0);
+
+        let rotated = rotated_path(&trace_path, 1, false);
+        assert!(rotated.exists(), "rotated file at slot 1 should exist");
+    }
+
+    #[test]
+    fn rotation_shifts_existing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace_path = tmp.path().join("trace.jsonl");
+
+        fs::write(rotated_path(&trace_path, 1, false), "old-1").unwrap();
+        fs::write(rotated_path(&trace_path, 2, false), "old-2").unwrap();
+        fs::write(&trace_path, "current").unwrap();
+
+        let new_file = rotate_file(&trace_path, 3, false).unwrap();
+        drop(new_file);
+
+        assert_eq!(
+            fs::read_to_string(rotated_path(&trace_path, 3, false)).unwrap(),
+            "old-2"
+        );
+        assert_eq!(
+            fs::read_to_string(rotated_path(&trace_path, 2, false)).unwrap(),
+            "old-1"
+        );
+        assert_eq!(
+            fs::read_to_string(rotated_path(&trace_path, 1, false)).unwrap(),
+            "current"
+        );
+        assert_eq!(fs::metadata(&trace_path).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn rotation_deletes_oldest_beyond_max_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace_path = tmp.path().join("trace.jsonl");
+
+        fs::write(rotated_path(&trace_path, 1, false), "old-1").unwrap();
+        fs::write(rotated_path(&trace_path, 2, false), "old-2-should-die").unwrap();
+        fs::write(&trace_path, "current").unwrap();
+
+        let new_file = rotate_file(&trace_path, 2, false).unwrap();
+        drop(new_file);
+
+        assert_eq!(
+            fs::read_to_string(rotated_path(&trace_path, 2, false)).unwrap(),
+            "old-1"
+        );
+        assert_eq!(
+            fs::read_to_string(rotated_path(&trace_path, 1, false)).unwrap(),
+            "current"
+        );
+    }
+
+    #[test]
+    fn rotation_compresses_with_zstd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace_path = tmp.path().join("trace.jsonl");
+        let payload = "hello zstd compression test payload";
+        fs::write(&trace_path, payload).unwrap();
+
+        let new_file = rotate_file(&trace_path, 3, true).unwrap();
+        drop(new_file);
+
+        let compressed_path = rotated_path(&trace_path, 1, true);
+        assert!(
+            compressed_path.exists(),
+            "compressed rotated file should exist"
+        );
+        assert!(compressed_path.to_string_lossy().ends_with(".zst"));
+
+        let compressed_data = fs::read(&compressed_path).unwrap();
+        let decompressed = zstd::decode_all(compressed_data.as_slice()).unwrap();
+        assert_eq!(String::from_utf8(decompressed).unwrap(), payload);
+
+        assert_eq!(fs::metadata(&trace_path).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn rotated_path_naming() {
+        let base = PathBuf::from("/tmp/trace.jsonl");
+        assert_eq!(
+            rotated_path(&base, 1, false),
+            PathBuf::from("/tmp/trace.1.jsonl")
+        );
+        assert_eq!(
+            rotated_path(&base, 3, true),
+            PathBuf::from("/tmp/trace.3.jsonl.zst")
+        );
+    }
+
+    #[test]
+    fn tracer_write_triggers_rotation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace_path = tmp.path().join("trace.jsonl");
+
+        // Pre-fill the file to simulate near-limit (just over 1 MB)
+        {
+            let mut f = File::create(&trace_path).unwrap();
+            let big_line = "x".repeat(1024 * 1024 + 1);
+            write!(f, "{}", big_line).unwrap();
+        }
+
+        let config = make_config(tmp.path(), 1, 3, false);
+        let tracer = MessageTracer::new(config);
+
+        #[derive(Serialize)]
+        struct Dummy {
+            msg: String,
+        }
+        let dummy = Dummy {
+            msg: "test".to_string(),
+        };
+        if let Some(ref fm) = tracer.file {
+            tracer.write_trace(&dummy, fm);
+        }
+
+        let slot1 = rotated_path(&trace_path, 1, false);
+        assert!(slot1.exists(), "rotation should have created slot 1 file");
+
+        let current_size = fs::metadata(&trace_path).unwrap().len();
+        assert!(
+            current_size < 1024,
+            "current file should be small after rotation, got {current_size}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Ajoute la rotation de fichiers trace par taille configurable (max_size_mb)
- Compression zstd en streaming des fichiers rotatés (fix après DENY initial)
- Configuration max_files pour limiter le nombre de fichiers conservés

## Test plan

- [x] Tests rotation + compression zstd streaming
- [x] Fix streaming zstd après deny
- [x] Sous-chef 3-lentilles APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)