### PR TITLE
feat(auth): OAuth reauth + token rotation (B-08)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-test",
+ "tokio-util",
  "toml 0.8.23",
  "tower 0.5.3",
  "tower-http",
@@ -5300,6 +5301,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ axum = "0.7"
 
 # Async Runtime
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 futures = "0.3"
 
 # Serialization

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -6,6 +6,8 @@ pub mod auto_flow;
 pub mod jwt;
 /// OAuth PKCE flows for Anthropic, OpenAI, and Gemini.
 pub mod oauth;
+/// Background daemon that proactively refreshes OAuth tokens.
+pub mod refresh_daemon;
 /// Persistent token storage for OAuth credentials.
 pub mod token_store;
 /// Virtual API key management for multi-tenant access control.

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -332,6 +332,7 @@ impl OAuthClient {
             expires_at,
             enterprise_url: None,
             project_id: None,
+            needs_reauth: None,
         };
 
         self.token_store.save(token.clone())?;
@@ -427,6 +428,7 @@ impl OAuthClient {
             expires_at,
             enterprise_url: existing_token.enterprise_url,
             project_id: existing_token.project_id,
+            needs_reauth: None,
         };
 
         self.token_store.save(token.clone())?;

--- a/src/auth/refresh_daemon.rs
+++ b/src/auth/refresh_daemon.rs
@@ -1,0 +1,273 @@
+//! Background daemon that proactively refreshes OAuth tokens before they expire.
+//!
+//! Wakes every [`DEFAULT_TICK_INTERVAL`] and, for each token in the
+//! [`TokenStore`], triggers a refresh if the token expires within
+//! [`DEFAULT_REFRESH_WINDOW`]. On refresh failure (e.g. revoked
+//! `refresh_token`), the token is marked as needing manual re-authentication.
+//!
+//! The daemon listens on a [`CancellationToken`] for graceful shutdown.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+use crate::auth::oauth::{OAuthClient, OAuthConfig};
+use crate::auth::token_store::{OAuthToken, TokenStore};
+
+/// Default interval between proactive refresh sweeps.
+pub const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Default window ahead of `expires_at` at which a token is eligible for refresh.
+pub const DEFAULT_REFRESH_WINDOW: chrono::Duration = chrono::Duration::minutes(15);
+
+/// Maps an `oauth_provider_id` to the corresponding [`OAuthConfig`] factory.
+///
+/// Kept in sync with [`crate::auth::auto_flow`] mappings.
+fn config_for_provider_id(provider_id: &str) -> Option<OAuthConfig> {
+    match provider_id {
+        "anthropic-max" | "claude-max" | "anthropic-oauth" => Some(OAuthConfig::anthropic()),
+        "openai-codex" => Some(OAuthConfig::openai_codex()),
+        "gemini" => Some(OAuthConfig::gemini()),
+        _ => None,
+    }
+}
+
+/// Returns `true` when `now + window >= expires_at`.
+///
+/// Pure function extracted for unit testing.
+pub(crate) fn should_refresh(
+    token: &OAuthToken,
+    now: DateTime<Utc>,
+    window: chrono::Duration,
+) -> bool {
+    if token.needs_reauth.unwrap_or(false) {
+        return false;
+    }
+    now + window >= token.expires_at
+}
+
+/// Possible outcomes of a single-token refresh attempt.
+///
+/// Returned by [`refresh_one`] for ease of unit testing.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RefreshOutcome {
+    /// Token was not eligible (already valid or already flagged needs_reauth).
+    Skipped,
+    /// Refresh succeeded and the new token was persisted.
+    Refreshed,
+    /// Refresh failed; the token was marked `needs_reauth`.
+    MarkedNeedsReauth,
+    /// Refresh failed transiently; the token was left untouched for retry.
+    TransientFailure,
+}
+
+/// Refreshes a single token if it is eligible, updating the store accordingly.
+pub(crate) async fn refresh_one(
+    store: &TokenStore,
+    token: &OAuthToken,
+    now: DateTime<Utc>,
+    window: chrono::Duration,
+) -> RefreshOutcome {
+    if !should_refresh(token, now, window) {
+        return RefreshOutcome::Skipped;
+    }
+
+    let Some(config) = config_for_provider_id(&token.provider_id) else {
+        debug!(
+            provider = %token.provider_id,
+            "refresh daemon: no OAuthConfig mapping — skipping"
+        );
+        return RefreshOutcome::Skipped;
+    };
+
+    let client = OAuthClient::new(config, store.clone());
+    match client.refresh_token(&token.provider_id).await {
+        Ok(_) => {
+            info!(
+                provider = %token.provider_id,
+                "OAuth token refreshed proactively"
+            );
+            RefreshOutcome::Refreshed
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            // Terminal failures: the refresh_token itself was rejected.
+            // 401/invalid_grant/invalid_token are all treated as permanent.
+            let terminal = msg.contains("401")
+                || msg.contains("invalid_grant")
+                || msg.contains("invalid_token")
+                || msg.contains("unauthorized_client");
+            if terminal {
+                warn!(
+                    provider = %token.provider_id,
+                    error = %msg,
+                    "OAuth refresh failed permanently — marking token as needing re-authentication. Run: grob connect --force-reauth"
+                );
+                if let Err(store_err) = store.mark_needs_reauth(&token.provider_id) {
+                    error!(
+                        provider = %token.provider_id,
+                        error = %store_err,
+                        "Failed to mark token as needs_reauth"
+                    );
+                }
+                RefreshOutcome::MarkedNeedsReauth
+            } else {
+                warn!(
+                    provider = %token.provider_id,
+                    error = %msg,
+                    "OAuth refresh failed transiently — will retry next tick"
+                );
+                RefreshOutcome::TransientFailure
+            }
+        }
+    }
+}
+
+/// Spawns the refresh daemon as a tokio task.
+///
+/// Returns a [`CancellationToken`] handle that, when cancelled, causes the
+/// daemon to terminate at the next tick boundary.
+pub fn spawn(store: TokenStore) -> CancellationToken {
+    spawn_with_config(store, DEFAULT_TICK_INTERVAL, DEFAULT_REFRESH_WINDOW)
+}
+
+/// Spawns the refresh daemon with a custom tick interval and refresh window.
+///
+/// Primarily useful for tests that need to drive refresh activity faster than
+/// the production defaults allow.
+pub fn spawn_with_config(
+    store: TokenStore,
+    tick: Duration,
+    window: chrono::Duration,
+) -> CancellationToken {
+    let cancel = CancellationToken::new();
+    let cancel_child = cancel.clone();
+    tokio::spawn(async move {
+        info!(
+            tick_secs = tick.as_secs(),
+            window_secs = window.num_seconds(),
+            "OAuth refresh daemon started"
+        );
+        loop {
+            tokio::select! {
+                _ = cancel_child.cancelled() => {
+                    info!("OAuth refresh daemon shutting down");
+                    break;
+                }
+                _ = tokio::time::sleep(tick) => {
+                    run_tick(&store, window).await;
+                }
+            }
+        }
+    });
+    cancel
+}
+
+/// Runs a single refresh sweep over all tokens in the store.
+pub(crate) async fn run_tick(store: &TokenStore, window: chrono::Duration) {
+    let now = Utc::now();
+    let tokens = store.all();
+    for (_id, token) in tokens {
+        let _ = refresh_one(store, &token, now, window).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::SecretString;
+
+    fn make_token(expires_in_minutes: i64, needs_reauth: Option<bool>) -> OAuthToken {
+        OAuthToken {
+            provider_id: "anthropic-max".to_string(),
+            access_token: SecretString::new("access".into()),
+            refresh_token: SecretString::new("refresh".into()),
+            expires_at: Utc::now() + chrono::Duration::minutes(expires_in_minutes),
+            enterprise_url: None,
+            project_id: None,
+            needs_reauth,
+        }
+    }
+
+    #[test]
+    fn should_refresh_triggers_when_within_window() {
+        let token = make_token(10, None);
+        assert!(should_refresh(
+            &token,
+            Utc::now(),
+            chrono::Duration::minutes(15)
+        ));
+    }
+
+    #[test]
+    fn should_refresh_skips_when_outside_window() {
+        let token = make_token(30, None);
+        assert!(!should_refresh(
+            &token,
+            Utc::now(),
+            chrono::Duration::minutes(15)
+        ));
+    }
+
+    #[test]
+    fn should_refresh_skips_when_needs_reauth_flagged() {
+        let token = make_token(1, Some(true));
+        assert!(!should_refresh(
+            &token,
+            Utc::now(),
+            chrono::Duration::minutes(15)
+        ));
+    }
+
+    #[test]
+    fn should_refresh_triggers_when_already_expired() {
+        let token = make_token(-1, None);
+        assert!(should_refresh(
+            &token,
+            Utc::now(),
+            chrono::Duration::minutes(15)
+        ));
+    }
+
+    #[tokio::test]
+    async fn refresh_one_skips_when_outside_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStore::new(dir.path().join("tokens.json")).unwrap();
+        let token = make_token(30, None);
+        store.save(token.clone()).unwrap();
+
+        let outcome = refresh_one(&store, &token, Utc::now(), chrono::Duration::minutes(15)).await;
+        assert_eq!(outcome, RefreshOutcome::Skipped);
+    }
+
+    #[tokio::test]
+    async fn refresh_one_skips_unknown_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStore::new(dir.path().join("tokens.json")).unwrap();
+        let mut token = make_token(5, None);
+        token.provider_id = "unknown-provider".into();
+        store.save(token.clone()).unwrap();
+
+        let outcome = refresh_one(&store, &token, Utc::now(), chrono::Duration::minutes(15)).await;
+        assert_eq!(outcome, RefreshOutcome::Skipped);
+    }
+
+    #[tokio::test]
+    async fn spawn_with_config_runs_and_shuts_down_on_cancel() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TokenStore::new(dir.path().join("tokens.json")).unwrap();
+
+        let cancel = spawn_with_config(
+            store,
+            Duration::from_millis(10),
+            chrono::Duration::minutes(15),
+        );
+        // Let a few ticks run.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        cancel.cancel();
+        // Give the task a moment to notice cancellation.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}

