### PR TITLE
docs(sync): Tier 3 + Tier 2 docs convergence (10 items)

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -14,10 +14,10 @@
 ## dispatch(ctx, request)
 
 **Module:** `src/server/dispatch/mod.rs`
-**Intention:** Execute the full request pipeline in a strict, ordered sequence: DLP input scan, MCP tool calibration, pledge filtering, cache lookup, routing, provider mapping resolution, tool layer processing, cache hit check, fan-out (if configured), and finally the provider fallback loop. Returns either a streaming or complete response.
+**Intention:** Execute the full request pipeline in a strict, ordered sequence: grob_hint harvesting (Step 0, header/MCP hint), DLP input scan, MCP tool calibration, pledge filtering, cache lookup, routing, provider mapping resolution (including Step 5.5 tier fan-out when a `[[tiers]]` matches), tool layer processing, cache hit check, fan-out (if configured), and finally the provider fallback loop. Returns either a streaming or complete response.
 
 **Invariants:**
-- INV-1 (Pipeline order): Steps must execute in the documented order (DLP -> MCP -> pledge -> cache key -> route -> resolve mappings -> tool layer -> cache hit -> fan-out -> provider loop). No step may be skipped except when gated by feature flags.
+- INV-1 (Pipeline order): Steps must execute in the documented order (Step 0 grob_hint -> DLP -> MCP -> pledge -> cache key -> route -> resolve mappings (+ Step 5.5 tier fan-out) -> tool layer -> cache hit -> fan-out -> provider loop). No step may be skipped except when gated by feature flags.
 - INV-2 (DLP before provider): DLP input scanning must always complete before any data is sent to an external provider. A DLP block must prevent the request from reaching any provider.
 - INV-3 (Fallback exhaustion): The provider loop must try all available mappings in order before returning an error. Circuit-broken providers are skipped, not retried.
 - INV-4 (Atomic routing): The routing decision is computed once and used for all provider attempts within a single dispatch. Re-routing mid-dispatch is not allowed.
@@ -50,10 +50,10 @@
 ## Router::route(request)
 
 **Module:** `src/router/mod.rs`
-**Intention:** Classify an incoming request into a route type and resolve the target model name by evaluating rules in strict priority order: WebSearch > Background > AutoMap > SubagentTag > PromptRules > Think > Default. Note: SubagentTag extracts a model from `<GROB-SUBAGENT-MODEL>` system prompt tags but returns `RouteType::Default` (no dedicated variant).
+**Intention:** Classify an incoming request into a route type and resolve the target model name by evaluating rules in strict priority order: `grob_hint` header/MCP (Step 0) > WebSearch > Background > AutoMap > SubagentTag > PromptRules > Think > ComplexityTier (T-P1 classifier) > Default. Note: SubagentTag extracts a model from `<GROB-SUBAGENT-MODEL>` system prompt tags but returns `RouteType::Default` (no dedicated variant). The `complexity_tier` field on `RouteDecision` is populated when the stateless classifier matches, and feeds the tier fan-out layer downstream (Step 5.5 in `dispatch`).
 
 **Invariants:**
-- INV-1 (Priority order): A higher-priority rule always wins. If a request matches both WebSearch and Think, WebSearch is returned.
+- INV-1 (Priority order): A higher-priority rule always wins. If a request matches both WebSearch and Think, WebSearch is returned. An explicit `grob_hint` always short-circuits classification.
 - INV-2 (Determinism): Given the same request and config, `route()` always returns the same `RouteDecision`.
 - INV-3 (Auto-map mutation): Auto-mapping mutates `request.model` in place. This mutation must only happen if no higher-priority rule matched, and must happen before prompt-rule evaluation.
 - INV-4 (Single match): Exactly one route type is returned per call. The function never returns multiple matches.
@@ -209,10 +209,10 @@
 
 ---
 
-## CircuitBreaker::can_execute()
+## CircuitBreaker::can_execute() (security)
 
 **Module:** `src/security/circuit_breaker.rs`
-**Intention:** Determine whether a request should be allowed through to a provider based on the circuit breaker's current state.
+**Intention:** Determine whether a request should be allowed through to a provider based on the circuit breaker's current state. This is the **provider-level, stateful** breaker (Closed/Open/HalfOpen state machine). See `routing::CircuitBreaker::is_healthy()` below for the **endpoint-level, passive** breaker introduced by ADR-0018 (RE-1a). The two coexist: the security CB gates the provider globally, the routing CB gates each `(provider, model)` endpoint. Both must agree for a dispatch to proceed.
 
 **Invariants:**
 - INV-1 (State machine): Three states only: Closed (allow all), Open (reject unless timeout elapsed), HalfOpen (allow up to `half_open_max_calls`).
