### PR TITLE
fix(audit): sprint S3 audit fixes — shell, security, control, CI

### DIFF
--- a/.github/actions/setup-e2e-pod/action.yml
+++ b/.github/actions/setup-e2e-pod/action.yml
@@ -19,7 +19,8 @@ runs:
       shell: bash
       run: |
         sudo apt-get update -qq && sudo apt-get install -y -qq podman
-        curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_x86_64.tar.gz" \
+        curl -fsSL --retry 3 --retry-delay 10 --retry-all-errors \
+          "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_x86_64.tar.gz" \
           | sudo tar xz -C /usr/local/bin crane
 
     - name: Pull grob image (multi-registry fallback)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,8 @@ jobs:
       - name: Install gitleaks
         run: |
           VERSION=8.24.3  # pinned — update manually
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+          curl -sSfL --retry 3 --retry-delay 10 --retry-all-errors \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
             | sudo tar xz -C /usr/local/bin gitleaks
       - name: Run gitleaks
         run: |
@@ -537,7 +538,8 @@ jobs:
         if: matrix.use-cross
         run: |
           VERSION=0.2.5  # pinned — update manually
-          curl -fsSL "https://github.com/cross-rs/cross/releases/download/v${VERSION}/cross-x86_64-unknown-linux-musl.tar.gz" \
+          curl -fsSL --retry 3 --retry-delay 10 --retry-all-errors \
+            "https://github.com/cross-rs/cross/releases/download/v${VERSION}/cross-x86_64-unknown-linux-musl.tar.gz" \
             | tar xz -C /usr/local/bin
           cross --version
 
@@ -608,7 +610,8 @@ jobs:
       - name: Install crane
         run: |
           VERSION=0.21.2
-          curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+          curl -fsSL --retry 3 --retry-delay 10 --retry-all-errors \
+            "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
             | tar xz -C /usr/local/bin crane
 
       - name: Login to GHCR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Multi-provider LLM routing proxy that sits between AI coding assistants and LLM 
 - **HTTP framework**: Axum 0.7 with Tower middleware
 - **HTTP client**: reqwest 0.12 (HTTP/2, rustls)
 - **Config**: TOML (serde)
-- **Storage**: redb (embedded key-value store for tokens, spend) + spend.json (legacy fallback)
+- **Storage**: Atomic files + append-only JSONL journals (tokens in `~/.grob/tokens/*.json.enc`, spend in `~/.grob/spend/YYYY-MM.jsonl`)
 - **CLI**: clap 4 (derive mode)
 - **Allocator**: jemalloc on non-MSVC targets
 - **CI**: GitHub Actions (fmt, clippy, nextest, coverage, cargo-audit, cargo-deny, cargo-hack, cargo-machete)
@@ -18,7 +18,7 @@ Multi-provider LLM routing proxy that sits between AI coding assistants and LLM 
 
 ## Architecture
 
-Grob accepts requests in Anthropic (`/v1/messages`) and OpenAI (`/v1/chat/completions`) formats. All requests are normalized to a canonical internal message format (the `CanonicalRequest` type). OpenAI-specific extension fields (response_format, reasoning_effort, seed, etc.) are captured in `RequestExtensions` for lossless roundtrips. A regex-based router classifies each request by task type (web_search, background, subagent, prompt_rule, think, default) and selects a named model. Each model maps to one or more providers ordered by priority. If the highest-priority provider fails, the request falls through to the next. Circuit breakers (5 failures = open, 30s timeout) prevent hammering degraded providers. DLP scanning runs on stream chunks using Aho-Corasick automata. Persistent spend tracking in redb (`~/.grob/grob.db`) enforces monthly budgets at global, per-provider, and per-model granularity.
+Grob accepts requests in Anthropic (`/v1/messages`) and OpenAI (`/v1/chat/completions`) formats. All requests are normalized to a canonical internal message format (the `CanonicalRequest` type). OpenAI-specific extension fields (response_format, reasoning_effort, seed, etc.) are captured in `RequestExtensions` for lossless roundtrips. A regex-based router classifies each request by task type (web_search, background, subagent, prompt_rule, think, default) and selects a named model. Each model maps to one or more providers ordered by priority. If the highest-priority provider fails, the request falls through to the next. Circuit breakers (5 failures = open, 30s timeout) prevent hammering degraded providers. DLP scanning runs on stream chunks using Aho-Corasick automata. Persistent spend tracking in append-only JSONL journals (`~/.grob/spend/YYYY-MM.jsonl`) enforces monthly budgets at global, per-provider, and per-model granularity.
 
 ## Domain Concepts
 
