### PR TITLE
chore: release v0.36.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.23](https://github.com/azerozero/grob/compare/v0.36.22...v0.36.23) - 2026-04-20
+
+### Fixed
+
+- *(infra)* corriger 5 regressions Tier 3 Containerfile + deploy
+
+### Other
+
+- *(features)* supprimer log_backend orphelin (1469 LOC)
+
 ## [0.36.22](https://github.com/azerozero/grob/compare/v0.36.21...v0.36.22) - 2026-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.22"
+version = "0.36.23"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.22"
+version = "0.36.23"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.22 -> 0.36.23

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.23](https://github.com/azerozero/grob/compare/v0.36.22...v0.36.23) - 2026-04-20

### Fixed

- *(infra)* corriger 5 regressions Tier 3 Containerfile + deploy

### Other

- *(features)* supprimer log_backend orphelin (1469 LOC)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).