### PR TITLE
feat(router): ajouter le match declaratif [tiers.match] (T-P3b)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,8 @@ tempfile = "3"
 # Credential encryption at rest (AES-256-GCM)
 aes-gcm = "0.10"
 
-# Policy engine (glob pattern matching for policy rules)
-globset = { version = "0.4", optional = true }
+# Glob pattern matching (tier routing + policy engine)
+globset = "0.4"
 
 # Encrypted audit export (envelope encryption, multi-recipient)
 age = { version = "0.11", features = ["armor"] }
@@ -207,7 +207,7 @@ tap = []
 compliance = []
 mcp = []
 harness = []
-policies = ["globset"]
+policies = []
 test-util = []
 
 [package.metadata.cargo-machete]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -824,6 +824,34 @@ impl ProviderConfig {
     }
 }
 
+/// Declarative match conditions for tier activation.
+///
+/// All specified fields are AND-combined: every non-empty field must match
+/// for the tier to activate. Within a field (e.g. `keywords`), values are
+/// OR-combined (any hit satisfies that field). Omitted/empty fields are
+/// unconstrained.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct TierMatchCondition {
+    /// Substring keywords matched against the last user message (OR-combined, case-insensitive).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+    /// Glob patterns matched against file paths found in message content (OR-combined).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_patterns: Vec<String>,
+    /// Tool names that must be present in the request (OR-combined).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
+    /// Activates when `max_tokens >= this` value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens_above: Option<u32>,
+    /// Activates when `max_tokens <= this` value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens_below: Option<u32>,
+    /// Activates when message count `>= this` value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_messages: Option<usize>,
+}
+
 /// Declarative tier configuration mapping complexity tiers to provider lists.
 ///
 /// Each `[[tiers]]` entry binds a [`ComplexityTier`](crate::router::classify::ComplexityTier)
@@ -839,4 +867,7 @@ pub struct TierConfig {
     /// Send the request to all tier providers in parallel (fan-out).
     #[serde(default)]
     pub fanout: bool,
+    /// Optional declarative match conditions (bypasses the algorithmic scorer).
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "match")]
+    pub match_conditions: Option<TierMatchCondition>,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,7 +16,7 @@ pub use config::{
     FanOutConfig, FanOutMode, FipsConfig, ModelConfig, ModelMapping, ModelStrategy, OtelConfig,
     PoolConfig, PoolStrategy, PresetConfig, ProjectConfig, ProjectRouterOverlay, PromptRule,
     ProviderConfig, RouterConfig, SecurityConfig, ServerConfig, TeeConfig, TierConfig,
-    TimeoutConfig, TlsConfig, TracingConfig, UserConfig,
+    TierMatchCondition, TimeoutConfig, TlsConfig, TracingConfig, UserConfig,
 };
 pub use newtypes::{BodySizeLimit, BudgetUsd, ConfigSource, Port};
 

--- a/src/router/classify.rs
+++ b/src/router/classify.rs
@@ -200,7 +200,7 @@ fn score_keywords(request: &CanonicalRequest) -> f32 {
 }
 
 /// Extracts text from the last user message for keyword scanning.
