### PR TITLE
chore: release v0.36.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.25](https://github.com/azerozero/grob/compare/v0.36.24...v0.36.25) - 2026-04-20
+
+### Other
+
+- *(cli)* move AppConfig to models::config to break mega-SCC (T-SP-1 #7)
+
 ## [0.36.24](https://github.com/azerozero/grob/compare/v0.36.23...v0.36.24) - 2026-04-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.24"
+version = "0.36.25"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.24"
+version = "0.36.25"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.24 -> 0.36.25

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.25](https://github.com/azerozero/grob/compare/v0.36.24...v0.36.25) - 2026-04-20

### Other

- *(cli)* move AppConfig to models::config to break mega-SCC (T-SP-1 #7)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).