### PR TITLE
chore: release v0.36.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.13](https://github.com/azerozero/grob/compare/v0.36.12...v0.36.13) - 2026-04-13
+
+### Fixed
+
+- *(ci)* auto-cleanup des sync-main PRs obsoletes et resolution de conflits
+
+### Other
+
+- absorber l'historique main dans develop
+- *(adr)* marquer ADR-0013 et ADR-0015 done apres Phase A
+
 ## [0.36.12](https://github.com/azerozero/grob/compare/v0.36.11...v0.36.12) - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.12"
+version = "0.36.13"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.12"
+version = "0.36.13"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.12 -> 0.36.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.13](https://github.com/azerozero/grob/compare/v0.36.12...v0.36.13) - 2026-04-13

### Fixed

- *(ci)* auto-cleanup des sync-main PRs obsoletes et resolution de conflits

### Other

- absorber l'historique main dans develop
- *(adr)* marquer ADR-0013 et ADR-0015 done apres Phase A
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).