### PR TITLE
fix(code-quality): convergence Tier 2 + Tier 1 (items 15, 41, 42)

### DIFF
--- a/docs/decisions/0018-nature-inspired-routing.md
+++ b/docs/decisions/0018-nature-inspired-routing.md
@@ -632,21 +632,24 @@ pub struct Beta {
 
 impl Beta {
     pub fn sample(&self, rng: &mut impl Rng) -> f64 {
-        let a = self.alpha.load(Ordering::Relaxed);
-        let b = self.beta.load(Ordering::Relaxed);
-        rand_distr::Beta::new(a, b).unwrap().sample(rng)
+        // NOTE: illustrative snippet; the real implementation threads a
+        // recoverable error so a pathological (alpha, beta) pair cannot
+        // panic the dispatch hot path.
+        let a = self.alpha.load(Ordering::Relaxed).max(f64::EPSILON);
+        let b = self.beta.load(Ordering::Relaxed).max(f64::EPSILON);
+        rand_distr::Beta::new(a, b)
+            .map(|d| d.sample(rng))
+            .unwrap_or(0.5)
     }
 }
 
-pub fn pick(endpoints: &[Endpoint], rng: &mut impl Rng) -> &Endpoint {
-    endpoints
-        .iter()
-        .max_by(|a, b| {
-            a.beta.sample(rng)
-                .partial_cmp(&b.beta.sample(rng))
-                .unwrap()
-        })
-        .unwrap()
+pub fn pick<'a>(endpoints: &'a [Endpoint], rng: &mut impl Rng) -> Option<&'a Endpoint> {
+    endpoints.iter().max_by(|a, b| {
+        a.beta
+            .sample(rng)
+            .partial_cmp(&b.beta.sample(rng))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })
 }
 ```
 

--- a/src/auth/refresh_daemon.rs
+++ b/src/auth/refresh_daemon.rs
@@ -48,6 +48,52 @@ pub(crate) fn should_refresh(
     now + window >= token.expires_at
 }
 
+/// Classification of an OAuth refresh error, derived from the error message.
+///
+/// Replaces the ad-hoc `msg.contains("401")` heuristic with a typed verdict
+/// so callers can decide terminal vs transient without touching strings.
+/// The heuristic stays in one place and is unit-tested.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum OAuthRefreshError {
+    /// `invalid_grant` / `invalid_token` / `unauthorized_client` — the
+    /// refresh token is permanently rejected. Requires user re-auth.
+    InvalidGrant,
+    /// HTTP 401 without a specific OAuth error body — treat as terminal.
+    Unauthorized,
+    /// Transient network error, rate limit, or 5xx from the authorization server.
+    Transient,
+}
+
+impl OAuthRefreshError {
+    /// Returns `true` when the token must be marked `needs_reauth`.
+    pub(crate) fn is_terminal(self) -> bool {
+        matches!(self, Self::InvalidGrant | Self::Unauthorized)
+    }
+}
+
+/// Classifies an OAuth refresh error message.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::auth::refresh_daemon::{classify_refresh_error, OAuthRefreshError};
+/// assert!(classify_refresh_error("invalid_grant").is_terminal());
+/// assert!(!classify_refresh_error("connection reset by peer").is_terminal());
+/// ```
+pub(crate) fn classify_refresh_error(msg: &str) -> OAuthRefreshError {
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("invalid_grant")
+        || lower.contains("invalid_token")
+        || lower.contains("unauthorized_client")
+    {
+        OAuthRefreshError::InvalidGrant
+    } else if lower.contains("401") {
+        OAuthRefreshError::Unauthorized
+    } else {
+        OAuthRefreshError::Transient
+    }
+}
+
 /// Possible outcomes of a single-token refresh attempt.
 ///
 /// Returned by [`refresh_one`] for ease of unit testing.
