### PR TITLE
fix(router): auto-mapping visible + workflow auto-update-branch

### DIFF
--- a/.github/workflows/auto-update-branch.yml
+++ b/.github/workflows/auto-update-branch.yml
@@ -16,9 +16,9 @@ jobs:
         run: |
           gh pr list --base main --state open --json number,autoMergeRequest,mergeStateStatus \
             --jq '.[] | select(.autoMergeRequest != null) | select(.mergeStateStatus=="BEHIND") | .number' \
-            | while read pr; do
-                echo "Updating PR #$pr"
-                gh pr update-branch $pr || echo "Skip PR #$pr"
+            | while read -r pr; do
+                echo "Updating PR #${pr}"
+                gh pr update-branch "${pr}" || echo "Skip PR #${pr}"
               done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-update-branch.yml
+++ b/.github/workflows/auto-update-branch.yml
@@ -1,0 +1,24 @@
+name: Auto-update PR branches on main push
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update BEHIND PRs with auto-merge
+        run: |
+          gh pr list --base main --state open --json number,autoMergeRequest,mergeStateStatus \
+            --jq '.[] | select(.autoMergeRequest != null) | select(.mergeStateStatus=="BEHIND") | .number' \
+            | while read pr; do
+                echo "Updating PR #$pr"
+                gh pr update-branch $pr || echo "Skip PR #$pr"
+              done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -290,8 +290,8 @@ impl Router {
         // 3. Auto-mapping (model name transformation, after background check)
         if let Some(ref mapper) = self.auto_mapper {
             if mapper.is_match(&request.model) {
-                debug!(
-                    "🔀 Auto-mapped model '{}' → '{}'",
+                info!(
+                    "Auto-mapped model '{}' → '{}'",
                     request.model, self.config.router.default
                 );
                 request.model.clone_from(&self.config.router.default);


### PR DESCRIPTION
## Summary

- **B-06** : `src/router/mod.rs` — auto-mapping passe de `debug!` à `info!` pour tracer quand un `claude-*` model est rewrit en `router.default`
- **B-07** : `.github/workflows/auto-update-branch.yml` — auto-update des PRs en retard sur main (fix du workflow GitHub auto-merge bloqué sur BEHIND)

## Test plan
- [x] `cargo clippy` passe
- [ ] CI tourne
- [ ] Vérifier log INFO auto-mapping visible dans les grob traces

Part of sprint grob-s5. Commits du commis-2 (brigade cuisine pattern).