### PR TITLE
chore: release v0.36.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.14](https://github.com/azerozero/grob/compare/v0.36.13...v0.36.14) - 2026-04-14
+
+### Fixed
+
+- *(ci)* ajouter retry aux installations curl dans le pipeline
+- *(shell)* gater les couleurs ANSI sur TTY et NO_COLOR
+- *(shell)* supprimer le chemin hardcode et renforcer build.sh
+- *(security)* passer SARIF_FILE par variable d'env dans codeql-check.sh
+
+### Other
+
+- *(control)* deplacer Role dans le control engine
+
 ## [0.36.13](https://github.com/azerozero/grob/compare/v0.36.12...v0.36.13) - 2026-04-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.13"
+version = "0.36.14"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.13"
+version = "0.36.14"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.13 -> 0.36.14

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.14](https://github.com/azerozero/grob/compare/v0.36.13...v0.36.14) - 2026-04-14

### Fixed

- *(ci)* ajouter retry aux installations curl dans le pipeline
- *(shell)* gater les couleurs ANSI sur TTY et NO_COLOR
- *(shell)* supprimer le chemin hardcode et renforcer build.sh
- *(security)* passer SARIF_FILE par variable d'env dans codeql-check.sh

### Other

- *(control)* deplacer Role dans le control engine
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).