### PR TITLE
chore: release v0.36.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.16](https://github.com/azerozero/grob/compare/v0.36.15...v0.36.16) - 2026-04-14
+
+### Added
+
+- *(router)* ajouter le match declaratif [tiers.match] pour le routing par complexite
+
+### Other
+
+- migrate from Git Flow (develop+main) to GitHub Flow (main only) ([#198](https://github.com/azerozero/grob/pull/198))
+
 ## [0.36.15](https://github.com/azerozero/grob/compare/v0.36.14...v0.36.15) - 2026-04-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.15"
+version = "0.36.16"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.15"
+version = "0.36.16"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.15 -> 0.36.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.16](https://github.com/azerozero/grob/compare/v0.36.15...v0.36.16) - 2026-04-14

### Added

- *(router)* ajouter le match declaratif [tiers.match] pour le routing par complexite

### Other

- migrate from Git Flow (develop+main) to GitHub Flow (main only) ([#198](https://github.com/azerozero/grob/pull/198))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).