@@ -35,7 +35,7 @@ Grob accepts requests in Anthropic (`/v1/messages`) and OpenAI (`/v1/chat/comple
 - **Spend**: Monthly cost tracking per provider/model with budget enforcement (HTTP 402 on exceed).
 - **MCP**: Model Context Protocol tool matrix -- tool-calling capability catalogue with per-provider reliability scoring.
 - **Subagent model**: A system prompt tag (`GROB-SUBAGENT-MODEL`) that overrides model selection for nested agent calls.
-- **GrobStore**: Unified redb storage backend (`~/.grob/grob.db`) for OAuth tokens and spend. Migrates from legacy JSON files on first open.
+- **GrobStore**: Persistent storage layer using atomic files and append-only JSONL journals (`~/.grob/`). OAuth tokens stored as individually encrypted files (`tokens/<id>.json.enc`, AES-256-GCM), spend tracked in monthly journals (`spend/YYYY-MM.jsonl`).
 - **Harness**: Record & replay sandwich testing. Captures raw HTTP traffic as `.tape.jsonl` files, then replays through grob with a mock backend to exercise the full pipeline (DLP, routing, cache, streaming, etc.).
 
 ## Key Patterns
@@ -115,7 +115,7 @@ cargo bench --bench hotpath
 
 - Default port is **13456**, not 3456. Default bind address is `::1` (IPv6 localhost).
 - Config file is `~/.grob/config.toml`. Override with `--config <path>` or `GROB_CONFIG=<path|url>`.
-- OAuth tokens and spend stored in `~/.grob/grob.db` (redb). Legacy spend data may also exist in `~/.grob/spend.json` (auto-migrated on first run).
+- OAuth tokens stored in `~/.grob/tokens/<id>.json.enc` (AES-256-GCM encrypted). Spend tracked in `~/.grob/spend/YYYY-MM.jsonl` (append-only journals).
 - The `models` field on `ProviderConfig` is a legacy field -- model support is determined by `[[models.mappings]]`, not by listing models on the provider.
 - `jemalloc` is not available on MSVC targets -- the `#[cfg(not(target_env = "msvc"))]` guard handles this.
 - `cargo chef` is used in the Containerfile for layer caching.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Grob is a multi-provider LLM routing proxy written in Rust. It routes requests t
 - **Provider abstraction**: All providers implement the `LlmProvider` trait (`src/providers/mod.rs`).
 - **Routing**: Regex-based prompt rules in `src/router/mod.rs` classify requests into task types (thinking, web_search, background, default).
 - **OAuth**: Custom implementation (no `oauth2` crate) with PKCE in `src/auth/oauth.rs`.
-- **Spend tracking**: Persistent monthly spend in redb (`~/.grob/grob.db`) with budget enforcement.
+- **Spend tracking**: Persistent monthly spend in append-only JSONL journals (`~/.grob/spend/YYYY-MM.jsonl`) with budget enforcement.
 
 ### Module Layout
 
@@ -47,7 +47,7 @@ Grob is a multi-provider LLM routing proxy written in Rust. It routes requests t
 | `src/features/harness/` | Record & replay sandwich testing (opt-in `harness` feature) |
 | `src/security/` | Circuit breakers, rate limiting, audit log, headers, scoring |
 | `src/traits.rs` | Core trait contracts (7+ traits for dispatch pipeline) |
-| `src/storage/` | Unified redb storage backend (GrobStore) |
+| `src/storage/` | Persistent storage layer: atomic files, JSONL journals, AES-256-GCM encryption (GrobStore) |
 | `src/preset/` | Preset management system |
 | `src/auth/auto_flow.rs` | Automatic credential setup at startup |
 | `src/features/tool_layer/` | Tool-calling abstraction layer |

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ src/
 │   ├── log_backend/     Structured audit log backend
 │   └── log_export/      Encrypted audit log export
 ├── security/            Circuit breakers, rate limiting, audit log
-├── storage/             Unified redb storage backend (GrobStore)
+├── storage/             Persistent storage layer: atomic files, JSONL journals (GrobStore)
 ├── models/              Model and message type definitions
 ├── cache/               Response cache layer
 ├── message_tracing/     Request/response trace pipeline

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,7 @@ flowchart TB
     subgraph response["Response"]
         resp1["Stream SSE events / buffer"]
         resp2["Record metrics (latency, tokens, cost)"]
-        resp3["Update spend tracker (redb)"]
+        resp3["Update spend tracker (JSONL journal)"]
         resp4["Emit webhook tap event"]
         resp5["Write audit log entry"]
     end
@@ -88,7 +88,7 @@ flowchart TB
 | `preset` | `src/preset/mod.rs` | Preset management (list, apply, export, sync, validate) |
 | `auth` | `src/auth/mod.rs` | Auth module aggregator |
 | `auth::oauth` | `src/auth/oauth.rs` | OAuth client with PKCE |
-| `auth::token_store` | `src/auth/token_store.rs` | Persistent OAuth token storage (redb-backed) |
+| `auth::token_store` | `src/auth/token_store.rs` | Persistent OAuth token storage (encrypted files) |
 | `auth::jwt` | `src/auth/jwt.rs` | JWT validation and JWKS refresh |
 | `features::token_pricing` | `src/features/token_pricing/mod.rs` | Token counting and dynamic pricing table |
 | `features::token_pricing::spend` | `src/features/token_pricing/spend.rs` | Persistent monthly spend tracking and budget enforcement |
@@ -108,7 +108,7 @@ flowchart TB
 | `security::cache` | `src/security/cache.rs` | Response caching (moka) |
 | `security::provider_scorer` | `src/security/provider_scorer.rs` | Adaptive provider scoring (EWMA latency, success rate) |
 | `security::risk` | `src/security/risk.rs` | Risk assessment for EU AI Act compliance |
-| `storage` | `src/storage/mod.rs` | Unified redb storage backend (GrobStore) |
+| `storage` | `src/storage/mod.rs` | Persistent storage layer: atomic files, JSONL journals (GrobStore) |
 | `storage::migrate` | `src/storage/migrate.rs` | Storage migrations |
 | `models` | `src/models/mod.rs` | Anthropic request/response types, route types |
 | `features::mcp` | `src/features/mcp/mod.rs` | MCP tool matrix: tool catalogue, scoring, calibration |
@@ -135,7 +135,7 @@ flowchart TB
 
 **Streaming-first.** Both SSE streaming and buffered responses are supported. DLP scanning operates on stream chunks using Aho-Corasick automata, so no full-response buffering is needed.
 
-**Persistent state in redb.** OAuth tokens, monthly spend, and storage data are kept in an embedded redb database at `~/.grob/grob.db`. This survives restarts without requiring an external database.
+**Persistent state in atomic files.** OAuth tokens are stored as individually encrypted files (`~/.grob/tokens/<id>.json.enc`, AES-256-GCM). Monthly spend is tracked in append-only JSONL journals (`~/.grob/spend/YYYY-MM.jsonl`). Virtual keys are stored in `~/.grob/vkeys/<hash>.json.enc`. All writes are crash-safe (journals use `O_APPEND`, other files use atomic rename). See ADR-0013.
 
 **Security middleware stack.** All security features are toggled via the `[security]` TOML section: `rate_limit_rps`, `rate_limit_burst`, `max_body_size`, `security_headers`, `circuit_breaker`, `audit_dir`. Set `enabled = false` to disable the entire security layer. Each request gets a `X-Request-Id` (UUID v4 if not provided) for tracing across logs.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -37,7 +37,7 @@ warn_at_percent = 80          # Log warning at this % of any limit (default: 80)
 
 Budget checks follow a priority order: model limit > provider limit > global limit. When a limit is reached, requests return HTTP 402 with a `budget_exceeded` error. OAuth providers cost $0 and never hit caps.
 
-Spend is tracked in `~/.grob/grob.db` (redb) and resets automatically each month. Legacy `spend.json` data is auto-migrated on first run.
+Spend is tracked in append-only JSONL journals (`~/.grob/spend/YYYY-MM.jsonl`) and resets automatically each month.
 
 ## Providers
 

--- a/docs/DCI-REPORT.md
+++ b/docs/DCI-REPORT.md
@@ -88,7 +88,7 @@ The README has curl examples but SDK examples are still missing:
 The how-to/deploy.md covers basics but could benefit from:
 
 - Grafana dashboard setup guide (the JSON file exists at `docs/grafana-dashboard.json` but is undocumented)
-- Backup/restore procedures for the redb database
+- Backup/restore procedures for the storage directory (`~/.grob/`)
 - Terraform/Pulumi snippets for cloud deployment
 
 ### 3. CI Workflow Documentation (Impact: Low-Medium, Effort: Low)

--- a/docs/OAUTH_SETUP.md
+++ b/docs/OAUTH_SETUP.md
@@ -7,7 +7,7 @@ grob now supports OAuth authentication for Claude Pro/Max subscriptions, allowin
 - ✅ **Zero Cost**: Max plan users pay $0 for API calls
 - ✅ **PKCE Security**: Secure OAuth 2.0 with PKCE (Proof Key for Code Exchange)
 - ✅ **Auto Refresh**: Tokens are automatically refreshed when expired
-- ✅ **Persistent Storage**: Tokens stored securely in `~/.grob/grob.db` (redb)
+- ✅ **Persistent Storage**: Tokens stored securely in `~/.grob/tokens/<id>.json.enc` (AES-256-GCM)
 
 ## OAuth PKCE Flow
 
@@ -124,7 +124,7 @@ For creating an API key via OAuth (alternative flow):
 
 ## Token Storage
 
-Tokens are stored in `~/.grob/grob.db` using redb (embedded key-value store). Legacy `oauth_tokens.json` data is auto-migrated on first run. The database file is created with restricted permissions for security.
+Tokens are stored as individually encrypted files in `~/.grob/tokens/<id>.json.enc` (AES-256-GCM). Each file is created with restricted permissions (`0600`) for security.
 
 ## API Endpoints
 
@@ -160,8 +160,8 @@ let response = reqwest::Client::new()
 
 ## Security Notes
 
-1. **Never commit tokens**: The `grob.db` file contains sensitive credentials
-2. **File permissions**: The database file has restricted permissions (Unix)
+1. **Never commit tokens**: The `~/.grob/tokens/` directory contains sensitive credentials
+2. **File permissions**: Token files have restricted permissions (`0600`, Unix)
 3. **PKCE**: Uses SHA-256 challenge for additional security
 4. **Auto-refresh**: Tokens are refreshed 5 minutes before expiration
 

--- a/docs/OAUTH_TESTING.md
+++ b/docs/OAUTH_TESTING.md
@@ -8,7 +8,7 @@ This guide shows how to test the OAuth authentication flow for Claude Pro/Max.
 grob connect anthropic
 ```
 
-This will open your browser, complete the OAuth PKCE flow, and save the token to the redb store (`~/.grob/grob.db`).
+This will open your browser, complete the OAuth PKCE flow, and save the token as an encrypted file in `~/.grob/tokens/`.
 
 ## Testing with API Endpoints
 
@@ -138,7 +138,7 @@ The provider will automatically use the OAuth token from TokenStore and authenti
 
 Check if token exists:
 ```bash
-cat ~/.grob/oauth_tokens.json
+ls ~/.grob/tokens/
 ```
 
 Should show:
@@ -176,14 +176,14 @@ Common issues:
 
 After successful authentication:
 
-1. ✅ Token saved to `~/.grob/oauth_tokens.json`
+1. ✅ Token saved to `~/.grob/tokens/<provider>.json.enc`
 2. ✅ Configure provider with `auth_type = "oauth"`
 3. ✅ Bearer token injection works automatically
 
 ## Security Notes
 
-- Tokens stored with `0600` permissions (owner read/write only)
-- Never commit `oauth_tokens.json` to version control
+- Token files stored with `0600` permissions (owner read/write only)
+- Never commit `~/.grob/tokens/` contents to version control
 - Tokens auto-refresh before expiration
 - PKCE ensures secure authorization flow
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -51,7 +51,7 @@ auth_type = "oauth"
 oauth_provider = "anthropic-max"
 ```
 
-On first `grob start`, a browser window opens for OAuth login. Tokens are stored in `~/.grob/grob.db` (redb) and refreshed automatically.
+On first `grob start`, a browser window opens for OAuth login. Tokens are stored as encrypted files in `~/.grob/tokens/` (AES-256-GCM) and refreshed automatically.
 
 See [OAuth Setup](OAUTH_SETUP.md) for details.
 

--- a/docs/decisions/0001-static-config-no-hot-reload.md
+++ b/docs/decisions/0001-static-config-no-hot-reload.md
@@ -45,7 +45,7 @@ Chosen option: "Explicit API-triggered reload", because it eliminates filesystem
 | Field | Why stable |
 |-------|-----------|
 | `spend_tracker` | Cross-reload spend continuity |
-| `grob_store` | Embedded redb database |
+| `grob_store` | File-based storage backend |
 | `token_store` | OAuth token cache |
 | `audit_log` | Hash chain must be continuous |
 | `rate_limiter` | Token bucket state must persist |

--- a/docs/decisions/0004-persistent-spend-tracking.md
+++ b/docs/decisions/0004-persistent-spend-tracking.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by [ADR-0013](0013-storage-files-no-redb.md)
 
 ## Context and Problem Statement
 

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -149,7 +149,7 @@ Virtual keys are managed via CLI or API. Each key record contains:
 
 ### Storage
 
-Virtual key records are stored encrypted (AES-256-GCM) in redb with two index entries:
+Virtual key records are stored as individually encrypted files (`~/.grob/vkeys/<hash>.json.enc`, AES-256-GCM) with two index strategies:
 - **Primary**: keyed by SHA-256 hash (for O(1) authentication lookups).
 - **Secondary**: keyed by `id:<uuid>` (for list/revoke/delete by ID).
 
@@ -187,7 +187,7 @@ All providers use PKCE (Proof Key for Code Exchange) with SHA-256 challenge meth
 1. **Generate**: Random 32-byte verifier, base64url-encoded. Challenge = `base64url(SHA-256(verifier))`.
 2. **Authorize**: Redirect user to provider's auth URL with `code_challenge` and `code_challenge_method=S256`.
 3. **Exchange**: POST authorization code + verifier to token endpoint. Provider verifies `SHA-256(verifier) == challenge`.
-4. **Store**: Access token, refresh token, and expiration saved to redb (encrypted).
+4. **Store**: Access token, refresh token, and expiration saved as encrypted files (`~/.grob/tokens/<id>.json.enc`, AES-256-GCM).
 
 ### Token lifecycle
 
@@ -210,7 +210,7 @@ All providers use PKCE (Proof Key for Code Exchange) with SHA-256 challenge meth
 
 ### Token storage
 
-OAuth tokens are stored in `~/.grob/grob.db` (redb) under the `oauth_tokens` table. Each token is encrypted with AES-256-GCM before storage. Legacy `oauth_tokens.json` files are auto-migrated on first database open (see [Storage Reference](storage.md)).
+OAuth tokens are stored as individually encrypted files in `~/.grob/tokens/<id>.json.enc` (AES-256-GCM). Each file is written atomically (write → fsync → rename) and has restricted permissions (`0600`). See [Storage Reference](storage.md).
 
 ### Provider-specific notes
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -93,7 +93,7 @@ Run 11 diagnostic checks:
 6. Port availability (if service not running)
 7. DLP status
 8. Security settings (rate limit, circuit breaker)
-9. Storage backend (redb)
+9. Storage backend (atomic files)
 10. Missing environment variables
 11. Podman availability
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -221,7 +221,7 @@ Every compliance claim was verified against the actual codebase:
 | Live TUI | `grob watch` — real-time traffic inspector with DLP/fallback events | `grob watch` (feature `watch`) |
 | SSE event stream | `GET /api/events` for programmatic monitoring | Built-in |
 | Message tracing | Per-request trace IDs with structured logging | `[server.tracing] enabled = true` |
-| Spend tracking | Persistent monthly spend per provider/model/tenant (redb) | Built-in |
+| Spend tracking | Persistent monthly spend per provider/model/tenant (JSONL journals) | Built-in |
 | Budget alerts | Warning at configurable threshold (default 80%) | `[budget] warn_at_percent` |
 
 ## Operations
@@ -282,7 +282,7 @@ Every compliance claim was verified against the actual codebase:
 ## Architecture
 
 - **Language**: Rust (tokio async runtime, axum HTTP framework)
-- **Storage**: redb embedded KV store (no PostgreSQL, no Redis)
+- **Storage**: Atomic files + JSONL journals (no PostgreSQL, no Redis, no embedded DB)
 - **Allocator**: jemalloc (non-MSVC) for ~20% throughput improvement
 - **Container**: 6 MB `FROM scratch`, rustls TLS bundled
 - **Codebase**: ~29K lines of Rust, 520+ tests

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -199,7 +199,7 @@ The event bus uses a broadcast channel with a capacity of 1024 events. The TUI k
 
 ## Spend tracking
 
-Monthly spend is tracked persistently in `~/.grob/grob.db` (redb) or `~/.grob/spend.json` (legacy fallback). Data auto-resets on the first request of a new calendar month.
+Monthly spend is tracked persistently in append-only JSONL journals (`~/.grob/spend/YYYY-MM.jsonl`). Data auto-resets on the first request of a new calendar month (new journal file).
 
 ### Budget enforcement
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -205,6 +205,6 @@ The `grob doctor` command runs 11 diagnostic checks:
 6. Port availability
 7. DLP enabled/disabled
 8. Security configuration (rate limit, circuit breaker)
-9. Storage backend (redb) accessibility
+9. Storage backend (atomic files) accessibility
 10. Missing environment variables
 11. Podman availability (optional)

--- a/scripts/build-podman.sh
+++ b/scripts/build-podman.sh
@@ -7,11 +7,15 @@ set -e
 TAG=${1:-latest}
 CONTAINERFILE="Containerfile"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# Colors (gated on TTY + NO_COLOR)
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+else
+    RED='' GREEN='' YELLOW='' NC=''
+fi
 
 echo -e "${GREEN}Building Grob container image with Podman...${NC}"
 echo "Tag: ${TAG}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build script for Grob with security modules
-set -e
+set -euo pipefail
 
-echo "🔒 Building Grob with full security stack..."
-cd /Users/clementliard/Workspace/grob
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+echo "Building Grob with full security stack..."
 
 echo "Running security tests..."
 cargo test --lib security:: 2>&1 | head -50
@@ -11,4 +13,4 @@ cargo test --lib security:: 2>&1 | head -50
 echo "Checking compilation..."
 cargo check --release --features tls
 
-echo "✅ Build complete!"
+echo "Build complete!"

--- a/scripts/cleancode-audit.sh
+++ b/scripts/cleancode-audit.sh
@@ -36,12 +36,16 @@ NESTING_CRITICAL=5
 NESTING_MIN_LINES=20
 CLONE_DENSITY_FLAG=10
 
-# --- Colors for terminal ---
-RED='\033[0;31m'
-YELLOW='\033[0;33m'
-GREEN='\033[0;32m'
-CYAN='\033[0;36m'
-NC='\033[0m'
+# --- Colors for terminal (gated on TTY + NO_COLOR) ---
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+    RED='\033[0;31m'
+    YELLOW='\033[0;33m'
+    GREEN='\033[0;32m'
+    CYAN='\033[0;36m'
+    NC='\033[0m'
+else
+    RED='' YELLOW='' GREEN='' CYAN='' NC=''
+fi
 
 # --- Counters ---
 critical_count=0

--- a/scripts/codeql-check.sh
+++ b/scripts/codeql-check.sh
@@ -36,9 +36,9 @@ RESULTS=$(codeql database analyze "$DB_DIR" \
 echo "$RESULTS"
 
 if [[ -n "$SARIF_FILE" ]] && [[ -f "$SARIF_FILE" ]]; then
-    ALERT_COUNT=$(python3 -c "
-import json, sys
-with open('$SARIF_FILE') as f:
+    ALERT_COUNT=$(SARIF_FILE="$SARIF_FILE" python3 -c "
+import json, os
+with open(os.environ['SARIF_FILE']) as f:
     d = json.load(f)
     total = sum(len(r.get('results', [])) for r in d.get('runs', []))
     print(total)

--- a/scripts/install-rootless.sh
+++ b/scripts/install-rootless.sh
@@ -9,11 +9,15 @@ CONFIG_DIR="${GROB_DIR}/config"
 DATA_DIR="${GROB_DIR}/data"
 QUADLET_DIR="${HOME}/.config/containers/systemd"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+# Colors (gated on TTY + NO_COLOR)
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+else
+    RED='' GREEN='' YELLOW='' NC=''
+fi
 
 echo -e "${GREEN}Installing Grob as rootless Podman container...${NC}"
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,11 +6,15 @@ set -e
 echo "Running Claude Code Mux Test Suite"
 echo "=================================="
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# Colors (gated on TTY + NO_COLOR)
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+else
+    RED='' GREEN='' YELLOW='' NC=''
+fi
 
 # Function to run tests
 run_tests() {

--- a/src/control/engine.rs
+++ b/src/control/engine.rs
@@ -7,6 +7,29 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+// ── RBAC role hierarchy ──
+
+/// Access role derived from transport credentials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    /// Read-only: list endpoints and budget queries.
+    Observer = 0,
+    /// Operational: server control, routing changes.
+    Operator = 1,
+    /// Administrative: config and key management.
+    Admin = 2,
+    /// Unrestricted: localhost-only, full access.
+    Superadmin = 3,
+}
+
+impl Role {
+    /// Returns `true` if this role has at least the given privilege level.
+    pub fn has_at_least(self, required: Role) -> bool {
+        (self as u8) >= (required as u8)
+    }
+}
+
 // ── Action catalog ──
 
 /// Top-level action routed by the control engine.
@@ -291,8 +314,6 @@ impl ControlError {
 }
 
 // ── Role requirement mapping (pure) ──
-
-use crate::server::rpc::types::Role;
 
 /// Returns the minimum [`Role`] required for the given action.
 pub fn required_role(action: &Action) -> Role {

--- a/src/server/rpc/types.rs
+++ b/src/server/rpc/types.rs
@@ -23,28 +23,9 @@ pub fn rpc_err(code: i32, msg: impl Into<String>) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(code, msg.into(), None::<()>)
 }
 
-// ── RBAC role hierarchy ──
+// ── RBAC role hierarchy (canonical definition in control::engine) ──
 
-/// Access role derived from transport credentials.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Role {
-    /// Read-only: list endpoints and budget queries.
-    Observer = 0,
-    /// Operational: server control, routing changes.
-    Operator = 1,
-    /// Administrative: config and key management.
-    Admin = 2,
-    /// Unrestricted: localhost-only, full access.
-    Superadmin = 3,
-}
-
-impl Role {
-    /// Returns `true` if this role has at least the given privilege level.
-    pub fn has_at_least(self, required: Role) -> bool {
-        (self as u8) >= (required as u8)
-    }
-}
+pub use crate::control::engine::Role;
 
 // ── Common response envelopes ──
 


### PR DESCRIPTION
## Summary
Sprint S3 (cli-cycle audit) produced 5 fixes across shell scripts, security, control engine, and CI pipeline:

- **fix(security)**: pass SARIF_FILE via env variable in codeql-check.sh (CWE-78 injection fix)
- **fix(shell)**: remove hardcoded paths in build.sh, use `$0`-relative resolution
- **fix(shell)**: gate ANSI colors on TTY detection and `NO_COLOR` env var
- **refactor(control)**: move `Role` enum from RPC types into control engine (tangle cycle fix)
- **fix(ci)**: add retry with backoff to curl installations in CI pipeline

## Context
These fixes were generated by the Sprint S3 brigade (cli-forge-boss + cli-cycle) running in tmux session `grob-s3`. The brigade completed Wave 1 (9 audits), Wave 2 (8 fixes), and Wave 3 (scorecard). These commits were on the local develop branch but never pushed because develop is protected.

## Test plan
- [x] `cargo test` passes (all pre-push hooks green)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `gitleaks` clean
- [x] `cargo deny` + `cargo audit` clean
- [ ] CI pipeline passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)