@@ -306,3 +306,71 @@
 - Block error returned but request still sent to provider
 - Content added to request during sanitization (amplification)
 - Scan skipped for certain message roles or content types
+
+---
+
+## routing::CircuitBreaker::is_healthy() (passive, RE-1a)
+
+**Module:** `src/routing/circuit_breaker.rs`
+**Intention:** Caddy-style passive per-endpoint circuit breaker. Observes real dispatch outcomes via `record_success` / `record_failure` and trips the `(provider, model)` endpoint when consecutive failures exceed `max_fails` within the `fail_duration` sliding window. The hot path (`is_healthy()`) is a single atomic load + one `ArcSwap` load — no lock, no syscall.
+
+**Invariants:**
+- INV-1 (Opt-in): `fail_duration = 0` disables the breaker; `is_healthy()` unconditionally returns `true`.
+- INV-2 (Atomic counter): Failures and successes mutate `AtomicU32` / `ArcSwap<Option<Instant>>` only. No mutex on the hot path.
+- INV-3 (Sliding window): Each failure spawns a tokio task that decrements the counter after `fail_duration`, implementing the sliding window without a timestamp ring buffer.
+- INV-4 (Cooldown priority): When tripped, the endpoint stays down for `cooldown.unwrap_or(fail_duration)` regardless of the counter; `record_success` clears the trip early.
+- INV-5 (Independence from security CB): The routing CB gates one endpoint; the security CB gates the provider globally. The AND gate in `ProviderRegistry::is_endpoint_healthy` composes both.
+
+**Preconditions:**
+- Breaker is constructed with a valid `CircuitBreakerConfig` (may be `Default` = disabled).
+
+**Postconditions:**
+- Returns `true` if the endpoint is usable, `false` if tripped (within cooldown).
+- Idempotent — calling multiple times without intervening `record_*` returns the same answer.
+
+**Boundary behavior:**
+- `fail_duration = 0` (disabled): always `true`, no allocation, no counter mutation.
+- Concurrent failures beyond `max_fails`: only one trip log emitted (guarded by the tripped-until timestamp check).
+
+**Known drifts:**
+- (none recorded yet)
+
+**Red flags to detect:**
+- Mutex or async lock reintroduced on `is_healthy()` hot path.
+- `record_failure` that skips the decrement task (counter grows unbounded).
+- Trip log emitted on every failure after the first (instead of once per trip cycle).
+
+---
+
+## routing::HealthChecker::status() (active, RE-1b)
+
+**Module:** `src/routing/health_check.rs`
+**Intention:** Caddy-style active per-provider health probe. Background tokio task polls `health_uri` on a fixed interval and flips the provider's aggregate health status based on the status-code predicate. Independent of the passive CB above; both signals are AND-gated at the registry layer.
+
+**Invariants:**
+- INV-1 (Opt-in, zero cost): Without a `[providers.health_check]` section, no task is spawned and `status()` returns `HealthStatus::NotConfigured` (treated as healthy by the AND gate).
+- INV-2 (Lifecycle): Each enabled checker owns a `tokio::task::JoinHandle`. `Drop` aborts the task, so replacing the `ProviderRegistry` (via `/api/config/reload`) cleans up probes deterministically — no background leak.
+- INV-3 (Status predicate): `StatusMatcher::parse` accepts `"2xx"`, `"200-204"`, `"200"`, `"*"`, and comma-separated mixes. Invalid specs fail at parse time, never at probe time.
+- INV-4 (Dedicated client): The probe uses its own `reqwest::Client` with `timeout = health_timeout`, not the provider's main client. A health-check timeout cannot disturb in-flight real requests.
+- INV-5 (AND gate priority): In `ProviderRegistry::is_endpoint_healthy`, a `HealthStatus::Down` immediately short-circuits to `false` regardless of the CB state.
+
+**Preconditions:**
+- Called from within a tokio runtime.
+- `HealthCheckConfig::uri` is `Some(_)` when the checker was spawned (construction-time guarantee).
+
+**Postconditions:**
+- `status()` returns one of `NotConfigured`, `Up`, `Down` — never blocks.
+- `is_healthy()` returns `true` for both `NotConfigured` and `Up`.
+
+**Boundary behavior:**
+- Probe HTTP error (timeout, DNS, TLS): endpoint is marked `Down`.
+- Probe returns an unexpected status code: endpoint is marked `Down`, logged at `debug!`.
+- State transition (Up -> Down or Down -> Up): logged at `info!` once per flip.
+
+**Known drifts:**
+- (none recorded yet)
+
+**Red flags to detect:**
+- Probe spawned with `BlockingClient` or on the dispatch runtime — must stay on tokio, timeout isolated.
+- `JoinHandle::abort()` missing from `Drop` — registry reload would leak tasks.
+- `HealthStatus` retrieved via mutex on the hot path — must stay `AtomicBool`.

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ think = "claude-opus-thinking"
 port = 13456
 ```
 
-See [Configuration Reference](docs/CONFIGURATION.md) for all options.
+See [Configuration Reference](docs/reference/configuration.md) for all options.
 
 ## CLI
 
@@ -294,7 +294,10 @@ src/
 │   ├── watch_sse.rs     Live traffic inspector SSE backend
 │   └── fan_out.rs       Parallel multi-provider dispatch
 ├── providers/           Provider implementations and registry
-├── router/              Regex-based request routing engine
+├── router/              Regex-based request routing engine (classify task type)
+├── routing/             Nature-inspired routing primitives (ADR-0018: RE-1a/RE-1b)
+│   ├── circuit_breaker.rs  Passive per-endpoint circuit breaker (Caddy-style)
+│   └── health_check.rs     Active health probe (opt-in)
 ├── cli/                 Config structs and CLI argument parsing
 ├── commands/            CLI command implementations
 ├── auth/                OAuth client, token store, JWT validation
@@ -358,15 +361,15 @@ cargo bench --bench hotpath
 |-----|-------------|
 | [Feature Matrix](docs/reference/features.md) | Complete feature list with config references |
 | [Getting Started](docs/tutorials/getting-started.md) | Step-by-step tutorial |
-| [Configuration Reference](docs/CONFIGURATION.md) | All config options |
+| [Configuration Reference](docs/reference/configuration.md) | All config options |
 | [DLP Reference](docs/reference/dlp.md) | Secret scanning, PII, injection, URL exfil |
 | [DLP How-To](docs/how-to/dlp.md) | Recipes for each DLP feature |
 | [Security Model](docs/explanation/security.md) | Rate limiting, audit, circuit breakers |
-| [Architecture](docs/ARCHITECTURE.md) | Module layout and design decisions |
+| [Architecture](docs/explanation/architecture.md) | Module layout and design decisions |
 | [CLI Reference](docs/reference/cli.md) | Full command documentation |
-| [OAuth Setup](docs/OAUTH_SETUP.md) | Anthropic Max, Gemini Pro |
+| [OAuth Setup](docs/how-to/oauth-setup.md) | Anthropic Max, Gemini Pro |
 | [Benchmarks](docs/reference/benchmarks.md) | AWS results, competitor comparison |
-| [Provider Setup](docs/PROVIDERS.md) | Per-provider guides |
+| [Provider Setup](docs/how-to/providers.md) | Per-provider guides |
 
 ## Contributing
 

--- a/docs/diagrams/ci-cd-pert.md
+++ b/docs/diagrams/ci-cd-pert.md
@@ -1,6 +1,6 @@
 # CI/CD Pipeline PERT
 
-## CI Workflow (push to develop / PR)
+## CI Workflow (push to main / PR)
 
 ```mermaid
 flowchart LR
