### PR TITLE
chore: release v0.36.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.20](https://github.com/azerozero/grob/compare/v0.36.19...v0.36.20) - 2026-04-18
+
+### Fixed
+
+- *(routing)* resoudre actual_model via [[models]] dans branche tiers
+
+### Other
+
+- *(adr)* proposer 0018 nature-inspired routing
+
 ## [0.36.19](https://github.com/azerozero/grob/compare/v0.36.18...v0.36.19) - 2026-04-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.19"
+version = "0.36.20"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.19"
+version = "0.36.20"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.19 -> 0.36.20

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.20](https://github.com/azerozero/grob/compare/v0.36.19...v0.36.20) - 2026-04-18

### Fixed

- *(routing)* resoudre actual_model via [[models]] dans branche tiers

### Other

- *(adr)* proposer 0018 nature-inspired routing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).