### PR TITLE
fix(ci): debloquer les PRs docs-only dans le pipeline CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,6 @@ on:
       - ".vscode/**"
   pull_request:
     branches: [main, develop]
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - "LICENSE*"
-      - ".editorconfig"
-      - ".gitignore"
-      - ".gitattributes"
-      - "**.txt"
-      - "CODEOWNERS"
-      - ".vscode/**"
   workflow_dispatch:
     inputs:
       run_load:


### PR DESCRIPTION
## Summary
- Supprime `paths-ignore` du trigger `pull_request` dans `ci.yml`
- Les PRs docs-only declenchent maintenant le workflow : `dorny/paths-filter` skip les jobs Rust, le job `Required checks` tourne et reporte success
- Le `paths-ignore` sur `push` (develop) est conserve pour economiser les minutes CI

## Contexte
Les PRs ne touchant que des `.md` ne declenchaient jamais le workflow CI. Le job `Required checks` (seul status requis par le ruleset) n'etait jamais cree, bloquant indefiniment le merge. Ref: PR #167.

## Test plan
- [x] La PR #167 (docs-only) etait bloquee — ce fix resout le probleme
- [x] Le pruning interne (`dorny/paths-filter` + `if:` conditions) skip deja les jobs Rust inutiles
- [x] Le job `required` accepte les resultats `skipped` (ligne 993: ne fail que sur `failure`/`cancelled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)