@@ -55,7 +55,7 @@ flowchart LR
 
 ```mermaid
 flowchart TB
-  push["push develop"]
+  push["push main"]
   releasePlz["release-plz\nbump + tag\n~1min"]
   push --> releasePlz
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -84,6 +84,9 @@ flowchart TB
 | `providers::streaming` | `src/providers/streaming.rs` | SSE stream parsing and forwarding |
 | `providers::registry` | `src/providers/registry.rs` | Provider registration and model lookup |
 | `router` | `src/router/mod.rs` | Request routing engine (regex rules, task classification) |
+| `routing` | `src/routing/mod.rs` | Nature-inspired routing primitives (ADR-0018). Opt-in, independent. |
+| `routing::circuit_breaker` | `src/routing/circuit_breaker.rs` | RE-1a passive per-endpoint circuit breaker (Caddy-style `max_fails` + `fail_duration`) |
+| `routing::health_check` | `src/routing/health_check.rs` | RE-1b active per-provider health probe (Caddy-style `health_uri`/`health_interval`/`health_timeout`/`health_status`). AND-gated with RE-1a in `ProviderRegistry::is_endpoint_healthy` |
 | `cli` | `src/cli/mod.rs` | Config structs (AppConfig, ServerConfig, etc.) and CLI parsing |
 | `preset` | `src/preset/mod.rs` | Preset management (list, apply, export, sync, validate) |
 | `auth` | `src/auth/mod.rs` | Auth module aggregator |

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,17 @@ Grob accepts requests in both Anthropic and OpenAI API formats, normalizes them,
 | [0005](decisions/0005-anthropic-native-provider-trait.md) | Anthropic-native provider trait |
 | [0006](decisions/0006-policy-engine-encrypted-audit-hit-gateway.md) | Policy engine, encrypted audit, HIT gateway |
 | [0008](decisions/0008-wizard-lifecycle.md) | Wizard lifecycle |
+| [0009](decisions/0009-pledge-structural-tool-filtering.md) | Pledge structural tool filtering |
+| [0010](decisions/0010-universal-tool-layer.md) | Universal tool layer |
+| [0011](decisions/0011-control-engine-mcp-tools.md) | Control engine + MCP tools |
+| [0012](decisions/0012-no-unikernel.md) | No unikernel (rejected) |
+| [0013](decisions/0013-storage-files-no-redb.md) | Storage: atomic files, no redb |
+| [0014](decisions/0014-mesh-wireguard-kiss.md) | Mesh: WireGuard KISS |
+| [0015](decisions/0015-indirect-prompt-injection-coverage.md) | Indirect prompt injection coverage |
+| [0016](decisions/0016-decision-tokens-transparent-routing.md) | Decision tokens, transparent routing |
+| [0017](decisions/0017-sokolsky-log-backend.md) | Sokolsky log backend |
+| [0018](decisions/0018-nature-inspired-routing.md) | Nature-inspired routing (RE-1a/RE-1b) |
 
 ## Version
 
-Current release: **v0.35.1** -- see [CHANGELOG](../CHANGELOG.md) for history.
+Current release: **v0.36.22** -- see [CHANGELOG](../CHANGELOG.md) for history.

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -2,7 +2,7 @@
 
 > **90 µs overhead** with routing + auth + rate limiting + cache + DLP on 4 vCPU ARM — 40x faster than LiteLLM, with more features than Bifrost.
 
-Grob v0.35.1 — 2026-04-09 — `grob bench --concurrency` (c=vCPU, 5 sec/scenario, mock TCP backend on localhost).
+Grob v0.36.22 — 2026-04-09 — `grob bench --concurrency` (c=vCPU, 5 sec/scenario, mock TCP backend on localhost).
 
 > v0.26.0 added the HIT policy engine (SSE stream interception + approval channel). For requests without tool_use blocks the overhead is unchanged. For tool_use blocks requiring human approval, stream latency includes the approval wait time (not a grob bottleneck).
 >

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -288,6 +288,24 @@ Check which environment variables are required by configured providers. Shows wh
 grob env
 ```
 
