### PR TITLE
chore: release v0.36.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.15](https://github.com/azerozero/grob/compare/v0.36.14...v0.36.15) - 2026-04-14
+
+### Fixed
+
+- *(ci)* absorber main dans develop apres chaque sync-main
+
+### Other
+
+- *(dlp)* kill mutation survivor in IndirectInjectionBlocked Display
+
 ## [0.36.14](https://github.com/azerozero/grob/compare/v0.36.13...v0.36.14) - 2026-04-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.14"
+version = "0.36.15"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.14"
+version = "0.36.15"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.14 -> 0.36.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.15](https://github.com/azerozero/grob/compare/v0.36.14...v0.36.15) - 2026-04-14

### Fixed

- *(ci)* absorber main dans develop apres chaque sync-main

### Other

- *(dlp)* kill mutation survivor in IndirectInjectionBlocked Display
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).