### PR TITLE
chore: release v0.36.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.22](https://github.com/azerozero/grob/compare/v0.36.21...v0.36.22) - 2026-04-19
+
+### Added
+
+- *(routing)* active health checks Caddy-style (RE-1b)
+
 ## [0.36.21](https://github.com/azerozero/grob/compare/v0.36.20...v0.36.21) - 2026-04-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.21"
+version = "0.36.22"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.21"
+version = "0.36.22"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.21 -> 0.36.22

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.22](https://github.com/azerozero/grob/compare/v0.36.21...v0.36.22) - 2026-04-19

### Added

- *(routing)* active health checks Caddy-style (RE-1b)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).