### PR TITLE
feat(tracing): chiffrer les traces JSONL avec AES-256-GCM + grob logs decrypt

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -37,6 +37,7 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "init",
     "key",
     "launch", // alias of exec
+    "logs",
     "model",
     "preset",
     "restart",
@@ -227,6 +228,12 @@ pub enum Commands {
         #[command(subcommand)]
         action: KeyAction,
     },
+    /// Manage trace logs (decrypt encrypted traces)
+    Logs {
+        /// Logs subcommand
+        #[command(subcommand)]
+        action: LogsAction,
+    },
     /// Restore previous configuration from backup
     Rollback,
     /// Run performance benchmark on the current system
@@ -302,6 +309,20 @@ pub enum HarnessAction {
         /// Maximum duration in seconds (0 = no limit)
         #[arg(long, default_value = "0")]
         duration: u64,
+    },
+}
+
+/// Subcommands for trace log management.
+#[derive(Subcommand)]
+pub enum LogsAction {
+    /// Decrypt and display encrypted trace entries
+    Decrypt {
+        /// Path to trace file (default: ~/.grob/trace.jsonl)
+        #[arg(short, long)]
+        path: Option<std::path::PathBuf>,
+        /// Write decrypted output to file instead of stdout
+        #[arg(short, long)]
+        output: Option<std::path::PathBuf>,
     },
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -426,6 +426,9 @@ pub struct TracingConfig {
     /// Compress rotated files with zstd (default: false)
     #[serde(default)]
     pub compress: bool,
+    /// Encrypt trace entries with AES-256-GCM at rest (default: false)
+    #[serde(default)]
+    pub encrypt: bool,
 }
 
 impl Default for TracingConfig {
@@ -437,6 +440,7 @@ impl Default for TracingConfig {
             max_size_mb: default_max_size_mb(),
             max_files: default_max_files(),
             compress: false,
+            encrypt: false,
         }
     }
 }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -1,0 +1,84 @@
