### PR TITLE
fix(infra): Tier 3 Containerfile + deploy regressions (5 items)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@
 # Multi-stage build with cargo-chef for fast rebuilds
 
 # Stage 1: Chef planner — compute dependency recipe
-FROM rust:1.85-alpine AS chef
+FROM rust:alpine AS chef
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static && \
     cargo install cargo-chef --locked
 WORKDIR /usr/src/grob
@@ -13,15 +13,17 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 # Stage 2: Build dependencies (cached unless Cargo.toml/lock change)
+# NOTE: ENV RUSTFLAGS must be set BEFORE `cargo chef cook` so the cached
+# layer matches the final build's compilation flags. Otherwise the chef
+# cache is invalidated on every build.
 FROM chef AS builder
+ENV RUSTFLAGS="-C target-feature=+crt-static -C link-self-contained=yes"
 COPY --from=planner /usr/src/grob/recipe.json recipe.json
-RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
+RUN cargo chef cook --release --locked --target x86_64-unknown-linux-musl --recipe-path recipe.json
 
 # Copy source and build final binary (only this layer invalidates on code changes)
 COPY . .
-ENV RUSTFLAGS="-C target-feature=+crt-static -C link-self-contained=yes"
-RUN cargo update time@0.3.47 --precise 0.3.35 && \
-    cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --release --locked --target x86_64-unknown-linux-musl
 
 # Strip symbols for smaller binary
 RUN strip target/x86_64-unknown-linux-musl/release/grob
@@ -32,7 +34,7 @@ FROM scratch
 # Metadata
 LABEL org.opencontainers.image.title="grob"
 LABEL org.opencontainers.image.description="LLM Routing Proxy with DLP and compliance"
-LABEL org.opencontainers.image.source="https://github.com/gelwood/grob"
+LABEL org.opencontainers.image.source="https://github.com/azerozero/grob"
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
 # Copy CA certificates for TLS (from builder)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
     volumes:
       # Config (read-only bind mount)
-      - ${GROB_CONFIG:-~/.grob/config}:/etc/grob:ro
+      - ${GROB_CONFIG:-${HOME}/.grob/config}:/etc/grob:ro
       # Persistent data (spend DB, encryption keys)
       - grob-data:/var/lib/grob
 

--- a/deploy/grob.container
+++ b/deploy/grob.container
@@ -5,7 +5,7 @@
 
 [Unit]
 Description=Grob LLM Routing Proxy
-Documentation=https://github.com/gelwood/grob
+Documentation=https://github.com/azerozero/grob
 Wants=network-online.target
 After=network-online.target
 


### PR DESCRIPTION
Phoenix cycle audit 2026-04-18 Tier 3 — 5 régressions non corrigées depuis 2026-04-13.

## Changes

| # | Fichier | Fix |
|---|---|---|
| 1 | Containerfile:6 | \`rust:1.85-alpine\` → \`rust:alpine\` (match CI \`@stable\`) |
| 2 | Containerfile:22-24 | Supprimer hack \`cargo update time@0.3.47 --precise 0.3.35\` inopérant ; ajouter \`--locked\` |
| 28 | Containerfile:22 | Déplacer \`ENV RUSTFLAGS\` **avant** \`cargo chef cook\` (cache chef valide) |
| 3 | Containerfile:35, grob.container:8 | \`gelwood/grob\` → \`azerozero/grob\` (Docker Scout cassé) |
| 4 | docker-compose.yml:36 | \`:-~/.grob/config\` → \`:-\${HOME}/.grob/config\` (Docker n'expanse pas \`~\`) |

## Test plan

- [x] fmt/clippy/yaml checks (prek hooks passés au commit)
- [ ] CI verte (build container + deploy validations)