### PR TITLE
feat(routing): circuit breaker passif Caddy-style (RE-1a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1878,7 @@ dependencies = [
  "age",
  "aho-corasick",
  "anyhow",
+ "arc-swap",
  "async-stream",
  "async-trait",
  "axum",
@@ -1876,6 +1891,7 @@ dependencies = [
  "criterion",
  "crossterm 0.28.1",
  "cucumber",
+ "dashmap",
  "dirs",
  "ecdsa",
  "ed25519-dalek",
@@ -1980,6 +1996,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,11 @@ aes-gcm = "0.10"
 # Glob pattern matching (tier routing + policy engine)
 globset = "0.4"
 
+# Concurrent map (routing: per-endpoint circuit breaker state)
+dashmap = "6"
+# Atomic Arc swap (routing: lock-free tripped_until timestamp)
+arc-swap = "1"
+
 # Encrypted audit export (envelope encryption, multi-recipient)
 age = { version = "0.11", features = ["armor"] }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -819,12 +819,136 @@ pub struct ProviderConfig {
     /// Multi-account key pool for chaining API keys.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pool: Option<PoolConfig>,
+
+    /// Passive circuit breaker configuration (RE-1a, ADR-0018).
+    ///
+    /// Opt-in. When absent the breaker stays disabled (Caddy defaults
+    /// `max_fails = 1`, `fail_duration = 0`). Applies to every
+    /// `(provider, model)` endpoint served by this provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub circuit_breaker: Option<CircuitBreakerProviderConfig>,
 }
 
 impl ProviderConfig {
     /// Returns `true` if the provider is enabled (defaults to `true`).
     pub fn is_enabled(&self) -> bool {
         self.enabled.unwrap_or(true)
+    }
+}
+
+/// Passive circuit breaker knobs exposed through `[providers.circuit_breaker]`.
+///
+/// Mirror of [`crate::routing::CircuitBreakerConfig`] with TOML-friendly
+/// duration strings (`"30s"`, `"500ms"`). Durations accept any suffix
+/// understood by [`parse_duration`].
+///
+/// # Examples
+///
+/// ```toml
+/// [[providers]]
+/// name = "anthropic"
+/// provider_type = "anthropic"
+///
+/// [providers.circuit_breaker]
+/// max_fails = 3
+/// fail_duration = "30s"
+/// cooldown = "60s"
+/// ```
+///
+/// [`parse_duration`]: crate::cli::config::parse_duration
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct CircuitBreakerProviderConfig {
+    /// Consecutive failures that trip the breaker. Defaults to 1 (Caddy parity).
+    #[serde(default = "default_cb_max_fails")]
+    pub max_fails: u32,
+    /// Sliding window during which failures count. `"0s"` (or omitted) disables the breaker.
+    #[serde(default)]
+    pub fail_duration: Option<String>,
+    /// Post-trip cooldown. Omit to recover as soon as `fail_duration` expires.
+    #[serde(default)]
+    pub cooldown: Option<String>,
+}
+
+fn default_cb_max_fails() -> u32 {
+    1
+}
+
+/// Parses a duration string used across provider TOML knobs.
+///
+/// Accepts `"<int|float><unit>"` where unit is one of `ms`, `s`, `m`, `h`.
+/// Bare integers are treated as seconds for convenience.
+///
+/// # Errors
+///
+/// Returns a descriptive error string when the input is unparseable.
+///
+/// # Examples
+///
+/// ```
+/// use grob::cli::parse_duration;
+/// use std::time::Duration;
+///
+/// assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+/// assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+/// assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
+/// ```
+pub fn parse_duration(input: &str) -> Result<std::time::Duration, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("empty duration".to_string());
+    }
+
+    // Suffix-aware parse.
+    let parse_number = |s: &str| -> Result<f64, String> {
+        s.parse::<f64>()
+            .map_err(|_| format!("invalid duration number '{s}'"))
+    };
+
+    if let Some(rest) = trimmed.strip_suffix("ms") {
+        let n = parse_number(rest)?;
+        return Ok(std::time::Duration::from_millis(n as u64));
+    }
+    if let Some(rest) = trimmed.strip_suffix('s') {
+        let n = parse_number(rest)?;
+        return Ok(std::time::Duration::from_secs_f64(n));
+    }
+    if let Some(rest) = trimmed.strip_suffix('m') {
+        let n = parse_number(rest)?;
+        return Ok(std::time::Duration::from_secs_f64(n * 60.0));
+    }
+    if let Some(rest) = trimmed.strip_suffix('h') {
+        let n = parse_number(rest)?;
+        return Ok(std::time::Duration::from_secs_f64(n * 3600.0));
+    }
+    // Bare integer -> seconds (lenient).
+    if let Ok(n) = trimmed.parse::<u64>() {
+        return Ok(std::time::Duration::from_secs(n));
+    }
+    Err(format!(
+        "unknown duration '{input}' (expected suffix ms|s|m|h)"
+    ))
+}
+
+impl CircuitBreakerProviderConfig {
+    /// Converts the TOML view into a runtime [`crate::routing::CircuitBreakerConfig`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any duration string fails to parse.
+    pub fn to_runtime(&self) -> Result<crate::routing::CircuitBreakerConfig, String> {
+        let fail_duration = match self.fail_duration.as_deref() {
+            None => std::time::Duration::ZERO,
+            Some(s) => parse_duration(s)?,
+        };
+        let cooldown = match self.cooldown.as_deref() {
+            None => None,
+            Some(s) => Some(parse_duration(s)?),
+        };
+        Ok(crate::routing::CircuitBreakerConfig {
+            max_fails: self.max_fails,
+            fail_duration,
+            cooldown,
+        })
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,14 +9,15 @@ mod validation;
 
 pub use crate::features::log_export::LogExportConfig;
 pub use crate::features::tool_layer::config::ToolLayerConfig;
+pub use config::parse_duration;
 #[cfg(feature = "harness")]
 pub use config::HarnessConfig;
 pub use config::{
-    AcmeConfig, AuthType, BudgetConfig, CacheConfig, ComplianceConfig, EnforcementMode,
-    FanOutConfig, FanOutMode, FipsConfig, ModelConfig, ModelMapping, ModelStrategy, OtelConfig,
-    PoolConfig, PoolStrategy, PresetConfig, ProjectConfig, ProjectRouterOverlay, PromptRule,
-    ProviderConfig, RouterConfig, SecurityConfig, ServerConfig, TeeConfig, TierConfig,
-    TierMatchCondition, TimeoutConfig, TlsConfig, TracingConfig, UserConfig,
+    AcmeConfig, AuthType, BudgetConfig, CacheConfig, CircuitBreakerProviderConfig,
+    ComplianceConfig, EnforcementMode, FanOutConfig, FanOutMode, FipsConfig, ModelConfig,
+    ModelMapping, ModelStrategy, OtelConfig, PoolConfig, PoolStrategy, PresetConfig, ProjectConfig,
+    ProjectRouterOverlay, PromptRule, ProviderConfig, RouterConfig, SecurityConfig, ServerConfig,
+    TeeConfig, TierConfig, TierMatchCondition, TimeoutConfig, TlsConfig, TracingConfig, UserConfig,
 };
 pub use newtypes::{BodySizeLimit, BudgetUsd, ConfigSource, Port};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,12 @@ pub mod pricing;
 pub mod providers;
 /// Request routing engine with regex-based rules.
 pub mod router;
+/// Nature-inspired routing primitives (circuit breaker, EMA stats, bandit).
+///
+/// Tracks the RE phase of the ADR-0018 roadmap. Currently hosts the RE-1a
+/// passive circuit breaker; future primitives (health check, EMA stats,
+/// hedging, Thompson sampling) land here as sibling modules.
+pub mod routing;
 /// Security: rate limiting, circuit breakers, audit, headers.
 pub mod security;
 /// Axum HTTP server, middleware, and application state.

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -6,6 +6,8 @@ use super::{
 };
 use crate::auth::TokenStore;
 use crate::cli::{ModelConfig, TimeoutConfig};
+use crate::routing::{CircuitBreaker, CircuitBreakerConfig, EndpointId};
+use dashmap::DashMap;
 use secrecy::SecretString;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -30,6 +32,18 @@ pub struct ProviderRegistry {
     providers: HashMap<String, Arc<dyn LlmProvider>>,
     /// Map of model name -> provider name for fast lookup
     model_to_provider: HashMap<String, String>,
+    /// Per-provider circuit breaker template used to lazily mint endpoint breakers.
+    ///
+    /// Populated from each provider's `[providers.circuit_breaker]` TOML
+    /// section. A provider with no section maps to
+    /// [`CircuitBreakerConfig::default`] (disabled, Caddy parity).
+    cb_templates: HashMap<String, CircuitBreakerConfig>,
+    /// Per-endpoint passive circuit breakers (RE-1a, ADR-0018).
+    ///
+    /// Keyed by `(provider_name, actual_model)`. Entries are created
+    /// lazily on the first hit from the provider loop, so configs with
+    /// hundreds of models do not allocate hundreds of unused breakers.
+    endpoint_breakers: DashMap<EndpointId, Arc<CircuitBreaker>>,
 }
 
 impl ProviderRegistry {
@@ -38,6 +52,8 @@ impl ProviderRegistry {
         Self {
             providers: HashMap::new(),
             model_to_provider: HashMap::new(),
+            cb_templates: HashMap::new(),
+            endpoint_breakers: DashMap::new(),
         }
     }
 
@@ -310,6 +326,24 @@ impl ProviderRegistry {
             registry
                 .providers
                 .insert(config.name.clone(), Arc::from(provider));
+
+            // Materialise the circuit-breaker template for this provider. Lazy
+            // endpoint registration happens on the first call — this only
+            // stores the config shape (cheap clone).
+            if let Some(cb_cfg) = config.circuit_breaker.as_ref() {
+                match cb_cfg.to_runtime() {
+                    Ok(runtime) => {
+                        registry.cb_templates.insert(config.name.clone(), runtime);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            provider = %config.name,
+                            "invalid circuit_breaker config, using disabled defaults: {}",
+                            e
+                        );
+                    }
+                }
+            }
         }
 
         for model in models {
@@ -358,6 +392,66 @@ impl ProviderRegistry {
     /// List all providers
     pub fn list_providers(&self) -> Vec<String> {
         self.providers.keys().cloned().collect()
+    }
+
+    /// Returns the circuit-breaker template configured for a provider.
+    ///
+    /// When no `[providers.circuit_breaker]` section was supplied for the
+    /// provider, returns the disabled default (Caddy parity).
+    fn cb_template_for(&self, provider: &str) -> CircuitBreakerConfig {
+        self.cb_templates.get(provider).cloned().unwrap_or_default()
+    }
+
+    /// Looks up (or lazily creates) the passive circuit breaker for an endpoint.
+    ///
+    /// The endpoint identity is the `(provider, actual_model)` tuple —
+    /// two models served by the same provider own independent breakers.
+    pub fn endpoint_breaker(&self, provider: &str, model: &str) -> Arc<CircuitBreaker> {
+        let key: EndpointId = (provider.to_string(), model.to_string());
+        if let Some(cb) = self.endpoint_breakers.get(&key) {
+            return Arc::clone(cb.value());
+        }
+        let label = format!("{provider}/{model}");
+        let cfg = self.cb_template_for(provider);
+        let cb = CircuitBreaker::new(label, cfg);
+        // NOTE: `entry().or_insert_with` handles the race where two callers mint at once.
+        self.endpoint_breakers
+            .entry(key)
+            .or_insert_with(|| cb)
+            .value()
+            .clone()
+    }
+
+    /// Returns whether an endpoint is currently healthy (RE-1a, ADR-0018).
+    ///
+    /// Short-circuits to `true` when the breaker is disabled (no config
+    /// or `fail_duration = 0`).
+    pub fn is_endpoint_healthy(&self, provider: &str, model: &str) -> bool {
+        // Fast path: no breaker template for this provider means disabled.
+        if !self.cb_templates.contains_key(provider) {
+            return true;
+        }
+        self.endpoint_breaker(provider, model).is_healthy()
+    }
+
+    /// Records a successful dispatch against the endpoint breaker.
+    ///
+    /// No-op when no breaker template was configured for the provider.
+    pub fn record_endpoint_success(&self, provider: &str, model: &str) {
+        if !self.cb_templates.contains_key(provider) {
+            return;
+        }
+        self.endpoint_breaker(provider, model).record_success();
+    }
+
+    /// Records a failed dispatch against the endpoint breaker.
+    ///
+    /// No-op when no breaker template was configured for the provider.
+    pub fn record_endpoint_failure(&self, provider: &str, model: &str) {
+        if !self.cb_templates.contains_key(provider) {
+            return;
+        }
+        self.endpoint_breaker(provider, model).record_failure();
     }
 
     /// Pre-warm TLS connections to all providers (fire-and-forget).
@@ -431,6 +525,7 @@ mod tests {
                 tls_key: None,
                 tls_ca: None,
                 pool: None,
+                circuit_breaker: None,
             },
             ProviderConfig {
                 name: "provider-b".to_string(),
@@ -451,6 +546,7 @@ mod tests {
                 tls_key: None,
                 tls_ca: None,
                 pool: None,
+                circuit_breaker: None,
             },
         ];
 

--- a/src/routing/circuit_breaker.rs
+++ b/src/routing/circuit_breaker.rs
@@ -1,0 +1,421 @@
+//! Passive circuit breaker — RE-1a (Caddy-inspired, ADR-0018).
+//!
+//! Per-endpoint (provider + model pair) circuit breaker that observes the
+//! real traffic and trips when consecutive failures exceed a threshold. It
+//! is deliberately *passive* — no background probe, no health check request,
+//! no extra load on the upstream. The active probing flavour is tracked as
+//! RE-1b (`src/routing/health_check.rs`, to be added in a follow-up PR).
+//!
+//! # Caddy reference
+//!
+//! Design follows Caddy's [`reverse_proxy`
+//! passive health checks](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#passive-health-checks):
+//!
+//! - `max_fails` — how many failures before the endpoint is marked down
+//!   (Caddy default: 1, Grob default: 1 to preserve Caddy parity).
+//! - `fail_duration` — sliding window during which failures count. After
+//!   this duration a recorded failure is decremented back out. Default 0
+//!   disables the breaker entirely (opt-in, backward-compatible).
+//! - `cooldown` — optional post-trip rest period during which the endpoint
+//!   stays down regardless of the counter. Default none (recover immediately
+//!   once the failure decays out).
+//!
+//! # Hot path
+//!
+//! The hot path — [`CircuitBreaker::is_healthy`] — is a single atomic load
+//! plus one `ArcSwap` load. No mutex, no syscall, no heap allocation. The
+//! cost of a healthy dispatch is effectively zero.
+//!
+//! # Failure decay
+//!
+//! Failures are decremented by a tokio task scheduled at `record_failure`
+//! time. The alternative (absolute `tripped_until` timestamp without a
+//! background task) was rejected because RE-1a must support an opt-in
+//! sliding window independent of the trip — operators want "three
+//! failures in 30 seconds trips the breaker", not "three failures ever
+//! trips it until a dispatch succeeds".
+//!
+//! # Observability
+//!
+//! Every trip and every recovery emits one `info!` line with a clear
+//! banner so the event is trivially greppable in production logs. Counter
+//! metrics are deferred to RE-2 when the EMA stats module lands.
+
+use arc_swap::ArcSwap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::Instant;
+use tracing::info;
+
+/// Endpoint identity key: `(provider_name, model_name)` pair.
+///
+/// Used by higher layers (e.g. provider registry) to index a circuit
+/// breaker per physical endpoint. An "endpoint" in ADR-0018 parlance is
+/// the `(provider, model)` tuple — the same provider with two different
+/// models owns two breakers.
+pub type EndpointId = (String, String);
+
+/// Configuration for a per-endpoint passive circuit breaker.
+///
+/// # Defaults (Caddy parity)
+///
+/// - `max_fails = 1` — one failure is enough to trip.
+/// - `fail_duration = 0` — **disabled**. The breaker never trips.
+/// - `cooldown = None` — no post-trip rest.
+///
+/// The disabled-by-default default is intentional: RE-1a ships as opt-in.
+/// A brand-new Grob instance behaves exactly as before this module
+/// existed until the operator writes a config section.
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    /// Consecutive failures required to trip the breaker. Caddy default: 1.
+    pub max_fails: u32,
+    /// Sliding window for failure counting. Zero disables the breaker.
+    pub fail_duration: Duration,
+    /// Optional post-trip rest period.
+    pub cooldown: Option<Duration>,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        // NOTE: Caddy parity — MaxFails=1, FailDuration=0 (disabled).
+        Self {
+            max_fails: 1,
+            fail_duration: Duration::ZERO,
+            cooldown: None,
+        }
+    }
+}
+
+impl CircuitBreakerConfig {
+    /// Returns `true` when the breaker is effectively disabled.
+    ///
+    /// A zero `fail_duration` means failures never count against the
+    /// endpoint, so the breaker can short-circuit every code path.
+    pub fn is_enabled(&self) -> bool {
+        !self.fail_duration.is_zero()
+    }
+}
+
+/// Passive circuit breaker for one endpoint.
+///
+/// Construct with [`CircuitBreaker::new`], wire it into the provider loop
+/// via [`record_success`](Self::record_success),
+/// [`record_failure`](Self::record_failure), and
+/// [`is_healthy`](Self::is_healthy).
+pub struct CircuitBreaker {
+    /// Human-readable endpoint tag — used only in log lines.
+    label: String,
+    config: CircuitBreakerConfig,
+    /// Number of failures still inside the sliding window.
+    fail_count: AtomicU32,
+    /// When present and in the future, the endpoint is in post-trip cooldown.
+    tripped_until: ArcSwap<Option<Instant>>,
+}
+
+impl CircuitBreaker {
+    /// Creates a fresh circuit breaker with the given configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use grob::routing::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
+    /// use std::time::Duration;
+    ///
+    /// let cb = CircuitBreaker::new(
+    ///     "anthropic/claude-opus-4-7".to_string(),
+    ///     CircuitBreakerConfig {
+    ///         max_fails: 3,
+    ///         fail_duration: Duration::from_secs(30),
+    ///         cooldown: Some(Duration::from_secs(60)),
+    ///     },
+    /// );
+    /// assert!(cb.is_healthy());
+    /// ```
+    pub fn new(label: String, config: CircuitBreakerConfig) -> Arc<Self> {
+        Arc::new(Self {
+            label,
+            config,
+            fail_count: AtomicU32::new(0),
+            tripped_until: ArcSwap::from_pointee(None),
+        })
+    }
+
+    /// Returns the endpoint label used in log lines.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Returns the configuration snapshot.
+    pub fn config(&self) -> &CircuitBreakerConfig {
+        &self.config
+    }
+
+    /// Returns `true` when the endpoint is currently considered usable.
+    ///
+    /// An endpoint is healthy unless it is in post-trip cooldown.
+    pub fn is_healthy(&self) -> bool {
+        // Disabled breaker is always healthy — skip even the ArcSwap load.
+        if !self.config.is_enabled() {
+            return true;
+        }
+        !matches!(**self.tripped_until.load(), Some(until) if Instant::now() < until)
+    }
+
+    /// Records a successful response.
+    ///
+    /// Resets the failure counter to zero and clears any active cooldown,
+    /// restoring the endpoint to the healthy state. Idempotent.
+    pub fn record_success(&self) {
+        if !self.config.is_enabled() {
+            return;
+        }
+        let prev = self.fail_count.swap(0, Ordering::Relaxed);
+        let was_tripped = self.tripped_until.load().is_some();
+        if was_tripped {
+            self.tripped_until.store(Arc::new(None));
+            info!(
+                endpoint = %self.label,
+                "✅ circuit-breaker RECOVERED for endpoint {}",
+                self.label
+            );
+        } else if prev > 0 {
+            tracing::debug!(
+                endpoint = %self.label,
+                previous_fails = prev,
+                "circuit-breaker counter reset after success"
+            );
+        }
+    }
+
+    /// Records a failed response.
+    ///
+    /// Increments the failure counter. When the counter reaches
+    /// `max_fails`, the endpoint is tripped for the cooldown window (or
+    /// for `fail_duration` if no cooldown is configured). A tokio task is
+    /// scheduled to decrement the counter after `fail_duration` so that
+    /// stale failures do not accumulate across the sliding window.
+    pub fn record_failure(self: &Arc<Self>) {
+        if !self.config.is_enabled() {
+            return;
+        }
+
+        let new_count = self.fail_count.fetch_add(1, Ordering::Relaxed) + 1;
+
+        if new_count >= self.config.max_fails {
+            // NOTE: Only trip if not already tripped — avoids spamming the log on a burst.
+            let was_tripped = self.tripped_until.load().is_some();
+            if !was_tripped {
+                let rest = self.config.cooldown.unwrap_or(self.config.fail_duration);
+                let until = Instant::now() + rest;
+                self.tripped_until.store(Arc::new(Some(until)));
+                info!(
+                    endpoint = %self.label,
+                    fails = new_count,
+                    window_secs = self.config.fail_duration.as_secs(),
+                    "🚨 circuit-breaker TRIPPED for endpoint {} ({} fails in {}s)",
+                    self.label,
+                    new_count,
+                    self.config.fail_duration.as_secs()
+                );
+            }
+        }
+
+        // Schedule the decrement after the sliding-window expires.
+        // The Arc clone is cheap; the task holds no strong reference beyond its own scope.
+        let this = Arc::clone(self);
+        let window = self.config.fail_duration;
+        tokio::spawn(async move {
+            tokio::time::sleep(window).await;
+            // Saturating decrement: never underflow if record_success raced us.
+            loop {
+                let current = this.fail_count.load(Ordering::Relaxed);
+                if current == 0 {
+                    break;
+                }
+                if this
+                    .fail_count
+                    .compare_exchange_weak(
+                        current,
+                        current - 1,
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    )
+                    .is_ok()
+                {
+                    break;
+                }
+            }
+            // Cooldown auto-expires via `is_healthy` timestamp check — no action needed here.
+        });
+    }
+
+    /// Returns the current failure count (testing / observability hook).
+    pub fn fail_count(&self) -> u32 {
+        self.fail_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns `true` when the endpoint is in post-trip cooldown.
+    pub fn is_tripped(&self) -> bool {
+        matches!(
+            **self.tripped_until.load(),
+            Some(until) if Instant::now() < until
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn enabled_cfg(max_fails: u32, fail_duration: Duration) -> CircuitBreakerConfig {
+        CircuitBreakerConfig {
+            max_fails,
+            fail_duration,
+            cooldown: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn new_cb_is_healthy() {
+        let cb = CircuitBreaker::new("test".into(), enabled_cfg(3, Duration::from_secs(10)));
+        assert!(cb.is_healthy());
+        assert!(!cb.is_tripped());
+        assert_eq!(cb.fail_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn max_fails_trips_cb() {
+        let cb = CircuitBreaker::new(
+            "test".into(),
+            CircuitBreakerConfig {
+                max_fails: 3,
+                fail_duration: Duration::from_secs(60),
+                cooldown: Some(Duration::from_secs(60)),
+            },
+        );
+        cb.record_failure();
+        assert!(cb.is_healthy(), "1 failure below threshold");
+        cb.record_failure();
+        assert!(cb.is_healthy(), "2 failures still below threshold");
+        cb.record_failure();
+        assert!(!cb.is_healthy(), "3 failures trip the breaker");
+        assert!(cb.is_tripped());
+    }
+
+    #[tokio::test]
+    async fn success_resets_counter() {
+        let cb = CircuitBreaker::new("test".into(), enabled_cfg(3, Duration::from_secs(60)));
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.fail_count(), 2);
+        cb.record_success();
+        assert_eq!(cb.fail_count(), 0);
+        assert!(cb.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn success_clears_trip_state() {
+        let cb = CircuitBreaker::new(
+            "test".into(),
+            CircuitBreakerConfig {
+                max_fails: 1,
+                fail_duration: Duration::from_secs(60),
+                cooldown: Some(Duration::from_secs(60)),
+            },
+        );
+        cb.record_failure();
+        assert!(!cb.is_healthy());
+        cb.record_success();
+        assert!(cb.is_healthy(), "success must clear an active trip");
+        assert!(!cb.is_tripped());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cooldown_recovery() {
+        let cb = CircuitBreaker::new(
+            "test".into(),
+            CircuitBreakerConfig {
+                max_fails: 1,
+                // NOTE: fail_duration large so decrement task doesn't interfere with timing.
+                fail_duration: Duration::from_secs(3600),
+                cooldown: Some(Duration::from_millis(50)),
+            },
+        );
+        cb.record_failure();
+        assert!(!cb.is_healthy(), "tripped immediately after 1 failure");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(cb.is_healthy(), "breaker recovers after cooldown expires");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fail_duration_decrement() {
+        let cb = CircuitBreaker::new("test".into(), enabled_cfg(3, Duration::from_millis(100)));
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.fail_count(), 2);
+        // Advance the mocked clock past fail_duration so the decrement tasks fire.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            cb.fail_count(),
+            0,
+            "both scheduled decrement tasks must have run"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_cb_never_trips() {
+        // fail_duration = 0 means disabled (Caddy default).
+        let cb = CircuitBreaker::new("test".into(), CircuitBreakerConfig::default());
+        assert!(!cb.config().is_enabled());
+        for _ in 0..100 {
+            cb.record_failure();
+        }
+        assert!(cb.is_healthy(), "disabled breaker stays healthy forever");
+        assert_eq!(
+            cb.fail_count(),
+            0,
+            "disabled breaker does not even count failures"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn trip_then_fail_duration_expires_without_cooldown() {
+        // Without explicit cooldown, `rest` == `fail_duration`.
+        let cb = CircuitBreaker::new("test".into(), enabled_cfg(1, Duration::from_millis(50)));
+        cb.record_failure();
+        assert!(!cb.is_healthy(), "tripped on first failure");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            cb.is_healthy(),
+            "breaker recovers once the trip window expires"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_failures_trip_once() {
+        // Hammer the breaker from many tasks; only one trip log should fire.
+        let cb = CircuitBreaker::new(
+            "test".into(),
+            CircuitBreakerConfig {
+                max_fails: 5,
+                fail_duration: Duration::from_secs(60),
+                cooldown: Some(Duration::from_secs(60)),
+            },
+        );
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let cb = Arc::clone(&cb);
+            handles.push(tokio::spawn(async move {
+                cb.record_failure();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert!(!cb.is_healthy());
+        assert!(cb.fail_count() >= 5);
+    }
+}

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,0 +1,23 @@
+//! Routing primitives for the Grob dispatch pipeline (RE phase, ADR-0018).
+//!
+//! This module hosts the nature-inspired routing primitives defined by
+//! [ADR-0018](../../../docs/decisions/0018-nature-inspired-routing.md). The
+//! primitives are **opt-in** and **independent** — each adds one concern at a
+//! time on top of the existing provider loop:
+//!
+//! - [`circuit_breaker`] — RE-1a passive circuit breaker (Caddy-style
+//!   `max_fails` + `fail_duration`). Per-endpoint (provider + model pair),
+//!   lock-free hot path, tokio-driven failure decay. Off by default.
+//!
+//! Future phases (tracked in ADR-0018):
+//!
+//! - RE-1b active health checks.
+//! - RE-1c cooldown + half-open probes.
+//! - RE-2 EMA stats per endpoint.
+//! - RE-3 hedged requests.
+//! - RE-4 Thompson sampling bandit.
+
+/// Passive per-endpoint circuit breaker (RE-1a, Caddy-style).
+pub mod circuit_breaker;
+
+pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, EndpointId};

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -128,6 +128,22 @@ impl DispatchContext<'_> {
         }
     }
 
+    /// Records a successful dispatch on the routing-layer per-endpoint CB (RE-1a).
+    ///
+    /// Orthogonal to the security-layer global per-provider CB above.
+    pub(crate) fn record_endpoint_success(&self, provider: &str, model: &str) {
+        self.inner
+            .provider_registry
+            .record_endpoint_success(provider, model);
+    }
+
+    /// Records a failed dispatch on the routing-layer per-endpoint CB (RE-1a).
+    pub(crate) fn record_endpoint_failure(&self, provider: &str, model: &str) {
+        self.inner
+            .provider_registry
+            .record_endpoint_failure(provider, model);
+    }
+
     /// Emit an audit log entry if the audit log is enabled.
     /// Centralizes the repeated `AuditParams` / `AuditCompliance` construction.
     fn log_audit_if_enabled(&self, entry: AuditEntry<'_>) {

--- a/src/server/dispatch/provider_loop.rs
+++ b/src/server/dispatch/provider_loop.rs
@@ -60,6 +60,27 @@ pub(super) async fn resolve_provider(
         }
     }
 
+    // Routing-layer passive CB (RE-1a, ADR-0018). Per-endpoint, orthogonal
+    // to the global per-provider security CB above — an endpoint can be
+    // down while the provider still has other endpoints up.
+    if !ctx
+        .inner
+        .provider_registry
+        .is_endpoint_healthy(&mapping.provider, &mapping.actual_model)
+    {
+        info!(
+            "Endpoint {}/{} tripped by passive CB, skipping",
+            mapping.provider, mapping.actual_model
+        );
+        metrics::counter!(
+            "grob_routing_endpoint_cb_rejected_total",
+            "provider" => mapping.provider.clone(),
+            "model" => mapping.actual_model.clone(),
+        )
+        .increment(1);
+        return None;
+    }
+
     Some(provider)
 }
 
@@ -443,6 +464,7 @@ async fn dispatch_streaming(
             let latency_ms = overhead_ms;
             ctx.record_provider_success(&mapping.provider, latency_ms)
                 .await;
+            ctx.record_endpoint_success(&mapping.provider, &mapping.actual_model);
 
             let stream = wrap_stream_with_middleware(ctx, stream_response.stream, tap_request_body);
 
@@ -459,6 +481,7 @@ async fn dispatch_streaming(
         }
         Err(e) => {
             ctx.record_provider_failure(&mapping.provider).await;
+            ctx.record_endpoint_failure(&mapping.provider, &mapping.actual_model);
             if let Some(ref trace_id) = ctx.trace_id {
                 ctx.state
                     .observability
@@ -566,6 +589,10 @@ async fn dispatch_non_streaming(
                 let latency_ms = ctx.start_time.elapsed().as_millis() as u64;
                 ctx.record_provider_success(&attempt.mapping.provider, latency_ms)
                     .await;
+                ctx.record_endpoint_success(
+                    &attempt.mapping.provider,
+                    &attempt.mapping.actual_model,
+                );
                 ctx.sanitize_output(&mut response);
                 response.model = attempt.original_model.to_string();
 
@@ -659,6 +686,10 @@ async fn dispatch_non_streaming(
                 }
 
                 ctx.record_provider_failure(&attempt.mapping.provider).await;
+                ctx.record_endpoint_failure(
+                    &attempt.mapping.provider,
+                    &attempt.mapping.actual_model,
+                );
                 info!(
                     "Provider {} failed: {}, trying next fallback",
                     attempt.mapping.provider, e

--- a/tests/helpers/fixtures.rs
+++ b/tests/helpers/fixtures.rs
@@ -123,6 +123,7 @@ pub fn base_provider_config(name: &str) -> grob::providers::ProviderConfig {
         tls_key: None,
         tls_ca: None,
         pool: None,
+        circuit_breaker: None,
     }
 }
 

--- a/tests/unit/provider_test.rs
+++ b/tests/unit/provider_test.rs
@@ -29,6 +29,7 @@ mod tests {
             tls_key: None,
             tls_ca: None,
             pool: None,
+            circuit_breaker: None,
         };
 
         assert!(config.is_enabled());
@@ -56,6 +57,7 @@ mod tests {
             tls_key: None,
             tls_ca: None,
             pool: None,
+            circuit_breaker: None,
         };
 
         assert!(!config.is_enabled());


### PR DESCRIPTION
## Summary

Premier module de la phase RE (Routing Evolution), cf ADR 0018 merged dans #213.

Circuit breaker passif per-endpoint, opt-in via config TOML, atomic counters + tokio task décrément, pas de state machine. Nouveau module \`src/routing/\`, intégré au provider_loop dispatch.

Dépendances ajoutées: \`dashmap = 6\`, \`arc-swap = 1\`.

## Test plan
- [x] 9 tests unitaires routing::circuit_breaker (all pass)
- [x] 933/933 tests workspace pass (aucune régression)
- [ ] CI verte

Part of Phase RE kickoff.