### PR TITLE
docs(ci): documenter la dépendance ruleset → Required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -968,6 +968,11 @@ jobs:
     steps:
       - name: Check required jobs
         run: |
+          # This is the ONLY job referenced in the GitHub ruleset "Protect develop".
+          # Do NOT add individual job names (Clippy, Rustfmt, etc.) to the ruleset —
+          # path pruning skips them on non-Rust changes, causing eternal "pending".
+          # See: https://github.com/azerozero/grob/pull/153
+          #
           # Fail if any required job failed (skipped is OK for pruned paths).
           results=( \
             "${{ needs.fmt.result }}" \


### PR DESCRIPTION
## Summary
- Ajoute un commentaire dans le job `Required checks` expliquant qu'il est le seul check référencé dans le ruleset GitHub
- Prévient la régression : ne pas ajouter de checks individuels (Clippy, Rustfmt) dans le ruleset car le path pruning les skip sur les changes non-Rust → pending éternel

## Context
PR #153 était bloquée car le ruleset exigeait `Clippy (ubuntu-latest)` qui était skippé par le path pruning. Fix ruleset fait, ce commit documente la décision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)