-fn extract_last_user_text(request: &CanonicalRequest) -> Option<String> {
+pub(crate) fn extract_last_user_text(request: &CanonicalRequest) -> Option<String> {
     let last_user = request.messages.iter().rev().find(|m| m.role == "user")?;
     match &last_user.content {
         MessageContent::Text(t) => Some(t.clone()),

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -8,6 +8,8 @@ pub mod inference;
 mod message;
 /// Regex compilation and capture-group utilities.
 mod rules;
+/// Declarative tier matcher for `[tiers.match]` conditions.
+pub(crate) mod tier_match;
 
 use crate::cli::AppConfig;
 use crate::models::{CanonicalRequest, RouteDecision, RouteType};
@@ -134,6 +136,8 @@ pub struct Router {
     prompt_rules: Vec<CompiledPromptRule>,
     /// Scoring config for complexity classification. `None` disables scoring.
     scoring_config: Option<classify::ScoringConfig>,
+    /// Compiled declarative tier matchers from `[[tiers]]` with `[tiers.match]`.
+    tier_matchers: Vec<tier_match::CompiledTierMatch>,
 }
 
 impl Router {
@@ -197,9 +201,40 @@ impl Router {
             info!("📝 Loaded {} prompt routing rules", prompt_rules.len());
         }
 
-        // Scoring is always active (default config). T-P3 will add
-        // tier-based provider selection; until then the tier is informational.
         let scoring_config = Some(classify::ScoringConfig::default());
+
+        let tier_matchers: Vec<tier_match::CompiledTierMatch> = config
+            .tiers
+            .iter()
+            .filter_map(|tier_cfg| {
+                let condition = tier_cfg.match_conditions.as_ref()?;
+                let tier = match tier_cfg.name.to_lowercase().as_str() {
+                    "trivial" => classify::ComplexityTier::Trivial,
+                    "medium" => classify::ComplexityTier::Medium,
+                    "complex" => classify::ComplexityTier::Complex,
+                    _ => {
+                        tracing::warn!(
+                            "Unknown tier '{}' in [tiers.match], skipping",
+                            tier_cfg.name
+                        );
+                        return None;
+                    }
+                };
+                match tier_match::CompiledTierMatch::new(tier, condition.clone()) {
+                    Ok(m) => Some(m),
+                    Err(e) => {
+                        tracing::warn!("Invalid glob in tier '{}': {e}. Skipping.", tier_cfg.name);
+                        None
+                    }
+                }
+            })
+            .collect();
+        if !tier_matchers.is_empty() {
+            info!(
+                "📊 Loaded {} declarative tier matchers",
+                tier_matchers.len()
+            );
+        }
 
         Self {
             config,
@@ -208,6 +243,7 @@ impl Router {
             background_prefilter_bytes,
             prompt_rules,
             scoring_config,
+            tier_matchers,
         }
     }
 
@@ -300,11 +336,14 @@ impl Router {
             }
         }
 
-        // 8. Complexity scoring (after all rule-based routing, before default)
-        let tier = self.scoring_config.as_ref().map(|cfg| {
-            let t = classify::classify_complexity(request, cfg);
-            debug!(tier = %t, "📊 Complexity scoring");
-            t
+        // 8. Declarative tier match (checked FIRST, before algorithmic scorer)
+        // 9. Fallback: algorithmic complexity scoring
+        let tier = tier_match::evaluate_tier_matches(&self.tier_matchers, request).or_else(|| {
+            self.scoring_config.as_ref().map(|cfg| {
+                let t = classify::classify_complexity(request, cfg);
+                debug!(tier = %t, "📊 Complexity scoring (fallback)");
+                t
+            })
         });
 
         // 9. Default fallback

--- a/src/router/tier_match.rs
+++ b/src/router/tier_match.rs
@@ -1,0 +1,348 @@
+//! Declarative tier matcher: evaluates `[tiers.match]` conditions at routing time.
+
+use crate::cli::TierMatchCondition;
+use crate::models::CanonicalRequest;
+use crate::router::classify::{self, ComplexityTier};
+use globset::{Glob, GlobMatcher};
+use tracing::debug;
+
+/// Pre-compiled tier match with glob matchers for file patterns.
+#[derive(Clone)]
+pub(crate) struct CompiledTierMatch {
+    tier: ComplexityTier,
+    condition: TierMatchCondition,
+    file_globs: Vec<GlobMatcher>,
+}
+
+impl CompiledTierMatch {
+    /// Compiles a tier match condition into a ready-to-evaluate matcher.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any `file_patterns` glob is invalid.
+    pub fn new(
+        tier: ComplexityTier,
+        condition: TierMatchCondition,
+    ) -> Result<Self, globset::Error> {
+        let file_globs = condition
+            .file_patterns
+            .iter()
+            .map(|p| Glob::new(p).map(|g| g.compile_matcher()))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            tier,
+            condition,
+            file_globs,
+        })
+    }
+
+    /// Evaluates all conditions against a request (AND-combined).
+    fn matches(&self, request: &CanonicalRequest) -> bool {
+        if !self.condition.keywords.is_empty() && !self.matches_keywords(request) {
+            return false;
+        }
+        if !self.file_globs.is_empty() && !self.matches_file_patterns(request) {
+            return false;
+        }
+        if !self.condition.tools.is_empty() && !self.matches_tools(request) {
+            return false;
+        }
+        if let Some(above) = self.condition.max_tokens_above {
+            if request.max_tokens < above {
+                return false;
+            }
+        }
+        if let Some(below) = self.condition.max_tokens_below {
+            if request.max_tokens > below {
+                return false;
+            }
+        }
+        if let Some(min_msgs) = self.condition.min_messages {
+            if request.messages.len() < min_msgs {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn matches_keywords(&self, request: &CanonicalRequest) -> bool {
+        let text = match classify::extract_last_user_text(request) {
+            Some(t) => t.to_lowercase(),
+            None => return false,
+        };
+        self.condition
+            .keywords
+            .iter()
+            .any(|kw| text.contains(&kw.to_lowercase()))
+    }
+
+    fn matches_file_patterns(&self, request: &CanonicalRequest) -> bool {
+        let text = match classify::extract_last_user_text(request) {
+            Some(t) => t,
+            None => return false,
+        };
+        let paths = extract_file_paths(&text);
+        paths
+            .iter()
+            .any(|p| self.file_globs.iter().any(|g| g.is_match(p)))
+    }
+
+    fn matches_tools(&self, request: &CanonicalRequest) -> bool {
+        let tools = match &request.tools {
+            Some(t) => t,
+            None => return false,
+        };
+        self.condition.tools.iter().any(|required| {
+            tools.iter().any(|t| {
+                t.name
+                    .as_deref()
+                    .is_some_and(|n| n.eq_ignore_ascii_case(required))
+            })
+        })
+    }
+}
+
+/// Evaluates compiled tier matchers in declaration order, returns the first match.
+pub(crate) fn evaluate_tier_matches(
+    matchers: &[CompiledTierMatch],
+    request: &CanonicalRequest,
+) -> Option<ComplexityTier> {
+    for m in matchers {
+        if m.matches(request) {
+            debug!(tier = %m.tier, "📊 Declarative tier match");
+            return Some(m.tier);
+        }
+    }
+    None
+}
+
+/// Extracts file-path-like tokens from text for glob matching.
+fn extract_file_paths(text: &str) -> Vec<&str> {
+    text.split(|c: char| c.is_whitespace() || c == '`' || c == '\'' || c == '"')
+        .filter(|token| {
+            !token.is_empty()
+                && (token.contains('/')
+                    || token
+                        .rfind('.')
+                        .is_some_and(|dot| dot > 0 && dot < token.len() - 1))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::extensions::RequestExtensions;
+    use crate::models::{Message, MessageContent, Tool};
+
+    fn request_with_text(text: &str, max_tokens: u32) -> CanonicalRequest {
+        CanonicalRequest {
+            model: "test".into(),
+            messages: vec![Message {
+                role: "user".into(),
+                content: MessageContent::Text(text.into()),
+            }],
+            max_tokens,
+            thinking: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            metadata: None,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            extensions: RequestExtensions::default(),
+        }
+    }
+
+    fn request_with_tools(text: &str, tool_names: &[&str]) -> CanonicalRequest {
+        let tools = tool_names
+            .iter()
+            .map(|name| Tool {
+                r#type: Some("function".into()),
+                name: Some(name.to_string()),
+                description: None,
+                input_schema: None,
+            })
+            .collect();
+        let mut req = request_with_text(text, 4096);
+        req.tools = Some(tools);
+        req
+    }
+
+    fn condition(keywords: &[&str], file_patterns: &[&str]) -> TierMatchCondition {
+        TierMatchCondition {
+            keywords: keywords.iter().map(|s| s.to_string()).collect(),
+            file_patterns: file_patterns.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn keywords_match_case_insensitive() {
+        let m =
+            CompiledTierMatch::new(ComplexityTier::Complex, condition(&["unsafe"], &[])).unwrap();
+        assert!(m.matches(&request_with_text("Use unsafe block here", 4096)));
+    }
+
+    #[test]
+    fn keywords_no_match() {
+        let m =
+            CompiledTierMatch::new(ComplexityTier::Complex, condition(&["unsafe"], &[])).unwrap();
+        assert!(!m.matches(&request_with_text("use safe patterns only", 4096)));
+    }
+
+    #[test]
+    fn file_patterns_match_rs() {
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, condition(&[], &["*.rs"])).unwrap();
+        assert!(m.matches(&request_with_text("edit src/main.rs please", 4096)));
+    }
+
+    #[test]
+    fn file_patterns_match_tf() {
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, condition(&[], &["*.tf"])).unwrap();
+        assert!(m.matches(&request_with_text("update infra/main.tf", 4096)));
+    }
+
+    #[test]
+    fn file_patterns_no_match() {
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, condition(&[], &["*.rs"])).unwrap();
+        assert!(!m.matches(&request_with_text("edit main.py please", 4096)));
+    }
+
+    #[test]
+    fn tools_match_name() {
+        let cond = TierMatchCondition {
+            tools: vec!["code_editor".into()],
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, cond).unwrap();
+        assert!(m.matches(&request_with_tools(
+            "edit file",
+            &["code_editor", "web_search"]
+        )));
+    }
+
+    #[test]
+    fn tools_no_match() {
+        let cond = TierMatchCondition {
+            tools: vec!["code_editor".into()],
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, cond).unwrap();
+        assert!(!m.matches(&request_with_tools("edit file", &["web_search"])));
+    }
+
+    #[test]
+    fn max_tokens_above_match() {
+        let cond = TierMatchCondition {
+            max_tokens_above: Some(4000),
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, cond).unwrap();
+        assert!(m.matches(&request_with_text("anything", 8000)));
+    }
+
+    #[test]
+    fn max_tokens_above_no_match() {
+        let cond = TierMatchCondition {
+            max_tokens_above: Some(4000),
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, cond).unwrap();
+        assert!(!m.matches(&request_with_text("anything", 100)));
+    }
+
+    #[test]
+    fn max_tokens_below_match() {
+        let cond = TierMatchCondition {
+            max_tokens_below: Some(500),
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Trivial, cond).unwrap();
+        assert!(m.matches(&request_with_text("anything", 100)));
+    }
+
+    #[test]
+    fn min_messages_match() {
+        let cond = TierMatchCondition {
+            min_messages: Some(2),
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, cond).unwrap();
+        let mut req = request_with_text("msg1", 4096);
+        req.messages.push(Message {
+            role: "assistant".into(),
+            content: MessageContent::Text("reply".into()),
+        });
+        req.messages.push(Message {
+            role: "user".into(),
+            content: MessageContent::Text("msg2".into()),
+        });
+        assert!(m.matches(&req));
+    }
+
+    #[test]
+    fn all_conditions_and_combined() {
+        let cond = TierMatchCondition {
+            keywords: vec!["unsafe".into()],
+            file_patterns: vec!["*.rs".into()],
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, cond).unwrap();
+        // Both match
+        assert!(m.matches(&request_with_text("use unsafe in main.rs", 4096)));
+        // Only keywords match, file_patterns don't
+        assert!(!m.matches(&request_with_text("use unsafe in main.py", 4096)));
+        // Only file_patterns match, keywords don't
+        assert!(!m.matches(&request_with_text("edit main.rs safely", 4096)));
+    }
+
+    #[test]
+    fn empty_condition_matches_everything() {
+        let m =
+            CompiledTierMatch::new(ComplexityTier::Trivial, TierMatchCondition::default()).unwrap();
+        assert!(m.matches(&request_with_text("anything", 4096)));
+    }
+
+    #[test]
+    fn first_match_wins_declaration_order() {
+        let m1 =
+            CompiledTierMatch::new(ComplexityTier::Complex, condition(&["unsafe"], &[])).unwrap();
+        let m2 =
+            CompiledTierMatch::new(ComplexityTier::Medium, condition(&["unsafe"], &[])).unwrap();
+        let matchers = vec![m1, m2];
+        let req = request_with_text("use unsafe here", 4096);
+        assert_eq!(
+            evaluate_tier_matches(&matchers, &req),
+            Some(ComplexityTier::Complex)
+        );
+    }
+
+    #[test]
+    fn no_matchers_returns_none() {
+        let req = request_with_text("anything", 4096);
+        assert_eq!(evaluate_tier_matches(&[], &req), None);
+    }
+
+    #[test]
+    fn extract_file_paths_basic() {
+        let paths = extract_file_paths("edit src/main.rs and infra/vpc.tf please");
+        assert!(paths.contains(&"src/main.rs"));
+        assert!(paths.contains(&"infra/vpc.tf"));
+    }
+
+    #[test]
+    fn extract_file_paths_backtick_delimited() {
+        let paths = extract_file_paths("fix `main.rs` now");
+        assert!(paths.contains(&"main.rs"));
+    }
+
+    #[test]
+    fn extract_file_paths_no_extension_excluded() {
+        let paths = extract_file_paths("hello world");
+        assert!(paths.is_empty());
+    }
+}

--- a/tests/unit/config_test.rs
+++ b/tests/unit/config_test.rs
@@ -263,6 +263,7 @@ providers = ["cheap-provider"]
             name: "complex".to_string(),
             providers: vec!["prov-a".to_string(), "prov-b".to_string()],
             fanout: true,
+            match_conditions: None,
         };
         let toml = toml::to_string(&tier).unwrap();
         assert!(toml.contains("name = \"complex\""));

--- a/tests/unit/tier_config_test.rs
+++ b/tests/unit/tier_config_test.rs
@@ -93,11 +93,13 @@ default = "my-model"
                 name: "trivial".to_string(),
                 providers: vec!["haiku-provider".to_string(), "flash-provider".to_string()],
                 fanout: false,
+                match_conditions: None,
             },
             TierConfig {
                 name: "complex".to_string(),
                 providers: vec!["opus-provider".to_string()],
                 fanout: false,
+                match_conditions: None,
             },
         ];
 
@@ -118,6 +120,7 @@ default = "my-model"
             name: "trivial".to_string(),
             providers: vec!["cheap".to_string()],
             fanout: false,
+            match_conditions: None,
         }];
 
         // Medium is not configured -- fallback to default routing
@@ -131,6 +134,7 @@ default = "my-model"
             name: "trivial".to_string(),
             providers: vec![],
             fanout: false,
+            match_conditions: None,
         }];
 
         let result = resolve_tier_providers(&tiers, &ComplexityTier::Trivial, "my-model");
