### PR TITLE
chore: release v0.36.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.12](https://github.com/azerozero/grob/compare/v0.36.11...v0.36.12) - 2026-04-13
+
+### Added
+
+- *(mcp)* exposer les namespaces control via MCP tools + pledge CLI ([#179](https://github.com/azerozero/grob/pull/179))
+- *(cli)* migrer les commandes CLI vers le client RPC thin ([#178](https://github.com/azerozero/grob/pull/178))
+
+### Other
+
+- *(storage)* remplacer redb par fichiers atomiques + journal append-only (ADR-0013) ([#180](https://github.com/azerozero/grob/pull/180))
+
 ## [0.36.11](https://github.com/azerozero/grob/compare/v0.36.10...v0.36.11) - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.11"
+version = "0.36.12"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.11"
+version = "0.36.12"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.11 -> 0.36.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.12](https://github.com/azerozero/grob/compare/v0.36.11...v0.36.12) - 2026-04-13

### Added

- *(mcp)* exposer les namespaces control via MCP tools + pledge CLI ([#179](https://github.com/azerozero/grob/pull/179))
- *(cli)* migrer les commandes CLI vers le client RPC thin ([#178](https://github.com/azerozero/grob/pull/178))

### Other

- *(storage)* remplacer redb par fichiers atomiques + journal append-only (ADR-0013) ([#180](https://github.com/azerozero/grob/pull/180))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).