### PR TITLE
chore: release v0.36.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.28](https://github.com/azerozero/grob/compare/v0.36.27...v0.36.28) - 2026-04-21
+
+### Other
+
+- *(cli-config)* split cli/config.rs 1080 LOC en 10 sous-modules ([#11](https://github.com/azerozero/grob/pull/11)) ([#241](https://github.com/azerozero/grob/pull/241))
+
 ## [0.36.27](https://github.com/azerozero/grob/compare/v0.36.26...v0.36.27) - 2026-04-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.27"
+version = "0.36.28"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.27"
+version = "0.36.28"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.27 -> 0.36.28

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.28](https://github.com/azerozero/grob/compare/v0.36.27...v0.36.28) - 2026-04-21

### Other

- *(cli-config)* split cli/config.rs 1080 LOC en 10 sous-modules ([#11](https://github.com/azerozero/grob/pull/11)) ([#241](https://github.com/azerozero/grob/pull/241))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).