### PR TITLE
chore: release v0.36.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.19](https://github.com/azerozero/grob/compare/v0.36.18...v0.36.19) - 2026-04-15
+
+### Fixed
+
+- *(deps)* mettre a jour rustls-webpki 0.103.11 → 0.103.12
+- *(ci)* ajouter paths-ignore a CodeQL pour eviter la boucle de rebase docs PRs
+
 ## [0.36.18](https://github.com/azerozero/grob/compare/v0.36.17...v0.36.18) - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.18"
+version = "0.36.19"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.18"
+version = "0.36.19"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.18 -> 0.36.19

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.19](https://github.com/azerozero/grob/compare/v0.36.18...v0.36.19) - 2026-04-15

### Fixed

- *(deps)* mettre a jour rustls-webpki 0.103.11 → 0.103.12
- *(ci)* ajouter paths-ignore a CodeQL pour eviter la boucle de rebase docs PRs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).