### PR TITLE
style: corriger 7 lints clippy nightly

### DIFF
--- a/src/features/policies/matcher.rs
+++ b/src/features/policies/matcher.rs
@@ -91,7 +91,7 @@ impl PolicyMatcher {
         }
 
         // Sort by specificity descending (most specific first).
-        matches.sort_by(|a, b| b.specificity.cmp(&a.specificity));
+        matches.sort_by_key(|p| std::cmp::Reverse(p.specificity));
 
         self.merge(&matches)
     }

--- a/src/providers/streaming.rs
+++ b/src/providers/streaming.rs
@@ -232,10 +232,8 @@ impl<S> LoggingSseStream<S> {
                     }
                     tracking.logged_message_start = true;
                 }
-                Some("content_block_delta") => {
-                    if tracking.first_token_time.is_none() {
-                        tracking.first_token_time = Some(std::time::Instant::now());
-                    }
+                Some("content_block_delta") if tracking.first_token_time.is_none() => {
+                    tracking.first_token_time = Some(std::time::Instant::now());
                 }
                 Some("message_delta") => {
                     let usage = serde_json::from_str::<Value>(&event.data)
@@ -282,11 +280,9 @@ impl<S> LoggingSseStream<S> {
         let total_input = tokens.input + tokens.cache_creation + tokens.cache_read;
 
         let cache_info = if tokens.cache_creation > 0 || tokens.cache_read > 0 {
-            let cache_pct = if total_input > 0 {
-                (tokens.cache_read * 100) / total_input
-            } else {
-                0
-            };
+            let cache_pct = (tokens.cache_read * 100)
+                .checked_div(total_input)
+                .unwrap_or(0);
             format!(" cache:{}%", cache_pct)
         } else {
             String::new()

--- a/src/security/circuit_breaker.rs
+++ b/src/security/circuit_breaker.rs
@@ -112,13 +112,10 @@ impl CircuitBreaker {
         self.metrics.consecutive_failures = 0;
 
         match self.state {
-            CircuitState::HalfOpen => {
-                if self.metrics.consecutive_successes >= self.config.success_threshold {
-                    self.transition_to(CircuitState::Closed);
-                }
-            }
-            CircuitState::Closed => {
-                // Reset consecutive failures tracking
+            CircuitState::HalfOpen
+                if self.metrics.consecutive_successes >= self.config.success_threshold =>
+            {
+                self.transition_to(CircuitState::Closed);
             }
             _ => {}
         }
@@ -132,10 +129,10 @@ impl CircuitBreaker {
         self.metrics.last_failure_time = Some(Instant::now());
 
         match self.state {
-            CircuitState::Closed => {
-                if self.metrics.consecutive_failures >= self.config.failure_threshold {
-                    self.transition_to(CircuitState::Open);
-                }
+            CircuitState::Closed
+                if self.metrics.consecutive_failures >= self.config.failure_threshold =>
+            {
+                self.transition_to(CircuitState::Open);
             }
             CircuitState::HalfOpen => {
                 self.transition_to(CircuitState::Open);

--- a/src/server/openai_compat/transform.rs
+++ b/src/server/openai_compat/transform.rs
@@ -303,10 +303,8 @@ pub fn transform_canonical_to_openai(
 
     for block in &anthropic_resp.content {
         match block {
-            ContentBlock::Known(KnownContentBlock::Text { text, .. }) => {
-                if !text.is_empty() {
-                    text_parts.push(text.clone());
-                }
+            ContentBlock::Known(KnownContentBlock::Text { text, .. }) if !text.is_empty() => {
+                text_parts.push(text.clone());
             }
             ContentBlock::Known(KnownContentBlock::ToolUse { id, name, input }) => {
                 tool_calls.push(OpenAIToolCall {

--- a/src/server/responses_compat/transform.rs
+++ b/src/server/responses_compat/transform.rs
@@ -238,10 +238,8 @@ pub fn transform_canonical_to_responses(
 
     for block in &response.content {
         match block {
-            ContentBlock::Known(KnownContentBlock::Text { text, .. }) => {
-                if !text.is_empty() {
-                    text_parts.push(text.clone());
-                }
+            ContentBlock::Known(KnownContentBlock::Text { text, .. }) if !text.is_empty() => {
+                text_parts.push(text.clone());
             }
             ContentBlock::Known(KnownContentBlock::ToolUse { id, name, input }) => {
                 // Flush accumulated text as a message before function call


### PR DESCRIPTION
## Summary
- Corrige 7 lints clippy introduits dans les toolchains beta/nightly (`collapsible_match`, `sort_by_key`, `manual_checked_div`)
- Anticipe la compatibilite stable dans ~6 semaines
- 5 fichiers touches, -29/+18 lignes, zero changement de comportement

## Fichiers
- `src/features/policies/matcher.rs` — `sort_by` → `sort_by_key(Reverse)`
- `src/providers/streaming.rs` — match guard + `checked_div`
- `src/security/circuit_breaker.rs` — 2x match guards
- `src/server/openai_compat/transform.rs` — match guard
- `src/server/responses_compat/transform.rs` — match guard

## Test plan
- [x] `cargo clippy` — zero warning
- [x] `cargo test` — tous les tests passent
- [x] Pre-commit hooks (fmt, clippy, gitleaks, deny, audit) — tous passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)