+### `grob logs`
+
+Decrypt and display encrypted trace entries from `~/.grob/trace.jsonl`. Only subcommand today: `decrypt`.
+
+```bash
+grob logs decrypt                             # pretty-print to stdout
+grob logs decrypt --path <trace.jsonl>        # custom trace file
+grob logs decrypt --output <out.jsonl>        # write plaintext to file
+```
+
+### `grob record` (harness)
+
+Record live traffic to a tape file for later replay. Counterpart to `grob replay` (not yet surfaced here). Part of the opt-in `harness` feature.
+
+```bash
+grob record --output <tape.jsonl>
+```
+
 ### `grob connect`
 
 Interactive credential setup for providers. Without arguments, checks all providers. With a provider name, sets up that specific provider only.

--- a/docs/reference/dci-report.md
+++ b/docs/reference/dci-report.md
@@ -1,6 +1,6 @@
 # Documentation Completeness Index (DCI) Report
 
-**Project**: Grob v0.35.1
+**Project**: Grob v0.36.22
 **Date**: 2026-03-18
 **Auditor**: Doc Forge (automated)
 **Scope**: Full project audit (9th pass)

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -1,6 +1,6 @@
 # Feature Matrix
 
-Exhaustive list of grob capabilities, extracted from the codebase (v0.35.1).
+Exhaustive list of grob capabilities, extracted from the codebase (v0.36.22).
 
 ## Core Proxy
 
