### PR TITLE
fix(ci): add RUSTSEC-2026-0097 exception and fix gitleaks force-push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,13 +203,21 @@ jobs:
             | sudo tar xz -C /usr/local/bin gitleaks
       - name: Run gitleaks
         run: |
-          BEFORE="${{ github.event.before }}"
-          if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
-            # Tag push or new branch — no valid range, scan last 1 commit
-            echo "Tag/new-branch push detected — scanning HEAD~1..HEAD"
-            gitleaks detect --source . --log-opts "HEAD~1..HEAD" --verbose
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # PR: scan only commits in the PR against its base branch.
+            # Using base ref avoids broken ranges after force-pushes.
+            BASE="origin/${{ github.event.pull_request.base.ref }}"
+            echo "PR detected — scanning ${BASE}..HEAD"
+            gitleaks detect --source . --log-opts "${BASE}..HEAD" --verbose
           else
-            gitleaks detect --source . --log-opts "${BEFORE}..${{ github.sha }}" --verbose
+            BEFORE="${{ github.event.before }}"
+            if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+              # Tag push or new branch — no valid range, scan last 1 commit.
+              echo "Tag/new-branch push detected — scanning HEAD~1..HEAD"
+              gitleaks detect --source . --log-opts "HEAD~1..HEAD" --verbose
+            else
+              gitleaks detect --source . --log-opts "${BEFORE}..${{ github.sha }}" --verbose
+            fi
           fi
 
   deny:

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,9 @@ version = 2
 ignore = [
     "RUSTSEC-2023-0071",
     "RUSTSEC-2025-0134",
+    # rand: Unsound with custom logger calling rand::rng() (RUSTSEC-2026-0097).
+    # No impact: grob does not define a custom logger accessing ThreadRng.
+    "RUSTSEC-2026-0097",
 ]
 
 # ── Licenses ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **deny.toml**: Ignore RUSTSEC-2026-0097 (rand unsound with custom logger calling `rand::rng()`). No impact: grob does not define a custom logger accessing `ThreadRng`.
- **ci.yml**: For PRs, scan gitleaks against `origin/<base-ref>` instead of `github.event.before`. Force-pushes invalidate the "before" SHA, causing gitleaks to fail on a broken commit range. Using the base branch ref always resolves to a valid range.

## Context
Unblocks PRs #146, #147, #148 which all fail on `cargo deny` (RUSTSEC-2026-0097) and `gitleaks` (false positive from force-push).

## Test plan
- [x] `cargo deny check advisories` passes locally
- [ ] CI gitleaks step passes on this PR (validates the new range logic)
- [ ] Rebase #146, #147, #148 after merge — both checks should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)