--- a/src/auth/token_store.rs
+++ b/src/auth/token_store.rs
@@ -74,6 +74,12 @@ pub struct OAuthToken {
     /// Optional Google Cloud project ID for Gemini Code Assist API
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_id: Option<String>,
+    /// Marks the token as needing manual re-authentication (e.g. after a refresh 401).
+    ///
+    /// Optional with `#[serde(default)]` for backward compatibility with tokens
+    /// persisted before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub needs_reauth: Option<bool>,
 }
 
 impl OAuthToken {
@@ -201,6 +207,34 @@ impl TokenStore {
     pub fn get(&self, provider_id: &str) -> Option<OAuthToken> {
         let tokens = self.tokens.read().unwrap_or_else(|e| e.into_inner());
         tokens.get(provider_id).cloned()
+    }
+
+    /// Marks the token for `provider_id` as needing manual re-authentication.
+    ///
+    /// Called after a refresh-token failure (401) so the operator can be
+    /// prompted to run `grob connect --force-reauth`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if re-saving the updated token fails.
+    pub fn mark_needs_reauth(&self, provider_id: &str) -> Result<bool> {
+        let updated = {
+            let tokens = self.tokens.read().unwrap_or_else(|e| e.into_inner());
+            match tokens.get(provider_id) {
+                Some(t) => {
+                    let mut cloned = t.clone();
+                    cloned.needs_reauth = Some(true);
+                    Some(cloned)
+                }
+                None => None,
+            }
+        };
+        if let Some(token) = updated {
+            self.save(token)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     /// Removes a token for a provider.
@@ -465,6 +499,7 @@ mod tests {
             expires_at: Utc::now() + chrono::Duration::hours(1),
             enterprise_url: None,
             project_id: None,
+            needs_reauth: None,
         };
 
         store.save(token.clone()).unwrap();
@@ -486,6 +521,7 @@ mod tests {
             expires_at: Utc::now() - chrono::Duration::hours(1),
             enterprise_url: None,
             project_id: None,
+            needs_reauth: None,
         };
 
         assert!(expired_token.is_expired());
@@ -498,6 +534,7 @@ mod tests {
             expires_at: Utc::now() + chrono::Duration::hours(1),
             enterprise_url: None,
             project_id: None,
+            needs_reauth: None,
         };
 
         assert!(!valid_token.is_expired());

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -199,6 +199,11 @@ pub enum Commands {
     Connect {
         /// Specific provider name to configure (all if omitted)
         provider: Option<String>,
+        /// Force re-authentication: discards existing OAuth tokens and initiates a fresh OAuth flow.
+        ///
+        /// Use when 'grob connect' reports a revoked token.
+        #[arg(long)]
+        force_reauth: bool,
     },
     /// Initialize a per-project .grob.toml in the current directory
     Init,

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -1,10 +1,14 @@
 use crate::{cli, preset};
 
 /// Launches interactive credential setup for one or all providers.
-pub fn cmd_connect(
+///
+/// When `force_reauth` is set, any existing OAuth tokens for the targeted
+/// provider(s) are deleted and a fresh PKCE flow is initiated.
+pub async fn cmd_connect(
     config: &cli::AppConfig,
     config_source: &cli::ConfigSource,
     provider: Option<String>,
+    force_reauth: bool,
 ) -> anyhow::Result<()> {
     let file_path = match config_source {
         cli::ConfigSource::File(p) => p.clone(),
@@ -29,6 +33,13 @@ pub fn cmd_connect(
             );
             return Ok(());
         }
+    }
+
+    if force_reauth {
+        return force_reauth_flow(config, provider.as_deref()).await;
+    }
+
+    if let Some(ref provider_name) = provider {
         println!("🔑 Setting up credentials for '{}'...", provider_name);
         if let Err(e) =
             preset::setup_credentials_interactive_filtered(&file_path, Some(provider_name))
@@ -42,4 +53,145 @@ pub fn cmd_connect(
         }
     }
     Ok(())
+}
+
+/// Deletes existing OAuth tokens for `provider` (all OAuth providers if
+/// `None`), then triggers a fresh interactive OAuth flow.
+async fn force_reauth_flow(config: &cli::AppConfig, provider: Option<&str>) -> anyhow::Result<()> {
+    use crate::auth::auto_flow::{detect_credentials, run_interactive_flow, CredentialStatus};
+    use crate::auth::TokenStore;
+    use crate::providers::AuthType;
+    use crate::storage::GrobStore;
+    use std::sync::Arc;
+
+    println!("🔁 Force re-authentication flow");
+
+    let grob_store = Arc::new(
+        GrobStore::open(&GrobStore::default_path())
+            .map_err(|e| anyhow::anyhow!("Failed to initialize credential storage: {}", e))?,
+    );
+
+    #[cfg(feature = "oauth")]
+    let token_store = TokenStore::with_store(grob_store.clone())
+        .map_err(|e| anyhow::anyhow!("Failed to initialize token store: {}", e))?;
+    #[cfg(not(feature = "oauth"))]
+    let token_store = {
+        let _ = &grob_store;
+        TokenStore::new_empty()
+    };
+
+    // Step 1: Drop existing tokens for targeted OAuth providers.
+    let mut removed = 0usize;
+    for p in &config.providers {
+        if p.enabled == Some(false) {
+            continue;
+        }
+        if p.auth_type != AuthType::OAuth {
+            continue;
+        }
+        if let Some(filter) = provider {
+            if p.name != filter {
+                continue;
+            }
+        }
+        if let Some(ref oauth_id) = p.oauth_provider {
+            if token_store.get(oauth_id).is_some() {
+                match token_store.remove(oauth_id) {
+                    Ok(_) => {
+                        println!("  🗑  Deleted OAuth token for {} ({})", p.name, oauth_id);
+                        removed += 1;
+                    }
+                    Err(e) => {
+                        eprintln!("  ⚠  Failed to delete token for {}: {}", p.name, e);
+                    }
+                }
+            }
+        }
+    }
+
+    if removed == 0 {
+        println!("  (no existing OAuth tokens found for the requested scope)");
+    }
+
+    // Step 2: Re-detect and run the interactive flow, which will now find the
+    // token missing and walk the user through the PKCE flow from scratch.
+    let statuses = detect_credentials(&config.providers, &token_store);
+    let filtered: Vec<CredentialStatus> = if let Some(filter) = provider {
+        statuses
+            .into_iter()
+            .filter(|s| match s {
+                CredentialStatus::MissingOAuth { provider_name, .. }
+                | CredentialStatus::MissingApiKey { provider_name, .. } => provider_name == filter,
+                CredentialStatus::Ready => false,
+            })
+            .collect()
+    } else {
+        statuses
+    };
+
+    if filtered.is_empty() {
+        println!("  Nothing to re-authenticate (no OAuth providers configured).");
+        return Ok(());
+    }
+
+    run_interactive_flow(filtered, &token_store).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth::token_store::{OAuthToken, TokenStore};
+    use chrono::Utc;
+    use secrecy::SecretString;
+    use tempfile::TempDir;
+
+    fn make_token(provider_id: &str) -> OAuthToken {
+        OAuthToken {
+            provider_id: provider_id.to_string(),
+            access_token: SecretString::new("access".into()),
+            refresh_token: SecretString::new("refresh".into()),
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            enterprise_url: None,
+            project_id: None,
+            needs_reauth: None,
+        }
+    }
+
+    #[test]
+    fn force_reauth_removes_existing_token() {
+        // Simulates the token-deletion half of the force-reauth flow without
+        // invoking the interactive OAuth handshake (which requires a browser).
+        let dir = TempDir::new().unwrap();
+        let store = TokenStore::new(dir.path().join("tokens.json")).unwrap();
+        store.save(make_token("anthropic-max")).unwrap();
+        assert!(store.get("anthropic-max").is_some());
+
+        store.remove("anthropic-max").unwrap();
+
+        assert!(store.get("anthropic-max").is_none());
+    }
+
+    #[test]
+    fn force_reauth_filters_to_single_provider() {
+        // A --force-reauth targeted at one provider must not touch others.
+        let dir = TempDir::new().unwrap();
+        let store = TokenStore::new(dir.path().join("tokens.json")).unwrap();
+        store.save(make_token("anthropic-max")).unwrap();
+        store.save(make_token("openai-codex")).unwrap();
+
+        // Remove only the filtered provider.
+        store.remove("anthropic-max").unwrap();
+
+        assert!(store.get("anthropic-max").is_none());
+        assert!(store.get("openai-codex").is_some());
+    }
+
+    #[test]
+    fn force_reauth_is_idempotent_when_no_token() {
+        let dir = TempDir::new().unwrap();
+        let store = TokenStore::new(dir.path().join("tokens.json")).unwrap();
+        // No token stored — removing a non-existent token must not error.
+        store.remove("anthropic-max").unwrap();
+        assert!(store.get("anthropic-max").is_none());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,8 +190,11 @@ async fn main() -> anyhow::Result<()> {
         Commands::Completions { shell } => commands::completions::cmd_completions::<Cli>(shell),
         Commands::SetupCompletions => commands::setup_completions::cmd_setup_completions::<Cli>()?,
         Commands::Env => commands::env::cmd_env(&config),
-        Commands::Connect { provider } => {
-            commands::connect::cmd_connect(&config, &config_source, provider)?;
+        Commands::Connect {
+            provider,
+            force_reauth,
+        } => {
+            commands::connect::cmd_connect(&config, &config_source, provider, force_reauth).await?;
         }
         Commands::Init => commands::init::cmd_init()?,
         Commands::ConfigDiff { target } => {

--- a/src/providers/anthropic_compatible.rs
+++ b/src/providers/anthropic_compatible.rs
@@ -186,7 +186,41 @@ impl AnthropicCompatibleProvider {
                 .unwrap_or_else(|_| "Unknown error".to_string());
 
             if status == 401 && self.base.is_oauth() {
-                tracing::warn!("🔄 Received 401, OAuth token may be invalid or expired");
+                // A 401 can mean two things:
+                //   1. `rate_limit_error` — transient, provider loop will retry.
+                //   2. `authentication_error` — terminal, OAuth token revoked.
+                // Only invalidate the token for case (2) to avoid triggering
+                // reauth loops on rate-limit spikes.
+                let lower = error_text.to_ascii_lowercase();
+                let is_auth_error =
+                    !(lower.contains("rate_limit_error") || lower.contains("\"rate_limit\""));
+                if is_auth_error {
+                    if let (Some(provider_id), Some(store)) = (
+                        self.base.oauth_provider.as_deref(),
+                        self.base.token_store.as_ref(),
+                    ) {
+                        tracing::error!(
+                            provider = %provider_id,
+                            "OAuth token for provider {} revoked. Run: grob connect --force-reauth",
+                            provider_id
+                        );
+                        if let Err(e) = store.mark_needs_reauth(provider_id) {
+                            tracing::warn!(
+                                provider = %provider_id,
+                                error = %e,
+                                "Failed to mark token as needs_reauth"
+                            );
+                        }
+                    } else {
+                        tracing::error!(
+                            "OAuth 401 but no oauth_provider/token_store attached to base"
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        "🔄 Received 401 with rate_limit payload, treating as transient"
+                    );
+                }
             }
 
             return Err(ProviderError::ApiError {

--- a/src/server/budget.rs
+++ b/src/server/budget.rs
@@ -159,12 +159,42 @@ pub(crate) async fn calculate_cost(
 }
 
 /// Check if a provider error is retryable (429, 500, 502, 503, network errors).
+///
+/// Notably excludes 401 (`authentication_error`): a revoked OAuth token is a
+/// permanent failure that requires operator action (`grob connect
+/// --force-reauth`). 401 with `rate_limit_error` payload is handled as 429.
 pub(crate) fn is_retryable(e: &crate::providers::error::ProviderError) -> bool {
     match e {
-        crate::providers::error::ProviderError::ApiError { status, .. } => {
-            matches!(status, 429 | 500 | 502 | 503)
-        }
+        crate::providers::error::ProviderError::ApiError { status, message } => match status {
+            429 | 500 | 502 | 503 => true,
+            401 => is_rate_limit_payload(message),
+            _ => false,
+        },
         crate::providers::error::ProviderError::HttpError(_) => true,
+        _ => false,
+    }
+}
+
+/// Returns `true` when a 401 payload actually carries a `rate_limit_error`.
+///
+/// Some upstreams (notably Anthropic) will return 401 with
+/// `"type": "rate_limit_error"` — that is a transient signal, not a revoked
+/// credential. Any other 401 is treated as a permanent authentication failure.
+pub(crate) fn is_rate_limit_payload(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("rate_limit_error") || lower.contains("\"rate_limit\"")
+}
+
+/// Returns `true` when a 401 response indicates a revoked or invalid OAuth token.
+///
+/// Used by the provider loop to abort fallback and surface a terminal
+/// `authentication_error` to the client.
+pub(crate) fn is_auth_revoked_error(e: &crate::providers::error::ProviderError) -> bool {
+    match e {
+        crate::providers::error::ProviderError::ApiError {
+            status: 401,
+            message,
+        } => !is_rate_limit_payload(message),
         _ => false,
     }
 }
@@ -223,6 +253,49 @@ mod tests {
             message: "unauthorized".to_string(),
         };
         assert!(!is_retryable(&err));
+    }
+
+    #[test]
+    fn test_401_with_rate_limit_payload_is_retryable() {
+        let err = crate::providers::error::ProviderError::ApiError {
+            status: 401,
+            message:
+                r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"#
+                    .to_string(),
+        };
+        assert!(is_retryable(&err));
+        assert!(!is_auth_revoked_error(&err));
+    }
+
+    #[test]
+    fn test_401_authentication_error_marks_revoked() {
+        let err = crate::providers::error::ProviderError::ApiError {
+            status: 401,
+            message: r#"{"type":"error","error":{"type":"authentication_error","message":"invalid bearer token"}}"#
+                .to_string(),
+        };
+        assert!(!is_retryable(&err));
+        assert!(is_auth_revoked_error(&err));
+    }
+
+    #[test]
+    fn test_429_is_not_auth_revoked() {
+        let err = crate::providers::error::ProviderError::ApiError {
+            status: 429,
+            message: "rate limited".to_string(),
+        };
+        assert!(is_retryable(&err));
+        assert!(!is_auth_revoked_error(&err));
+    }
+
+    #[test]
+    fn test_500_is_retryable_not_auth_revoked() {
+        let err = crate::providers::error::ProviderError::ApiError {
+            status: 500,
+            message: "internal".to_string(),
+        };
+        assert!(is_retryable(&err));
+        assert!(!is_auth_revoked_error(&err));
     }
 
     #[test]

--- a/src/server/dispatch/provider_loop.rs
+++ b/src/server/dispatch/provider_loop.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 use super::super::{
-    check_budget, format_route_type, inject_continuation_text, is_provider_subscription,
-    is_retryable, retry_delay, AppError, MAX_RETRIES,
+    check_budget, format_route_type, inject_continuation_text, is_auth_revoked_error,
+    is_provider_subscription, is_retryable, retry_delay, AppError, MAX_RETRIES,
 };
 use super::telemetry::{
     calculate_and_record_metrics, record_success_telemetry, store_response_cache,
@@ -178,6 +178,19 @@ pub(super) async fn dispatch_provider_loop(
                 );
                 tokio::task::yield_now().await;
                 continue;
+            }
+            Err(ProviderLoopAction::AuthRevoked(msg)) => {
+                tracing::error!(
+                    provider = %mapping.provider,
+                    "OAuth token for provider {} revoked. Run: grob connect --force-reauth",
+                    mapping.provider
+                );
+                // Abort the fallback cascade: this is a user-actionable error,
+                // not a transient provider failure.
+                return Err(AppError::AuthenticationError(format!(
+                    "OAuth token for provider '{}' revoked. Run: grob connect --force-reauth. Details: {}",
+                    mapping.provider, msg
+                )));
             }
         }
     }
@@ -420,6 +433,10 @@ enum ProviderLoopAction {
     /// Rate-limited (429): the caller should attempt key pool rotation
     /// before falling through to the next provider mapping.
     RateLimited,
+    /// Terminal auth failure (401 `authentication_error`): do NOT fall back
+    /// to sibling providers — surface the error directly to the client so the
+    /// user is prompted to run `grob connect --force-reauth`.
+    AuthRevoked(String),
 }
 
 /// Handle the streaming path for a single provider attempt.
@@ -466,6 +483,9 @@ async fn dispatch_streaming(
                     .trace_error(trace_id, &e.to_string());
             }
             handle_provider_error(mapping, &e);
+            if is_auth_revoked_error(&e) {
+                return Err(ProviderLoopAction::AuthRevoked(e.to_string()));
+            }
             let is_rate_limit = matches!(
                 e,
                 crate::providers::error::ProviderError::ApiError { status: 429, .. }
@@ -625,6 +645,12 @@ async fn dispatch_non_streaming(
                 });
             }
             Err(e) => {
+                // 401 authentication_error is terminal — abort the cascade.
+                if is_auth_revoked_error(&e) {
+                    ctx.record_provider_failure(&attempt.mapping.provider).await;
+                    return Err(ProviderLoopAction::AuthRevoked(e.to_string()));
+                }
+
                 if classify_and_handle_error(ctx, attempt.mapping, &e, retry) {
                     // On 429, try rotating to next pooled key before retrying.
                     let is_rate_limit = matches!(

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -17,6 +17,10 @@ pub enum AppError {
     BudgetExceeded(String),
     /// Indicates the DLP pipeline blocked the request.
     DlpBlocked(String),
+    /// Indicates an upstream OAuth token is revoked or invalid (401 authentication_error).
+    ///
+    /// Surfaced to the client as a terminal 401 without fallback to sibling providers.
+    AuthenticationError(String),
 }
 
 impl IntoResponse for AppError {
@@ -27,6 +31,9 @@ impl IntoResponse for AppError {
             AppError::ProviderError(msg) => (StatusCode::BAD_GATEWAY, "error", msg),
             AppError::BudgetExceeded(msg) => (StatusCode::PAYMENT_REQUIRED, "budget_exceeded", msg),
             AppError::DlpBlocked(msg) => (StatusCode::BAD_REQUEST, "dlp_block", msg),
+            AppError::AuthenticationError(msg) => {
+                (StatusCode::UNAUTHORIZED, "authentication_error", msg)
+            }
         };
 
         let body = Json(serde_json::json!({
@@ -48,6 +55,7 @@ impl std::fmt::Display for AppError {
             AppError::ProviderError(msg) => write!(f, "Provider error: {}", msg),
             AppError::BudgetExceeded(msg) => write!(f, "Budget exceeded: {}", msg),
             AppError::DlpBlocked(msg) => write!(f, "DLP blocked: {}", msg),
+            AppError::AuthenticationError(msg) => write!(f, "Authentication error: {}", msg),
         }
     }
 }
@@ -118,6 +126,22 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(json["error"]["type"], "dlp_block");
         assert_eq!(json["error"]["message"], "secret detected in prompt");
+    }
+
+    #[tokio::test]
+    async fn authentication_error_returns_401_with_authentication_error_type() {
+        let err = AppError::AuthenticationError(
+            "OAuth token for provider 'anthropic' revoked. Run: grob connect --force-reauth"
+                .to_string(),
+        );
+        let (status, json) = error_response_parts(err).await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(json["error"]["type"], "authentication_error");
+        assert!(json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("grob connect --force-reauth"));
     }
 
     #[test]

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -37,6 +37,10 @@ pub(crate) async fn init_core_services(
                 "🔐 Loaded {} OAuth tokens from storage",
                 existing_tokens.len()
             );
+            // NOTE: Daemon handle is leaked intentionally — it lives for the
+            // process lifetime. Graceful shutdown is driven by the tokio runtime
+            // cancelling outstanding tasks.
+            let _daemon = crate::auth::refresh_daemon::spawn(ts.clone());
         }
         ts
     };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -34,8 +34,8 @@ mod watch_sse;
 pub use audit::AuditEntryBuilder;
 pub(crate) use audit::{log_audit, AuditCompliance, AuditParams};
 pub(crate) use budget::{
-    calculate_cost, check_budget, is_provider_subscription, is_retryable, record_request_metrics,
-    record_spend, retry_delay, RequestMetrics, MAX_RETRIES,
+    calculate_cost, check_budget, is_auth_revoked_error, is_provider_subscription, is_retryable,
+    record_request_metrics, record_spend, retry_delay, RequestMetrics, MAX_RETRIES,
 };
 pub use error::AppError;
 pub(crate) use helpers::{

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -429,6 +429,7 @@ mod tests {
             expires_at: Utc::now() + chrono::Duration::hours(1),
             enterprise_url: None,
             project_id: None,
+            needs_reauth: None,
         };
 
         store.save_oauth_token(&token).unwrap();


### PR DESCRIPTION
## Summary

Fix B-08 en 3 sous-tâches : daemon tokio refresh proactif + 401 auth vs rate_limit differenciation + `grob connect --force-reauth`.

## Test plan
- [x] 939/939 tests pass (15+ nouveaux)
- [ ] CI verte

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>