### PR TITLE
test(dlp): kill mutation survivor in IndirectInjectionBlocked Display

### DIFF
--- a/src/features/dlp/tests.rs
+++ b/src/features/dlp/tests.rs
@@ -1102,6 +1102,41 @@ fn display_indirect_injection_blocked() {
 }
 
 #[test]
+fn display_indirect_injection_blocked_multi() {
+    let err = DlpBlockError::IndirectInjectionBlocked(vec![
+        prompt_injection::InjectionDetection {
+            pattern_name: "en_ignore".into(),
+            matched_text: "ignore previous".into(),
+            start: 0,
+            end: 15,
+        },
+        prompt_injection::InjectionDetection {
+            pattern_name: "en_system".into(),
+            matched_text: "new system prompt".into(),
+            start: 20,
+            end: 37,
+        },
+    ]);
+    let msg = err.to_string();
+    assert!(
+        msg.starts_with("Indirect injection detected: "),
+        "must start with prefix"
+    );
+    assert!(
+        msg.contains(", "),
+        "multiple detections must be comma-separated"
+    );
+    assert!(
+        msg.contains("ignore previous"),
+        "must contain first detection"
+    );
+    assert!(
+        msg.contains("new system prompt"),
+        "must contain second detection"
+    );
+}
+
+#[test]
 fn indirect_injection_config_defaults() {
     let config = config::PromptInjectionConfig::default();
     assert!(config.scan_responses, "scan_responses default must be true");


### PR DESCRIPTION
## Summary
Kill the survived mutant at `src/features/dlp/mod.rs:149:26` (replace `>` with `==` in `<impl Display for DlpBlockError>::fmt`) that caused CI shard 2/5 to fail.

Adds `display_indirect_injection_blocked_multi` — tests Display with 2+ detections to verify comma-separated formatting.

## Test plan
- [x] `cargo test -- display_indirect_injection_blocked_multi` passes
- [ ] CI mutation testing shard 2/5 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)