### PR TITLE
feat(router): ajouter min_input_tokens au match declaratif des tiers

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -854,6 +854,9 @@ pub struct TierMatchCondition {
     /// Activates when message count `>= this` value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_messages: Option<usize>,
+    /// Activates when estimated input tokens `>= this` value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_input_tokens: Option<u32>,
 }
 
 /// Declarative tier configuration mapping complexity tiers to provider lists.

--- a/src/router/classify.rs
+++ b/src/router/classify.rs
@@ -159,7 +159,7 @@ fn score_context_size(request: &CanonicalRequest) -> f32 {
 
 /// Converts character count to estimated token count.
 #[inline]
-fn estimate_tokens_from_chars(chars: usize) -> usize {
+pub(crate) fn estimate_tokens_from_chars(chars: usize) -> usize {
     chars / 4
 }
 

--- a/src/router/tier_match.rs
+++ b/src/router/tier_match.rs
@@ -62,6 +62,24 @@ impl CompiledTierMatch {
                 return false;
             }
         }
+        if let Some(min_input) = self.condition.min_input_tokens {
+            let total_chars: usize = request
+                .messages
+                .iter()
+                .map(|m| match &m.content {
+                    crate::models::MessageContent::Text(t) => t.len(),
+                    crate::models::MessageContent::Blocks(blocks) => blocks
+                        .iter()
+                        .filter_map(|b| b.as_text())
+                        .map(|t| t.len())
+                        .sum(),
+                })
+                .sum();
+            let est_tokens = classify::estimate_tokens_from_chars(total_chars);
+            if est_tokens < min_input as usize {
+                return false;
+            }
+        }
         true
     }
 
@@ -325,6 +343,28 @@ mod tests {
     fn no_matchers_returns_none() {
         let req = request_with_text("anything", 4096);
         assert_eq!(evaluate_tier_matches(&[], &req), None);
+    }
+
+    #[test]
+    fn min_input_tokens_match() {
+        let cond = TierMatchCondition {
+            min_input_tokens: Some(100),
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, cond).unwrap();
+        // 500 chars ≈ 125 tokens (chars/4)
+        let long_text = "a".repeat(500);
+        assert!(m.matches(&request_with_text(&long_text, 4096)));
+    }
+
+    #[test]
+    fn min_input_tokens_no_match() {
+        let cond = TierMatchCondition {
+            min_input_tokens: Some(1000),
+            ..Default::default()
+        };
+        let m = CompiledTierMatch::new(ComplexityTier::Complex, cond).unwrap();
+        assert!(!m.matches(&request_with_text("short message", 4096)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add `min_input_tokens` to `[tiers.match]` for automatic context-size-based routing.

```toml
[[tiers]]
name = "complex"
providers = ["anthropic", "minimax"]
[tiers.match]
min_input_tokens = 100000
```

Routes large-context requests to providers that support them (Anthropic 200K, MiniMax 1M), preventing failures on providers with smaller context windows (Mercury 32K, Groq 128K).

- 2 new tests, 20 total tier_match tests pass
- clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)