### PR TITLE
chore: release v0.36.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.11](https://github.com/azerozero/grob/compare/v0.36.10...v0.36.11) - 2026-04-13
+
+### Added
+
+- *(dlp)* ajouter la detection d'injection indirecte dans les responses et tool_result ([#175](https://github.com/azerozero/grob/pull/175))
+- *(control)* implementer le moteur ControlEngine generique ([#174](https://github.com/azerozero/grob/pull/174))
+- *(hit)* implementer le scoring de risque parametrable ([#173](https://github.com/azerozero/grob/pull/173))
+
 ## [0.36.10](https://github.com/azerozero/grob/compare/v0.36.9...v0.36.10) - 2026-04-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.10"
+version = "0.36.11"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.10"
+version = "0.36.11"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.10 -> 0.36.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.11](https://github.com/azerozero/grob/compare/v0.36.10...v0.36.11) - 2026-04-13

### Added

- *(dlp)* ajouter la detection d'injection indirecte dans les responses et tool_result ([#175](https://github.com/azerozero/grob/pull/175))
- *(control)* implementer le moteur ControlEngine generique ([#174](https://github.com/azerozero/grob/pull/174))
- *(hit)* implementer le scoring de risque parametrable ([#173](https://github.com/azerozero/grob/pull/173))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).