### PR TITLE
chore: release v0.36.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.21](https://github.com/azerozero/grob/compare/v0.36.20...v0.36.21) - 2026-04-18
+
+### Fixed
+
+- *(init)* silence unused state sur --no-default-features
+- *(logs)* classifier validation par HTTP code
+- *(init)* supprimer la validation dupliquee au startup
+
+### Other
+
+- Merge pull request #217 from azerozero/fix/smart-validation-logs
+
 ## [0.36.20](https://github.com/azerozero/grob/compare/v0.36.19...v0.36.20) - 2026-04-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.20"
+version = "0.36.21"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.20"
+version = "0.36.21"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.20 -> 0.36.21

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.21](https://github.com/azerozero/grob/compare/v0.36.20...v0.36.21) - 2026-04-18

### Fixed

- *(init)* silence unused state sur --no-default-features
- *(logs)* classifier validation par HTTP code
- *(init)* supprimer la validation dupliquee au startup

### Other

- Merge pull request #217 from azerozero/fix/smart-validation-logs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).