### PR TITLE
fix(ci): ajouter RUSTSEC-2026-0097 a audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,4 +13,7 @@ ignore = [
     # axum-server 0.8 migrates to rustls-pki-types, but rustls-acme 0.12 pins 0.7.
     # Track: https://github.com/tokio-rs/axum/issues — bump when rustls-acme supports 0.8.
     "RUSTSEC-2025-0134",
+    # rand: Unsound with custom logger calling rand::rng() (RUSTSEC-2026-0097).
+    # No impact: grob does not define a custom logger accessing ThreadRng.
+    "RUSTSEC-2026-0097",
 ]


### PR DESCRIPTION
## Summary
- Ajoute RUSTSEC-2026-0097 (rand unsound avec custom logger) aux exceptions de `.cargo/audit.toml`
- Le fix deny.toml (PR #149) ne couvrait que `cargo deny`, pas `cargo audit`
- Pas d'impact : grob ne définit pas de custom logger utilisant ThreadRng

## Context
CI develop rouge depuis merge #148 (Security Audit fail). Bloque PR #152 (release v0.36.6) et PR #151 (sync-main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)