### PR TITLE
fix(ci): paths-ignore sur CodeQL pour casser la boucle rebase docs PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,30 @@ name: "CodeQL Security Analysis"
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "profiles/**"
+      - "LICENSE*"
+      - ".editorconfig"
+      - ".gitignore"
+      - ".gitattributes"
+      - "**.txt"
+      - "CODEOWNERS"
+      - ".vscode/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "profiles/**"
+      - "LICENSE*"
+      - ".editorconfig"
+      - ".gitignore"
+      - ".gitattributes"
+      - "**.txt"
+      - "CODEOWNERS"
+      - ".vscode/**"
   schedule:
     # Weekly scan (Mondays 06:00 UTC)
     - cron: "0 6 * * 1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
Add `paths-ignore` to CodeQL workflow to prevent 15-minute analysis runs on docs-only PRs.

## Root cause (tangle audit)
Cross-workflow temporal cycle: docs PR rebase → CodeQL starts (15min) → feature merges during → release-plz creates new commit → docs PR BEHIND → rebase → CodeQL restarts → infinite loop.

## Fix
`paths-ignore` on `push` and `pull_request` triggers in `codeql.yml` for docs, markdown, profiles, and non-code files. CodeQL only analyzes compiled Rust — scanning markdown is pointless.

CodeQL is NOT a required status check in the main ruleset, so no shim needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)