### PR TITLE
fix(deploy+shell): Tier 2 deploy + Tier 1 shell hygiene (5 items)

### DIFF
--- a/deploy/grob-kube.yml
+++ b/deploy/grob-kube.yml
@@ -9,7 +9,6 @@ metadata:
   name: grob
   labels:
     app: grob
-    version: v0.8.0
 spec:
   # Security context for rootless operation
   securityContext:

--- a/deploy/grob.container
+++ b/deploy/grob.container
@@ -53,8 +53,10 @@ CPUQuota=100%
 PidsLimit=1024
 
 [Service]
-Type=notify
-NotifyAccess=all
+# NOTE: grob does not call sd_notify itself, so Type=simple is the correct
+# contract. The Quadlet HealthCmd above is what signals readiness to
+# systemd — no user-space sd_notify glue needed.
+Type=simple
 Restart=on-failure
 RestartSec=5
 TimeoutStartSec=60

--- a/tests/e2e/tests/advanced/S5-hit-flow.sh
+++ b/tests/e2e/tests/advanced/S5-hit-flow.sh
@@ -17,7 +17,13 @@ CONFIG="config/mock/grob-test.toml"
 BACKUP="${CONFIG}.bak"
 
 cp "$CONFIG" "$BACKUP"
-trap 'cp "$BACKUP" "$CONFIG"; curl -sf -X POST "http://$HOST/api/config/reload" -H "Authorization: Bearer $JWT" >/dev/null 2>&1; rm -f "$BACKUP"' EXIT
+
+# NOTE: the EXIT trap is installed exactly once, after all temp paths are
+# known. Bash traps are last-write-wins, so a second `trap ... EXIT` later
+# in the script would silently drop the earlier cleanup and leak tempfiles.
+RESP_FILE="$(mktemp)"
+HEADER_FILE="$(mktemp)"
+trap 'cp "$BACKUP" "$CONFIG"; curl -sf -X POST "http://$HOST/api/config/reload" -H "Authorization: Bearer $JWT" >/dev/null 2>&1; rm -f "$BACKUP" "$RESP_FILE" "$HEADER_FILE"' EXIT
 
 # Add provider (tool-mock → vidaimock-tool:8102) + model + HIT policy
 cat >> "$CONFIG" << 'TOML'
@@ -55,11 +61,9 @@ if [ "$status" != "200" ]; then
     exit 1
 fi
 
-# Send request in background (streaming, will block on HIT approval)
-RESP_FILE=$(mktemp)
-HEADER_FILE=$(mktemp)
-trap 'cp "$BACKUP" "$CONFIG"; curl -sf -X POST "http://$HOST/api/config/reload" -H "Authorization: Bearer $JWT" >/dev/null 2>&1; rm -f "$BACKUP" "$RESP_FILE" "$HEADER_FILE"' EXIT
-
+# Send request in background (streaming, will block on HIT approval).
+# Temp paths already created + trap already installed at the top of the
+# script, so nothing extra to register here.
 curl -sf -N -D "$HEADER_FILE" -o "$RESP_FILE" \
     "http://$HOST/v1/chat/completions" -X POST \
     -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \

--- a/tests/e2e/tests/circuit-breaker/run-cb.sh
+++ b/tests/e2e/tests/circuit-breaker/run-cb.sh
@@ -37,7 +37,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 E2E_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 JWT="${JWT:-$(cat "${E2E_ROOT}/auth/tokens/jwt-default.txt" 2>/dev/null || echo "")}"
 
-HURL_OPTS="--test --color --variable host=${HOST} --variable jwt_default=${JWT}"
+HURL_OPTS=(--test --color --variable "host=${HOST}" --variable "jwt_default=${JWT}")
 
 PASS=0
 FAIL=0
@@ -87,7 +87,7 @@ run_hurl() {
     TOTAL=$((TOTAL + 1))
     echo ""
     echo "--- [${TOTAL}] ${label} ---"
-    if hurl ${HURL_OPTS} "${file}"; then
+    if hurl "${HURL_OPTS[@]}" "${file}"; then
         echo "PASS: ${label}"
         PASS=$((PASS + 1))
     else

--- a/tests/e2e/tests/failover/run-failover.sh
+++ b/tests/e2e/tests/failover/run-failover.sh
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 E2E_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 JWT="${JWT:-$(cat "${E2E_ROOT}/auth/tokens/jwt-default.txt" 2>/dev/null || echo "")}"
 
-HURL_OPTS="--test --color --variable host=${HOST} --variable jwt_default=${JWT}"
+HURL_OPTS=(--test --color --variable "host=${HOST}" --variable "jwt_default=${JWT}")
 
 PASS=0
 FAIL=0
@@ -77,7 +77,7 @@ run_hurl() {
     TOTAL=$((TOTAL + 1))
     echo ""
     echo "--- [${TOTAL}] ${label} ---"
-    if hurl ${HURL_OPTS} "${file}"; then
+    if hurl "${HURL_OPTS[@]}" "${file}"; then
         echo "PASS: ${label}"
         PASS=$((PASS + 1))
     else

--- a/tests/e2e/tests/wizard/run-wizard-tests.sh
+++ b/tests/e2e/tests/wizard/run-wizard-tests.sh
@@ -27,7 +27,11 @@ passed=0
 failed=0
 skipped=0
 
-inc() { eval "$1=\$(( $1 + 1 ))"; }
+inc() {
+    # Bash 4.3+ nameref avoids `eval` on caller-controlled strings.
+    local -n _counter="$1"
+    _counter=$((_counter + 1))
+}
 
 cleanup() {
     # Stop grob if running


### PR DESCRIPTION
Phoenix audit 2026-04-18 — 5 items convergents.

**Tier 2 deploy (29, 30)**
- `deploy/grob-kube.yml` : `version: v0.8.0` supprime
- `deploy/grob.container` : `Type=notify` -> `Type=simple` (grob ne fait pas sd_notify)

**Tier 1 shell (43, 44, 45)**
- `run-wizard-tests.sh` : `eval` -> nameref bash 4.3
- `S5-hit-flow.sh` : double `trap EXIT` fusionne (last-write-wins bash silencieux)
- `run-cb.sh` + `run-failover.sh` : `HURL_OPTS` string -> array

**Reportes** (justifies dans le commit) : item 46 getopts (scope >500 LoC), item 47 pricing.rs racine (break cycle intentionnel, doc comment), item 48 UPPER_CASE (convention GitHub root-level).