@@ -93,13 +139,8 @@ pub(crate) async fn refresh_one(
         }
         Err(e) => {
             let msg = e.to_string();
-            // Terminal failures: the refresh_token itself was rejected.
-            // 401/invalid_grant/invalid_token are all treated as permanent.
-            let terminal = msg.contains("401")
-                || msg.contains("invalid_grant")
-                || msg.contains("invalid_token")
-                || msg.contains("unauthorized_client");
-            if terminal {
+            let classification = classify_refresh_error(&msg);
+            if classification.is_terminal() {
                 warn!(
                     provider = %token.provider_id,
                     error = %msg,
@@ -269,5 +310,36 @@ mod tests {
         cancel.cancel();
         // Give the task a moment to notice cancellation.
         tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    #[test]
+    fn classify_invalid_grant_is_terminal() {
+        assert_eq!(
+            classify_refresh_error("oauth: invalid_grant"),
+            OAuthRefreshError::InvalidGrant
+        );
+        assert!(classify_refresh_error("invalid_grant").is_terminal());
+        assert!(classify_refresh_error("INVALID_TOKEN").is_terminal());
+        assert!(classify_refresh_error("unauthorized_client").is_terminal());
+    }
+
+    #[test]
+    fn classify_bare_401_is_terminal() {
+        assert_eq!(
+            classify_refresh_error("HTTP 401"),
+            OAuthRefreshError::Unauthorized
+        );
+        assert!(classify_refresh_error("401 Unauthorized").is_terminal());
+    }
+
+    #[test]
+    fn classify_transient_errors_are_not_terminal() {
+        assert_eq!(
+            classify_refresh_error("connection reset by peer"),
+            OAuthRefreshError::Transient
+        );
+        assert!(!classify_refresh_error("timeout").is_terminal());
+        assert!(!classify_refresh_error("500 Internal Server Error").is_terminal());
+        assert!(!classify_refresh_error("rate limited").is_terminal());
     }
 }

--- a/src/server/rpc/config_ns.rs
+++ b/src/server/rpc/config_ns.rs
@@ -39,7 +39,7 @@ pub async fn set(
 ) -> Result<StatusResponse, ErrorObjectOwned> {
     require_role(caller, Role::Admin)?;
 
-    // TODO: Implement in-memory config mutation with validation.
+    // TODO(#228): Implement in-memory config mutation with validation.
     // Phase 2 will add persistence and diff tracking.
     let _ = state;
 

--- a/src/server/rpc/hit_ns.rs
+++ b/src/server/rpc/hit_ns.rs
@@ -47,7 +47,7 @@ pub async fn set_policy(
 ) -> Result<serde_json::Value, ErrorObjectOwned> {
     require_role(caller, Role::Admin)?;
 
-    // TODO: Implement runtime policy mutation with config reload.
+    // TODO(#228): Implement runtime policy mutation with config reload.
     let _ = state;
 
     Ok(serde_json::json!({
@@ -88,7 +88,7 @@ pub async fn resolve(
     {
         match &inner.policy_matcher {
             Some(_matcher) => {
-                // TODO: Build RequestContext from JSON and run matcher.resolve().
+                // TODO(#228): Build RequestContext from JSON and run matcher.resolve().
                 Ok(serde_json::json!({
                     "resolved": true,
                     "message": "Policy resolution placeholder — full implementation in Phase 2"

--- a/src/server/rpc/pledge_ns.rs
+++ b/src/server/rpc/pledge_ns.rs
@@ -27,7 +27,7 @@ pub async fn set(
 ) -> Result<StatusResponse, ErrorObjectOwned> {
     require_role(caller, Role::Admin)?;
 
-    // TODO: Implement runtime pledge activation with config mutation.
+    // TODO(#228): Implement runtime pledge activation with config mutation.
     let _ = state;
 
     Ok(StatusResponse {
@@ -43,7 +43,7 @@ pub async fn clear(
 ) -> Result<StatusResponse, ErrorObjectOwned> {
     require_role(caller, Role::Admin)?;
 
-    // TODO: Implement pledge clear with config mutation.
+    // TODO(#228): Implement pledge clear with config mutation.
     let _ = state;
 
     Ok(StatusResponse {

--- a/src/server/rpc/tools_ns.rs
+++ b/src/server/rpc/tools_ns.rs
@@ -53,7 +53,7 @@ pub async fn enable(
 ) -> Result<StatusResponse, ErrorObjectOwned> {
     require_role(caller, Role::Admin)?;
 
-    // TODO: Implement runtime tool enable with config mutation.
+    // TODO(#228): Implement runtime tool enable with config mutation.
     let _ = state;
 
     Ok(StatusResponse {
@@ -70,7 +70,7 @@ pub async fn disable(
 ) -> Result<StatusResponse, ErrorObjectOwned> {
     require_role(caller, Role::Admin)?;
 
-    // TODO: Implement runtime tool disable with config mutation.
+    // TODO(#228): Implement runtime tool disable with config mutation.
     let _ = state;
 
     Ok(StatusResponse {


### PR DESCRIPTION
Phoenix audit 2026-04-18 — 3 items fixables sans churn :

- **15** `auth::refresh_daemon` : `classify_refresh_error()` + `enum OAuthRefreshError` (InvalidGrant / Unauthorized / Transient). Remplace heuristique `msg.contains('401')`. +3 tests.
- **41** 7 TODO dans `rpc/*_ns.rs` trackés via issue #228.
- **42** ADR-0018 : 3 `.unwrap()` du snippet Thompson sampling -> `.map().unwrap_or()`.

**Reportés** (commit message) : 16 (duplication auth/mod), 38 (Vale CI), 39 (traits Examples bulk), 40 (52 tautologies bulk) → sprints dédiés.

10/10 tests `auth::refresh_daemon` verts localement.