+//! Trace log management commands.
+
+use anyhow::{Context, Result};
+use base64::Engine;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+/// Decrypts and displays encrypted trace entries.
+pub fn cmd_logs_decrypt(path: Option<PathBuf>, output: Option<PathBuf>) -> Result<()> {
+    let trace_path = path.unwrap_or_else(|| {
+        let default = crate::storage::GrobStore::default_path();
+        default
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .join("trace.jsonl")
+    });
+
+    if !trace_path.exists() {
+        anyhow::bail!("Trace file not found: {}", trace_path.display());
+    }
+
+    let cipher = crate::storage::encrypt::StorageCipher::load_or_generate(
+        &crate::storage::GrobStore::default_path(),
+    )
+    .context("Failed to load encryption key")?;
+
+    let reader: Box<dyn BufRead> = if trace_path.extension().is_some_and(|ext| ext == "zst") {
+        let file = std::fs::File::open(&trace_path)
+            .with_context(|| format!("Failed to open: {}", trace_path.display()))?;
+        let decoder = zstd::Decoder::new(file).context("Failed to initialize zstd decoder")?;
+        Box::new(BufReader::new(decoder))
+    } else {
+        let file = std::fs::File::open(&trace_path)
+            .with_context(|| format!("Failed to open: {}", trace_path.display()))?;
+        Box::new(BufReader::new(file))
+    };
+
+    let mut writer: Box<dyn Write> = if let Some(ref out_path) = output {
+        Box::new(
+            std::fs::File::create(out_path)
+                .with_context(|| format!("Failed to create: {}", out_path.display()))?,
+        )
+    } else {
+        Box::new(std::io::stdout().lock())
+    };
+
+    let b64 = base64::engine::general_purpose::STANDARD;
+    let mut decrypted_count = 0u64;
+    let mut plaintext_count = 0u64;
+
+    for line_result in reader.lines() {
+        let line = line_result.context("Failed to read line")?;
+        if line.is_empty() {
+            continue;
+        }
+
+        let decrypted = if let Ok(bytes) = b64.decode(&line) {
+            match cipher.decrypt(&bytes) {
+                Ok(plain) => {
+                    decrypted_count += 1;
+                    String::from_utf8(plain).unwrap_or_else(|_| line.clone())
+                }
+                Err(_) => {
+                    plaintext_count += 1;
+                    line
+                }
+            }
+        } else {
+            plaintext_count += 1;
+            line
+        };
+
+        writeln!(writer, "{decrypted}").context("Failed to write output")?;
+    }
+
+    if output.is_some() {
+        eprintln!(
+            "Decrypted {decrypted_count} entries, {plaintext_count} plaintext (total {})",
+            decrypted_count + plaintext_count
+        );
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -29,6 +29,8 @@ pub mod harness;
 pub mod init;
 /// Virtual API key management (create, list, revoke).
 pub mod key;
+/// Trace log management (decrypt encrypted traces).
+pub mod logs;
 /// Lists, inspects, and manages available LLM models.
 pub mod model;
 /// Manages named configuration presets (save, load, delete).

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,9 @@ use std::path::PathBuf;
 use tracing_subscriber::EnvFilter;
 
 use grob::cli;
-use grob::cli::args::{detect_bare_trailing_cmd, Cli, Commands, KeyAction, PresetAction};
+use grob::cli::args::{
+    detect_bare_trailing_cmd, Cli, Commands, KeyAction, LogsAction, PresetAction,
+};
 use grob::commands;
 
 #[tokio::main]
@@ -198,6 +200,11 @@ async fn main() -> anyhow::Result<()> {
         Commands::Setup { .. } => {
             // Already handled above; if we reach here, wizard already ran.
         }
+        Commands::Logs { action } => match action {
+            LogsAction::Decrypt { path, output } => {
+                commands::logs::cmd_logs_decrypt(path, output)?;
+            }
+        },
         Commands::Key { action } => match action {
             KeyAction::Create {
                 name,

--- a/src/message_tracing/mod.rs
+++ b/src/message_tracing/mod.rs
@@ -1,7 +1,7 @@
 //! Message tracing for debugging
 //!
-//! Logs full request/response messages to a JSONL file with size-based rotation
-//! and optional zstd compression of rotated files.
+//! Logs full request/response messages to a JSONL file with size-based rotation,
+//! optional zstd compression of rotated files, and optional AES-256-GCM encryption.
 
 use crate::cli::TracingConfig;
 use crate::models::{CanonicalRequest, RouteType};
@@ -20,6 +20,7 @@ pub struct MessageTracer {
     /// Expanded absolute path to the trace file.
     trace_path: PathBuf,
     file: Option<Mutex<File>>,
+    cipher: Option<crate::storage::encrypt::StorageCipher>,
 }
 
 /// A trace entry for a request
@@ -68,8 +69,26 @@ impl MessageTracer {
                 config,
                 trace_path,
                 file: None,
+                cipher: None,
             };
         }
+
+        let cipher = if config.encrypt {
+            match crate::storage::encrypt::StorageCipher::load_or_generate(
+                &crate::storage::GrobStore::default_path(),
+            ) {
+                Ok(c) => {
+                    tracing::info!("Trace encryption enabled (AES-256-GCM)");
+                    Some(c)
+                }
+                Err(e) => {
+                    tracing::error!("Failed to initialize trace encryption: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
         // Ensure parent directory exists
         if let Some(parent) = trace_path.parent() {
@@ -79,6 +98,7 @@ impl MessageTracer {
                     config,
                     trace_path,
                     file: None,
+                    cipher: None,
                 };
             }
         }
@@ -91,6 +111,7 @@ impl MessageTracer {
                     config,
                     trace_path,
                     file: Some(Mutex::new(file)),
+                    cipher,
                 }
             }
             Err(e) => {
@@ -99,6 +120,7 @@ impl MessageTracer {
                     config,
                     trace_path,
                     file: None,
+                    cipher: None,
                 }
             }
         }
@@ -211,7 +233,21 @@ impl MessageTracer {
             }
         }
 
-        let _ = writeln!(file, "{}", json);
+        let line = if let Some(ref cipher) = self.cipher {
+            match cipher.encrypt(json.as_bytes()) {
+                Ok(encrypted) => {
+                    use base64::Engine;
+                    base64::engine::general_purpose::STANDARD.encode(&encrypted)
+                }
+                Err(e) => {
+                    tracing::error!("Trace encryption failed: {e}");
+                    return;
+                }
+            }
+        } else {
+            json
+        };
+        let _ = writeln!(file, "{}", line);
     }
 }
 
@@ -350,6 +386,7 @@ mod tests {
             max_size_mb,
             max_files,
             compress,
+            encrypt: false,
         }
     }
 


### PR DESCRIPTION
## Summary
- Optional AES-256-GCM encryption of trace JSONL entries at rest (per-line, crash-safe)
- New `grob logs decrypt` CLI command to read encrypted traces (supports `.zst` compressed files)
- Migration-safe: plaintext lines pass through unchanged

## Config
```toml
[server.tracing]
enabled = true
compress = true
encrypt = true
```

## CLI
```bash
grob logs decrypt                          # decrypt to stdout
grob logs decrypt -p trace.1.jsonl.zst     # zstd compressed file
grob logs decrypt -o decrypted.jsonl       # to file
```

## Changes
- `src/cli/config.rs` — add `encrypt: bool` to `TracingConfig`
- `src/message_tracing/mod.rs` — add optional `StorageCipher`, encrypt each JSONL line as base64
- `src/cli/args.rs` — add `Logs` command with `Decrypt` subcommand
- `src/commands/logs.rs` — **new**: decrypt command implementation
- `src/commands/mod.rs` + `src/main.rs` — wiring

## Test plan
- [x] All 1154 tests pass
- [x] clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)