@@ -146,11 +150,13 @@ default = "my-model"
                 name: "trivial".to_string(),
                 providers: vec!["a".to_string()],
                 fanout: false,
+                match_conditions: None,
             },
             TierConfig {
                 name: "complex".to_string(),
                 providers: vec!["b".to_string(), "c".to_string()],
                 fanout: true,
+                match_conditions: None,
             },
         ];
 
@@ -186,6 +192,7 @@ providers = ["cheap"]
             name: "complex".to_string(),
             providers: vec!["opus".to_string(), "sonnet".to_string()],
             fanout: false,
+            match_conditions: None,
         }];
 
         let decision = RouteDecision {


### PR DESCRIPTION
## Summary
- Add declarative `[tiers.match]` conditions to `[[tiers]]` config for tier-based routing
- Conditions are evaluated **before** the algorithmic scorer — first match wins, fallback to `classify_complexity` if none match
- Fully backward compatible: without `[tiers.match]`, behavior is identical to before

## Usage
```toml
[[tiers]]
name = "complex"
providers = ["anthropic-opus"]
[tiers.match]
keywords = ["unsafe", "lifetime", "Pin<"]
file_patterns = ["*.rs", "*.tf"]

[[tiers]]
name = "trivial"
providers = ["mercury-2"]
[tiers.match]
max_tokens_below = 500
```

## Match conditions (AND-combined, fields OR-combined)
- `keywords` — case-insensitive substring match in last user message
- `file_patterns` — glob patterns matched against file paths in message content
- `tools` — tool names that must be present in the request
- `max_tokens_above` / `max_tokens_below` — threshold comparisons
- `min_messages` — minimum message count

## Changes
- `src/cli/config.rs` — new `TierMatchCondition` struct, `match_conditions` field on `TierConfig`
- `src/router/tier_match.rs` — **new module**: `CompiledTierMatch`, `evaluate_tier_matches()`, file path extraction
- `src/router/mod.rs` — wire tier matchers into `Router` struct, `new()`, and `route()`
- `src/router/classify.rs` — make `extract_last_user_text` `pub(crate)` for reuse
- `Cargo.toml` — promote `globset` from optional to unconditional dependency
- 18 new tests + existing tests updated

## Test plan
- [x] 18 inline tests (keywords, file_patterns, tools, thresholds, AND semantics, first-match-wins, empty)
- [x] All 1152 existing tests pass (922 lib + 214 integration + 16 doc)
- [x] `cargo clippy --all-targets` clean
- [x] All pre-push hooks green (fmt, clippy, test, deny, audit, gitleaks, machete)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)