@@ -285,5 +285,5 @@ Every compliance claim was verified against the actual codebase:
 - **Storage**: Atomic files + JSONL journals (no PostgreSQL, no Redis, no embedded DB)
 - **Allocator**: jemalloc (non-MSVC) for ~20% throughput improvement
 - **Container**: 6 MB `FROM scratch`, rustls TLS bundled
-- **Codebase**: ~29K lines of Rust, 520+ tests
+- **Codebase**: ~66K lines of Rust, 1193 tests
 - **Traits**: 7 core abstractions (DlpPipeline, RequestRouter, Tracer, SpendTracking, AuditWriter, EventTap, ProviderAvailability)

--- a/llms.txt
+++ b/llms.txt
@@ -4,20 +4,20 @@
 
 ## Guides
 
-- [Quick Start](docs/QUICKSTART.md): Install and run Grob in 30 seconds
+- [Quick Start](docs/tutorials/quickstart.md): Install and run Grob in 30 seconds
 - [Getting Started](docs/tutorials/getting-started.md): Step-by-step tutorial from install to running
-- [Provider Setup](docs/PROVIDERS.md): Per-provider configuration guides for all 13+ supported backends
-- [OAuth Setup](docs/OAUTH_SETUP.md): OAuth authentication for Anthropic Pro/Max and Gemini Pro subscriptions
+- [Provider Setup](docs/how-to/providers.md): Per-provider configuration guides for all 13+ supported backends
+- [OAuth Setup](docs/how-to/oauth-setup.md): OAuth authentication for Anthropic Pro/Max and Gemini Pro subscriptions
 
 ## Reference
 
-- [Configuration Reference](docs/CONFIGURATION.md): All TOML config options with defaults and examples
+- [Configuration Reference](docs/reference/configuration.md): All TOML config options with defaults and examples
 - [CLI Reference](docs/reference/cli.md): All CLI commands and flags
 - [OpenAI Compatibility](docs/openai-compatibility.md): `/v1/chat/completions` endpoint details, supported features, and limitations
 - [OpenAPI Specification](docs/openapi.yaml): Full API reference in OpenAPI 3.0 format
 - [Error Reference](docs/reference/errors.md): HTTP status codes and error types
 - [Provider Reference](docs/reference/providers.md): Provider trait, implementations, format translation, streaming, and error types
-- [Troubleshooting](docs/TROUBLESHOOTING.md): Common errors, diagnostics, and fixes
+- [Troubleshooting](docs/how-to/troubleshooting.md): Common errors, diagnostics, and fixes
 
 ## How-to
 
@@ -27,7 +27,7 @@
 
 ## Architecture
 
-- [Architecture Overview](docs/ARCHITECTURE.md): Request flow, module layout, and key design decisions
+- [Architecture Overview](docs/explanation/architecture.md): Request flow, module layout, and key design decisions
 - [Design Principles](docs/design-principles.md): Philosophy, writing principles, and UX guidelines
 - [Security Model](docs/explanation/security.md): Threat model, defense layers, TLS, audit logging
 - [Gemini Integration](docs/gemini-integration.md): Gemini and Vertex AI provider specifics
@@ -62,7 +62,7 @@
 
 ## Configuration
 
-- [Configuration Reference](docs/CONFIGURATION.md): All TOML options
+- [Configuration Reference](docs/reference/configuration.md): All TOML options
 - [Example configs](docs/examples/): Sample configurations for common setups
 - [Presets](presets/): Built-in preset configurations (perf, medium, cheap, fast, local, gdpr, eu-ai-act)
 


### PR DESCRIPTION
Phoenix cycle audit 2026-04-18 — 10 docs items (4 Tier 3, 6 Tier 2).

## Tier 3
- CONTRACTS.md : RE-1a + RE-1b sections (routing module non couvert)
- CONTRACTS.md : dispatch() Step 0 grob_hint + Step 5.5 tier fan-out ; Router::route() priorite a jour
- README + llms.txt : 11 liens 404 UPPERCASE -> Diataxis lowercase
- 4 fichiers v0.35.1 -> v0.36.22

## Tier 2
- docs/index.md : ADR index 7 -> 18 entries (ADR-0009..ADR-0018)
- features.md:288 : ~29K/520 tests -> ~66K/1193
- cli.md : + `grob logs` + `grob record`
- README + architecture.md : src/routing/ visible dans layout
- ci-cd-pert.md : push develop -> push main