### PR TITLE
chore: release v0.36.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.8](https://github.com/azerozero/grob/compare/v0.36.7...v0.36.8) - 2026-04-11
+
+### Added
+
+- *(wizard)* polir le wizard setup pour atteindre le score audit 85+
+
 ## [0.36.7](https://github.com/azerozero/grob/compare/v0.36.6...v0.36.7) - 2026-04-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.7"
+version = "0.36.8"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.7"
+version = "0.36.8"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.7 -> 0.36.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.8](https://github.com/azerozero/grob/compare/v0.36.7...v0.36.8) - 2026-04-11

### Added

- *(wizard)* polir le wizard setup pour atteindre le score audit 85+
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).