### PR TITLE
chore: release v0.36.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.6](https://github.com/azerozero/grob/compare/v0.36.5...v0.36.6) - 2026-04-11
+
+### Added
+
+- *(cache)* ajouter cache sémantique SimHash avec distance de Hamming
+
+### Fixed
+
+- *(cache)* corriger normalisation SimHash et utiliser moka pour eviction
+- *(ci)* add RUSTSEC-2026-0097 exception and fix gitleaks force-push
+
+### Other
+
+- *(dlp,router)* ajouter proptests pour robustesse DLP et router
+
 ## [0.36.5](https://github.com/azerozero/grob/compare/v0.36.4...v0.36.5) - 2026-04-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.5"
+version = "0.36.6"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.5"
+version = "0.36.6"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.5 -> 0.36.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.6](https://github.com/azerozero/grob/compare/v0.36.5...v0.36.6) - 2026-04-11

### Added

- *(cache)* ajouter cache sémantique SimHash avec distance de Hamming

### Fixed

- *(cache)* corriger normalisation SimHash et utiliser moka pour eviction
- *(ci)* add RUSTSEC-2026-0097 exception and fix gitleaks force-push

### Other

- *(dlp,router)* ajouter proptests pour robustesse DLP et router
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).