### PR TITLE
chore: release v0.36.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.27](https://github.com/azerozero/grob/compare/v0.36.26...v0.36.27) - 2026-04-21
+
+### Other
+
+- *(dispatch)* cargo fmt on resolver/retry/provider_loop imports
+- *(dispatch)* split provider_loop 808 LoC into resolver + retry + orchestration (T-SP-3 #9)
+- *(nightly)* skip jemalloc + unix-signals features on Windows
+
 ## [0.36.26](https://github.com/azerozero/grob/compare/v0.36.25...v0.36.26) - 2026-04-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.26"
+version = "0.36.27"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.26"
+version = "0.36.27"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.26 -> 0.36.27

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.27](https://github.com/azerozero/grob/compare/v0.36.26...v0.36.27) - 2026-04-21

### Other

- *(dispatch)* cargo fmt on resolver/retry/provider_loop imports
- *(dispatch)* split provider_loop 808 LoC into resolver + retry + orchestration (T-SP-3 #9)
- *(nightly)* skip jemalloc + unix-signals features on Windows
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).