### PR TITLE
refactor(dlp): split pii.rs into cards/iban/bic (T-SP-4 #10)

### DIFF
--- a/src/features/dlp/bic.rs
+++ b/src/features/dlp/bic.rs
@@ -1,0 +1,187 @@
+//! BIC / SWIFT code detection and ISO 9362 format validation.
+//!
+//! Matches 8 or 11 character BIC patterns and validates structure:
+//! 4-letter bank code, ISO 3166 country code, alphanumeric location,
+//! and optional 3-character branch code. Canary generator emits a fake
+//! BIC preserving the original country and location suffix.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+// SAFETY: pattern is a compile-time constant; unwrap cannot fail.
+pub(super) static BIC_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b").unwrap());
+
+/// Validates a BIC/SWIFT code format.
+///
+/// Checks 4-letter bank code, 2-letter ISO 3166 country code, 2-character
+/// alphanumeric location, and optional 3-character branch code.
+///
+/// # Examples
+///
+/// ```
+/// use grob::features::dlp::bic::bic_format_check;
+///
+/// // Valid 8-char BIC (BNP Paribas, France)
+/// assert!(bic_format_check("BNPAFRPP"));
+/// // Valid 11-char BIC with branch
+/// assert!(bic_format_check("BNPAFRPP123"));
+/// // Invalid: wrong length
+/// assert!(!bic_format_check("BNPA"));
+/// // Invalid: lowercase
+/// assert!(!bic_format_check("bnpafrpp"));
+/// ```
+pub fn bic_format_check(bic: &str) -> bool {
+    let len = bic.len();
+    if len != 8 && len != 11 {
+        return false;
+    }
+
+    // First 4: letters (bank code)
+    if !bic[..4].chars().all(|c| c.is_ascii_uppercase()) {
+        return false;
+    }
+
+    // Next 2: ISO 3166 country code
+    let country = &bic[4..6];
+    if !is_valid_country_code(country) {
+        return false;
+    }
+
+    // Next 2: location (alphanumeric)
+    if !bic[6..8]
+        .chars()
+        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+    {
+        return false;
+    }
+
+    // Optional 3: branch (alphanumeric)
+    if len == 11
+        && !bic[8..11]
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+    {
+        return false;
+    }
+
+    true
+}
+
+/// Generates a fake BIC preserving the original country and location suffix.
+pub(super) fn generate_canary_bic(original: &str) -> String {
+    format!("GROB{}{}", &original[4..6], &original[6..])
+}
+
+/// Validate ISO 3166-1 alpha-2 country code against a static table.
+fn is_valid_country_code(code: &str) -> bool {
+    const COUNTRY_CODES: &[&str] = &[
+        "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AS", "AT", "AU", "AW", "AX",
+        "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ",
+        "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CA", "CC", "CD", "CF", "CG", "CH", "CI", "CK",
+        "CL", "CM", "CN", "CO", "CR", "CU", "CV", "CW", "CX", "CY", "CZ", "DE", "DJ", "DK", "DM",
+        "DO", "DZ", "EC", "EE", "EG", "EH", "ER", "ES", "ET", "FI", "FJ", "FK", "FM", "FO", "FR",
+        "GA", "GB", "GD", "GE", "GF", "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS",
+        "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IM", "IN",
+        "IO", "IQ", "IR", "IS", "IT", "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN",
+        "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV",
+        "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MQ",
+        "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NC", "NE", "NF", "NG", "NI",
+        "NL", "NO", "NP", "NR", "NU", "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL", "PM",
+        "PN", "PR", "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS", "RU", "RW", "SA", "SB", "SC",
+        "SD", "SE", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST", "SV",
+        "SX", "SY", "SZ", "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO", "TR",
+        "TT", "TV", "TW", "TZ", "UA", "UG", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI",
+        "VN", "VU", "WF", "WS", "XK", "YE", "YT", "ZA", "ZM", "ZW",
+    ];
+    COUNTRY_CODES.contains(&code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bic_valid_8() {
+        assert!(bic_format_check("DEUTDEFF")); // Deutsche Bank Frankfurt
+    }
+
+    #[test]
+    fn test_bic_valid_11() {
+        assert!(bic_format_check("BNPAFRPP75A")); // BNP Paribas Paris
+    }
+
+    #[test]
+    fn test_bic_invalid_country() {
+        assert!(!bic_format_check("DEUTXXFF")); // XX is not a valid country
+    }
+
+    #[test]
+    fn test_bic_invalid_length() {
+        assert!(!bic_format_check("DEUTDE")); // too short
+        assert!(!bic_format_check("DEUTDEFFAAAA")); // too long (12)
+    }
+
+    /// Tue : L257 != 8 && != 11 (accept only 8 or 11).
+    #[test]
+    fn test_kill_mutant_257_bic_length_strict() {
+        assert!(!bic_format_check("DEUTD")); // 5 chars
+        assert!(!bic_format_check("DEUTDEFF1")); // 9 chars
+        assert!(!bic_format_check("DEUTDEFF12")); // 10 chars
+        assert!(bic_format_check("DEUTDEFF")); // 8 exact
+        assert!(bic_format_check("BNPAFRPP75A")); // 11 exact
+    }
+
+    /// Tue : L262 !...all(uppercase) first 4 bank code.
+    #[test]
+    fn test_kill_mutant_262_bic_bank_code_uppercase_only() {
+        assert!(!bic_format_check("dEUTDEFF")); // lowercase first char
+        assert!(!bic_format_check("DEuTDEFF")); // lowercase third char
+        assert!(!bic_format_check("D3UTDEFF")); // digit in bank code
+    }
+
+    /// Tue : L268 is_valid_country_code negation.
+    #[test]
+    fn test_kill_mutant_268_bic_country_validation() {
+        assert!(!bic_format_check("DEUTXXFF")); // XX invalid country
+        assert!(!bic_format_check("DEUTQQFF")); // QQ invalid
+        assert!(bic_format_check("DEUTDEFF")); // DE valid
+        assert!(bic_format_check("BNPAFRPP")); // FR valid
+    }
+
+    /// Tue : L273-278 location alphanumeric check.
+    #[test]
+    fn test_kill_mutant_273_bic_location_alphanum() {
+        assert!(!bic_format_check("DEUTDE!!")); // special chars in location
+        assert!(bic_format_check("DEUTDE5F")); // digit in location ok
+        assert!(bic_format_check("DEUTDEFF")); // letters in location ok
+    }
+
+    /// Tue : L281-287 branch alphanumeric check (11-char BIC).
+    #[test]
+    fn test_kill_mutant_281_bic_branch_alphanum() {
+        assert!(!bic_format_check("DEUTDEFF!!!")); // special chars in branch
+        assert!(bic_format_check("DEUTDEFF123")); // digits in branch ok
+        assert!(bic_format_check("DEUTDEFFABC")); // letters in branch ok
+    }
+
+    /// Tue : L293 replace -> true/false (country code validation).
+    #[test]
+    fn test_kill_mutant_293_country_code_validation() {
+        assert!(is_valid_country_code("FR"));
+        assert!(is_valid_country_code("DE"));
+        assert!(is_valid_country_code("US"));
+        assert!(!is_valid_country_code("XX"));
+        assert!(!is_valid_country_code("QQ"));
+        assert!(!is_valid_country_code(""));
+    }
+
+    #[test]
+    fn test_canary_bic_preserves_suffix() {
+        let canary = generate_canary_bic("BNPAFRPP");
+        assert!(canary.starts_with("GROB"));
+        assert_eq!(&canary[4..6], "FR");
+        assert_eq!(&canary[6..], "PP");
+        assert_eq!(canary.len(), 8);
+    }
+}

--- a/src/features/dlp/cards.rs
+++ b/src/features/dlp/cards.rs
@@ -1,0 +1,256 @@
+//! Credit card detection and Luhn validation.
+//!
+//! Regex-based match of 13-19 digit runs (with optional spaces/dashes), followed
+//! by Luhn mod-10 checksum validation. Also generates Luhn-valid fake card
+//! numbers for canary replacement.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+// SAFETY: pattern is a compile-time constant; unwrap cannot fail.
+pub(super) static CC_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b(?:\d[ -]?){13,19}\b").unwrap());
+
+/// Validates a credit card number using the Luhn algorithm.
+///
+/// Expects a digit-only string (no spaces or dashes). Returns true
+/// when the sum of alternating doubled digits mod 10 equals 0.
+///
+/// # Examples
+///
+/// ```
+/// use grob::features::dlp::pii::luhn_check;
+///
+/// // Valid Visa test number
+/// assert!(luhn_check("4111111111111111"));
+/// // Invalid (last digit changed)
+/// assert!(!luhn_check("4111111111111112"));
+/// ```
+pub fn luhn_check(digits: &str) -> bool {
+    let mut sum: u32 = 0;
+    let mut double = false;
+
+    for ch in digits.chars().rev() {
+        let mut d = ch.to_digit(10).unwrap_or(0);
+        if double {
+            d *= 2;
+            // mutants::skip — d *= 2 produit uniquement des valeurs paires
+            // (0,2,4,6,8,10,12,14,16,18). d == 9 est inatteignable, donc > et >= sont equivalents.
+            if d > 9 {
+                d -= 9;
+            }
+        }
+        sum += d;
+        double = !double;
+    }
+
+    sum.is_multiple_of(10)
+}
+
+/// Generates a Luhn-valid fake credit card number with the same length.
+pub(super) fn generate_canary_cc(original: &str, id: u64) -> String {
+    let digits_only: String = original.chars().filter(|c| c.is_ascii_digit()).collect();
+    let len = digits_only.len();
+    if len < 2 {
+        return "0".repeat(len);
+    }
+
+    // Keep the first digit (card network) but replace the rest with id-derived digits.
+    let first = digits_only.chars().next().unwrap_or('4');
+    let seed = format!("{}{:0>width$}", first, id, width = len - 2);
+    let mut partial: Vec<u8> = seed
+        .chars()
+        .take(len - 1)
+        .map(|c| c.to_digit(10).unwrap_or(0) as u8)
+        .collect();
+
+    // Pad defensif : le format! ci-dessus genere toujours >= len-1 chars
+    // grace au zero-padding {:0>width$}, donc cette boucle ne fire jamais.
+    // mutants::skip — dead code defensif, partial.len() == len-1 toujours vrai ici.
+    while partial.len() < len - 1 {
+        partial.push(0);
+    }
+
+    let check = luhn_check_digit(&partial);
+    partial.push(check);
+
+    partial.iter().map(|d| (b'0' + d) as char).collect()
+}
+
+/// Computes the Luhn check digit for a sequence of digits.
+pub(super) fn luhn_check_digit(digits: &[u8]) -> u8 {
+    let mut sum: u32 = 0;
+    for (i, &d) in digits.iter().rev().enumerate() {
+        let mut val = d as u32;
+        if i % 2 == 0 {
+            val *= 2;
+            // mutants::skip — val *= 2 produit uniquement des valeurs paires (0..18),
+            // donc val == 9 est inatteignable et > vs >= sont equivalents.
+            if val > 9 {
+                val -= 9;
+            }
+        }
+        sum += val;
+    }
+    ((10 - (sum % 10)) % 10) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_luhn_valid_visa() {
+        assert!(luhn_check("4532015112830366"));
+    }
+
+    #[test]
+    fn test_luhn_valid_mastercard() {
+        assert!(luhn_check("5425233430109903"));
+    }
+
+    #[test]
+    fn test_luhn_valid_amex() {
+        assert!(luhn_check("374245455400126"));
+    }
+
+    #[test]
+    fn test_luhn_invalid() {
+        assert!(!luhn_check("4532015112830367")); // off by one
+        assert!(!luhn_check("1234567890123456"));
+    }
+
+    /// Tue : L212 *= -> += (d *= 2 -> d += 2 change le resultat).
+    #[test]
+    fn test_kill_mutant_212_luhn_double_multiplication() {
+        assert!(luhn_check("4111111111111111"));
+        assert!(!luhn_check("4111111111111112"));
+    }
+
+    /// Tue : L213 > -> >= / == / < (d > 9 seuil).
+    #[test]
+    fn test_kill_mutant_213_luhn_d_gt_9_threshold() {
+        assert!(luhn_check("5425233430109903"));
+        assert!(!luhn_check("5425233430109900"));
+    }
+
+    /// Tue : L214 -= -> += (d -= 9 doit soustraire, pas ajouter).
+    #[test]
+    fn test_kill_mutant_214_luhn_subtract_9() {
+        assert!(luhn_check("5425233430109903"));
+        assert!(!luhn_check("5425233430109904"));
+    }
+
+    /// Tue : L217 += -> -= (sum += d doit accumuler, pas soustraire).
+    #[test]
+    fn test_kill_mutant_217_luhn_sum_accumulate() {
+        assert!(luhn_check("4532015112830366"));
+        assert!(!luhn_check("4532015112830360"));
+    }
+
+    /// Tue : L218 delete ! (double = !double toggle).
+    #[test]
+    fn test_kill_mutant_218_luhn_double_toggle() {
+        assert!(luhn_check("374245455400126"));
+        assert!(!luhn_check("374245455400127"));
+    }
+
+    /// Tue : L340:12 < -> <= (len < 2 guard). Avec <=, len==2 retournerait "00"
+    /// au lieu de generer un canary derive de l'input.
+    #[test]
+    fn test_kill_mutant_340_canary_cc_len_2_generates_valid() {
+        let canary = generate_canary_cc("41", 1);
+        assert_eq!(canary.len(), 2);
+        assert_eq!(
+            canary.chars().next().unwrap(),
+            '4',
+            "Le premier digit doit etre preserve (network): {canary}"
+        );
+        assert!(
+            luhn_check(&canary),
+            "Canary CC 2 chars doit passer Luhn: {canary}"
+        );
+    }
+
+    /// Tue : L334 < (len < 2 guard). len==1 doit retourner "0".
+    #[test]
+    fn test_kill_mutant_334_canary_cc_len_1_returns_zero() {
+        let canary = generate_canary_cc("4", 1);
+        assert_eq!(canary, "0");
+    }
+
+    /// Tue : L349:19 - -> + / / (width = len - 2).
+    #[test]
+    fn test_kill_mutant_349_canary_cc_seed_width() {
+        let canary = generate_canary_cc("4111111111111111", 42);
+        assert_eq!(canary.len(), 16, "Canary doit avoir exactement 16 chars");
+        assert!(
+            luhn_check(&canary),
+            "Canary 16 chars doit passer Luhn: {canary}"
+        );
+    }
+
+    /// Tue : L354:25 < -> > (while partial.len() < len - 1 pad loop).
+    #[test]
+    fn test_kill_mutant_354_canary_cc_pad_loop() {
+        let canary = generate_canary_cc("4111111111111111", 1);
+        assert_eq!(canary.len(), 16);
+        assert!(luhn_check(&canary), "Canary pad doit passer Luhn: {canary}");
+        for c in canary.chars() {
+            assert!(c.is_ascii_digit(), "Char '{c}' n'est pas un digit");
+        }
+    }
+
+    /// Tue : L362:34 + -> - ((b'0' + d) as char).
+    #[test]
+    fn test_kill_mutant_362_canary_cc_ascii_digits() {
+        let canary = generate_canary_cc("5425233430109903", 999);
+        assert_eq!(canary.len(), 16);
+        for c in canary.chars() {
+            assert!(
+                c.is_ascii_digit(),
+                "Attendu digit, got '{c}' (U+{:04X})",
+                c as u32
+            );
+        }
+        assert!(luhn_check(&canary), "Canary doit passer Luhn: {canary}");
+    }
+
+    /// Tue : L364 *= -> += et L365-366 > / -= (meme pattern que luhn_check).
+    #[test]
+    fn test_kill_mutant_364_luhn_check_digit_correct() {
+        let digits = vec![4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+        let check = luhn_check_digit(&digits);
+        let mut full: Vec<u8> = digits;
+        full.push(check);
+        let s: String = full.iter().map(|d| (b'0' + d) as char).collect();
+        assert!(luhn_check(&s));
+    }
+
+    /// Tue : L372 % -> / dans ((10 - (sum % 10)) % 10).
+    #[test]
+    fn test_kill_mutant_372_luhn_check_digit_modulo() {
+        for prefix in [
+            vec![5, 4, 2, 5, 2, 3, 3, 4, 3, 0, 1, 0, 9, 9, 0],
+            vec![3, 7, 4, 2, 4, 5, 4, 5, 5, 4, 0, 0, 1, 2],
+        ] {
+            let check = luhn_check_digit(&prefix);
+            let mut full = prefix;
+            full.push(check);
+            let s: String = full.iter().map(|d| (b'0' + d) as char).collect();
+            assert!(luhn_check(&s), "Luhn check digit failed for {s}");
+        }
+    }
+
+    proptest::proptest! {
+        /// Luhn check digit generation always produces valid numbers.
+        #[test]
+        fn prop_luhn_check_digit_valid(digits in proptest::collection::vec(0u8..10, 12..18)) {
+            let check = luhn_check_digit(&digits);
+            let mut full: Vec<u8> = digits;
+            full.push(check);
+            let s: String = full.iter().map(|d| (b'0' + d) as char).collect();
+            proptest::prop_assert!(luhn_check(&s), "Generated number must pass Luhn: {s}");
+        }
+    }
+}

--- a/src/features/dlp/iban.rs
+++ b/src/features/dlp/iban.rs
@@ -1,0 +1,193 @@
+//! IBAN detection and ISO 7064 mod-97 validation.
+//!
+//! Matches `CC99...` patterns (country + 2-digit check + body) and validates
+//! via rearrangement + modular arithmetic. Canary generator emits a valid
+//! IBAN with the same country code and length.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+// SAFETY: pattern is a compile-time constant; unwrap cannot fail.
+pub(super) static IBAN_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b[A-Z]{2}\d{2}[A-Z0-9]{12,30}\b").unwrap());
+
+/// Validates an IBAN using ISO 7064 mod-97 arithmetic.
+///
+/// Rearranges country+check to end, converts letters to digits, then
+/// verifies the remainder equals 1. Returns false for strings shorter
+/// than 15 characters or containing non-alphanumeric characters.
+///
+/// # Examples
+///
+/// ```
+/// use grob::features::dlp::pii::iban_mod97_check;
+///
+/// // Valid French IBAN
+/// assert!(iban_mod97_check("FR7630006000011234567890189"));
+/// // Invalid (modified check digits)
+/// assert!(!iban_mod97_check("FR0030006000011234567890189"));
+/// // Too short
+/// assert!(!iban_mod97_check("FR76300060"));
+/// ```
+pub fn iban_mod97_check(iban: &str) -> bool {
+    if iban.len() < 15 {
+        return false;
+    }
+
+    // Rearrange: move first 4 chars to end
+    let rearranged = format!("{}{}", &iban[4..], &iban[..4]);
+
+    // Convert letters to digits (A=10, B=11, ..., Z=35) and compute mod 97
+    let mut remainder: u64 = 0;
+    for ch in rearranged.chars() {
+        if let Some(d) = ch.to_digit(10) {
+            remainder = (remainder * 10 + d as u64) % 97;
+        } else if ch.is_ascii_uppercase() {
+            let val = (ch as u64) - b'A' as u64 + 10;
+            // Two-digit number: shift by 2 decimal places
+            remainder = (remainder * 100 + val) % 97;
+        } else {
+            return false; // invalid character
+        }
+    }
+
+    remainder == 1
+}
+
+/// Generates a fake IBAN with the same country code and length.
+pub(super) fn generate_canary_iban(original: &str, id: u64) -> String {
+    let country = if original.len() >= 2 {
+        &original[..2]
+    } else {
+        "XX"
+    };
+    let body_len = original.len().saturating_sub(4); // minus country(2) + check(2)
+    let body = format!("{:0>width$}", id, width = body_len);
+
+    // Compute mod97 check digits (ISO 7064)
+    let rearranged = format!("{}{}00", body, country);
+    let mut remainder: u64 = 0;
+    for ch in rearranged.chars() {
+        let val = if ch.is_ascii_uppercase() {
+            (ch as u64) - 55 // A=10, B=11, ...
+        } else {
+            ch.to_digit(10).unwrap_or(0) as u64
+        };
+        if val >= 10 {
+            remainder = (remainder * 100 + val) % 97;
+        } else {
+            remainder = (remainder * 10 + val) % 97;
+        }
+    }
+    let check = 98 - remainder;
+
+    format!("{}{:02}{}", country, check, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_iban_valid_fr() {
+        assert!(iban_mod97_check("FR7630006000011234567890189"));
+    }
+
+    #[test]
+    fn test_iban_valid_de() {
+        assert!(iban_mod97_check("DE89370400440532013000"));
+    }
+
+    #[test]
+    fn test_iban_valid_gb() {
+        assert!(iban_mod97_check("GB29NWBK60161331926819"));
+    }
+
+    #[test]
+    fn test_iban_invalid() {
+        assert!(!iban_mod97_check("FR7630006000011234567890188"));
+        assert!(!iban_mod97_check("XX000000000000"));
+    }
+
+    /// Tue : L228:19 < -> == (si ==, un IBAN de 14 chars passerait le guard).
+    /// Tue : L228:19 < -> <= (si <=, un IBAN valide de 15 chars serait rejete).
+    #[test]
+    fn test_kill_mutant_228_iban_length_guard() {
+        assert!(!iban_mod97_check("FR123456789012"));
+        assert!(!iban_mod97_check("FR1234567890"));
+        // 15 chars VALIDE (Norway NO9386011117947)
+        assert!(iban_mod97_check("NO9386011117947"));
+    }
+
+    /// Tue : L239:53 % -> / et L239:41 + -> - dans remainder calc.
+    #[test]
+    fn test_kill_mutant_239_iban_remainder_arithmetic() {
+        assert!(iban_mod97_check("DE89370400440532013000"));
+        assert!(!iban_mod97_check("DE89370400440532013001"));
+    }
+
+    /// Tue : L243 replace * 100 avec autre chose dans letter conversion.
+    #[test]
+    fn test_kill_mutant_243_iban_letter_two_digit_shift() {
+        assert!(iban_mod97_check("GB82WEST12345698765432"));
+    }
+
+    /// Tue : L249 == -> != (remainder == 1 final check).
+    #[test]
+    fn test_kill_mutant_249_iban_remainder_must_be_1() {
+        assert!(iban_mod97_check("FR7630006000011234567890189"));
+        assert!(!iban_mod97_check("FR0030006000011234567890189"));
+    }
+
+    /// Tue : L405:49 % -> + dans le calcul remainder % 97 de generate_canary_iban.
+    #[test]
+    fn test_kill_mutant_405_canary_iban_mod97_valid_multiple() {
+        for id in [1, 7, 42, 99, 123, 9999, 100_000] {
+            let canary = generate_canary_iban("FR7630006000011234567890189", id);
+            assert!(canary.starts_with("FR"));
+            assert_eq!(canary.len(), 27);
+            assert!(
+                iban_mod97_check(&canary),
+                "Canary IBAN id={id} doit etre mod97-valide"
+            );
+        }
+    }
+
+    /// Tue : L377 len >= 2 guard et L382 saturating_sub.
+    #[test]
+    fn test_kill_mutant_377_canary_iban_short_input() {
+        let canary = generate_canary_iban("X", 1);
+        assert!(!canary.is_empty());
+    }
+
+    /// Tue : L394/397 val >= 10 branch (lettres vs digits dans le calcul).
+    #[test]
+    fn test_kill_mutant_394_canary_iban_letter_digit_branch() {
+        let canary = generate_canary_iban("GB29NWBK60161331926819", 42);
+        assert!(canary.starts_with("GB"));
+        assert!(
+            iban_mod97_check(&canary),
+            "Canary GB doit etre mod97-valide"
+        );
+    }
+
+    /// Tue : L400 - -> + (check = 98 - remainder).
+    #[test]
+    fn test_kill_mutant_400_canary_iban_check_digit_subtraction() {
+        let canary = generate_canary_iban("DE89370400440532013000", 7);
+        assert!(
+            iban_mod97_check(&canary),
+            "Canary DE doit etre mod97-valide"
+        );
+    }
+
+    proptest::proptest! {
+        /// IBAN mod97 validation rejects random alphanumeric strings.
+        #[test]
+        fn prop_iban_rejects_random(body in "[A-Z]{2}[0-9]{2}[A-Z0-9]{15,28}") {
+            // Overwhelming majority of random strings fail mod97.
+            // We just verify no panics and check the function is total.
+            let _ = iban_mod97_check(&body);
+        }
+    }
+}

--- a/src/features/dlp/mod.rs
+++ b/src/features/dlp/mod.rs
@@ -1,5 +1,7 @@
 //! Data Loss Prevention engine: PII redaction, secret scanning, prompt injection detection.
 
+/// BIC / SWIFT code detection and ISO 9362 format validation.
+pub mod bic;
 /// Built-in secret detection rules shipped with the engine.
 pub mod builtins;
 /// Canary token generation for watermarking redacted secrets.

--- a/src/features/dlp/mod.rs
+++ b/src/features/dlp/mod.rs
@@ -4,6 +4,8 @@
 pub mod builtins;
 /// Canary token generation for watermarking redacted secrets.
 pub mod canary;
+/// Credit card detection and Luhn validation.
+pub mod cards;
 /// Configuration structs for all DLP subsystems.
 pub mod config;
 /// DFA-based secret scanner with prefix-gated matching.

--- a/src/features/dlp/mod.rs
+++ b/src/features/dlp/mod.rs
@@ -12,6 +12,8 @@ pub mod config;
 pub mod dfa;
 /// Hot-reloadable runtime config for domain lists and patterns.
 pub mod hot_config;
+/// IBAN detection and ISO 7064 mod-97 validation.
+pub mod iban;
 mod injection_patterns;
 /// Name anonymization with reversible pseudonym mapping.
 pub mod names;

--- a/src/features/dlp/pii.rs
+++ b/src/features/dlp/pii.rs
@@ -1,9 +1,11 @@
+use super::cards::{self, CC_REGEX};
 use super::config::{PiiAction, PiiConfig};
 use regex::Regex;
 use std::sync::LazyLock;
 
+pub use cards::luhn_check;
+
 // SAFETY: patterns are compile-time constants; unwrap cannot fail.
-static CC_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\b(?:\d[ -]?){13,19}\b").unwrap());
 static IBAN_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b[A-Z]{2}\d{2}[A-Z0-9]{12,30}\b").unwrap());
 static BIC_REGEX: LazyLock<Regex> =
@@ -234,42 +236,6 @@ impl PiiScanner {
     }
 }
 
-/// Validates a credit card number using the Luhn algorithm.
-///
-/// Expects a digit-only string (no spaces or dashes). Returns true
-/// when the sum of alternating doubled digits mod 10 equals 0.
-///
-/// # Examples
-///
-/// ```
-/// use grob::features::dlp::pii::luhn_check;
-///
-/// // Valid Visa test number
-/// assert!(luhn_check("4111111111111111"));
-/// // Invalid (last digit changed)
-/// assert!(!luhn_check("4111111111111112"));
-/// ```
-pub fn luhn_check(digits: &str) -> bool {
-    let mut sum: u32 = 0;
-    let mut double = false;
-
-    for ch in digits.chars().rev() {
-        let mut d = ch.to_digit(10).unwrap_or(0);
-        if double {
-            d *= 2;
-            // mutants::skip — d *= 2 produit uniquement des valeurs paires
-            // (0,2,4,6,8,10,12,14,16,18). d == 9 est inatteignable, donc > et >= sont equivalents.
-            if d > 9 {
-                d -= 9;
-            }
-        }
-        sum += d;
-        double = !double;
-    }
-
-    sum.is_multiple_of(10)
-}
-
 /// Validates an IBAN using ISO 7064 mod-97 arithmetic.
 ///
 /// Rearranges country+check to end, converts letters to digits, then
@@ -401,59 +367,10 @@ fn generate_pii_canary(pii_type: &PiiType, original: &str) -> String {
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
 
     match pii_type {
-        PiiType::CreditCard => generate_canary_cc(original, id),
+        PiiType::CreditCard => cards::generate_canary_cc(original, id),
         PiiType::Iban => generate_canary_iban(original, id),
         PiiType::Bic => format!("GROB{}{}", &original[4..6], &original[6..]),
     }
-}
-
-/// Generates a Luhn-valid fake credit card number with the same length.
-fn generate_canary_cc(original: &str, id: u64) -> String {
-    let digits_only: String = original.chars().filter(|c| c.is_ascii_digit()).collect();
-    let len = digits_only.len();
-    if len < 2 {
-        return "0".repeat(len);
-    }
-
-    // Keep the first digit (card network) but replace the rest with id-derived digits.
-    let first = digits_only.chars().next().unwrap_or('4');
-    let seed = format!("{}{:0>width$}", first, id, width = len - 2);
-    let mut partial: Vec<u8> = seed
-        .chars()
-        .take(len - 1)
-        .map(|c| c.to_digit(10).unwrap_or(0) as u8)
-        .collect();
-
-    // Pad defensif : le format! ci-dessus genere toujours >= len-1 chars
-    // grace au zero-padding {:0>width$}, donc cette boucle ne fire jamais.
-    // mutants::skip — dead code defensif, partial.len() == len-1 toujours vrai ici.
-    while partial.len() < len - 1 {
-        partial.push(0);
-    }
-
-    // Compute Luhn check digit
-    let check = luhn_check_digit(&partial);
-    partial.push(check);
-
-    partial.iter().map(|d| (b'0' + d) as char).collect()
-}
-
-/// Computes the Luhn check digit for a sequence of digits.
-fn luhn_check_digit(digits: &[u8]) -> u8 {
-    let mut sum: u32 = 0;
-    for (i, &d) in digits.iter().rev().enumerate() {
-        let mut val = d as u32;
-        if i % 2 == 0 {
-            val *= 2;
-            // mutants::skip — val *= 2 produit uniquement des valeurs paires (0..18),
-            // donc val == 9 est inatteignable et > vs >= sont equivalents.
-            if val > 9 {
-                val -= 9;
-            }
-        }
-        sum += val;
-    }
-    ((10 - (sum % 10)) % 10) as u8
 }
 
 /// Generates a fake IBAN with the same country code and length.
@@ -498,29 +415,6 @@ mod tests {
             action: PiiAction::Redact,
         })
         .unwrap()
-    }
-
-    // ── Luhn ──────────────────────────────────────────────────
-
-    #[test]
-    fn test_luhn_valid_visa() {
-        assert!(luhn_check("4532015112830366"));
-    }
-
-    #[test]
-    fn test_luhn_valid_mastercard() {
-        assert!(luhn_check("5425233430109903"));
-    }
-
-    #[test]
-    fn test_luhn_valid_amex() {
-        assert!(luhn_check("374245455400126"));
-    }
-
-    #[test]
-    fn test_luhn_invalid() {
-        assert!(!luhn_check("4532015112830367")); // off by one
-        assert!(!luhn_check("1234567890123456"));
     }
 
     // ── IBAN ──────────────────────────────────────────────────
@@ -850,53 +744,6 @@ mod tests {
         assert!(scanner.might_contain_pii("1234 56789"));
     }
 
-    // -- luhn_check : operateurs arithmetiques --
-
-    /// Tue : L212 *= -> += (d *= 2 -> d += 2 change le resultat).
-    #[test]
-    fn test_kill_mutant_212_luhn_double_multiplication() {
-        // 4111111111111111 (Visa test) passe Luhn.
-        assert!(luhn_check("4111111111111111"));
-        // Le meme avec un digit change NE passe PAS.
-        assert!(!luhn_check("4111111111111112"));
-    }
-
-    /// Tue : L213 > -> >= / == / < (d > 9 seuil).
-    #[test]
-    fn test_kill_mutant_213_luhn_d_gt_9_threshold() {
-        // Numeros qui exercent le seuil d > 9 dans le doublement Luhn.
-        // 4111111111111111 a des digits 1 doubles a 2 (< 9) et 4 double a 8 (< 9).
-        // 5425233430109903 a des digits 5 doubles a 10 (> 9 -> -9 = 1).
-        assert!(luhn_check("5425233430109903"));
-        assert!(!luhn_check("5425233430109900"));
-    }
-
-    /// Tue : L214 -= -> += (d -= 9 doit soustraire, pas ajouter).
-    #[test]
-    fn test_kill_mutant_214_luhn_subtract_9() {
-        // 5425233430109903 (Mastercard test) exerce le d -= 9 path (digits >= 5 doubled = 10+).
-        assert!(luhn_check("5425233430109903"));
-        assert!(!luhn_check("5425233430109904"));
-    }
-
-    /// Tue : L217 += -> -= (sum += d doit accumuler, pas soustraire).
-    #[test]
-    fn test_kill_mutant_217_luhn_sum_accumulate() {
-        // Si sum -= d, le resultat serait tres different.
-        assert!(luhn_check("4532015112830366"));
-        assert!(!luhn_check("4532015112830360"));
-    }
-
-    /// Tue : L218 delete ! (double = !double toggle).
-    /// Sans le toggle, luhn doublerait tout ou rien.
-    #[test]
-    fn test_kill_mutant_218_luhn_double_toggle() {
-        // 374245455400126 (Amex) utilise le toggle intensivement.
-        assert!(luhn_check("374245455400126"));
-        // Un nombre qui passe uniquement avec le bon toggle.
-        assert!(!luhn_check("374245455400127"));
-    }
-
     // -- iban_mod97_check : longueur, conversion lettres, calcul mod --
 
     /// Tue : L228:19 < -> == (si ==, un IBAN de 14 chars passerait le guard).
@@ -1036,108 +883,6 @@ mod tests {
         assert!(scanner.redact("card 1234567890123456 done").is_none());
     }
 
-    // -- generate_canary_cc : integrite du canary genere --
-
-    /// Tue : L340:12 < -> <= (len < 2 guard). Avec <=, len==2 retournerait "00"
-    /// au lieu de generer un canary derive de l'input.
-    #[test]
-    fn test_kill_mutant_340_canary_cc_len_2_generates_valid() {
-        let canary = generate_canary_cc("41", 1);
-        assert_eq!(canary.len(), 2);
-        // Le canary doit commencer par le meme premier digit que l'input (network).
-        // Avec le mutant <=, "0".repeat(2) = "00" qui ne commence pas par '4'.
-        assert_eq!(
-            canary.chars().next().unwrap(),
-            '4',
-            "Le premier digit doit etre preserve (network): {canary}"
-        );
-        assert!(
-            luhn_check(&canary),
-            "Canary CC 2 chars doit passer Luhn: {canary}"
-        );
-    }
-
-    /// Tue : L334 < (len < 2 guard). len==1 doit retourner "0".
-    #[test]
-    fn test_kill_mutant_334_canary_cc_len_1_returns_zero() {
-        let canary = generate_canary_cc("4", 1);
-        assert_eq!(canary, "0");
-    }
-
-    /// Tue : L349:19 - -> + / / (width = len - 2).
-    /// Si + ou /, la longueur du seed serait fausse → canary de mauvaise longueur.
-    #[test]
-    fn test_kill_mutant_349_canary_cc_seed_width() {
-        let canary = generate_canary_cc("4111111111111111", 42);
-        assert_eq!(canary.len(), 16, "Canary doit avoir exactement 16 chars");
-        assert!(
-            luhn_check(&canary),
-            "Canary 16 chars doit passer Luhn: {canary}"
-        );
-    }
-
-    /// Tue : L354:25 < -> > (while partial.len() < len - 1 pad loop).
-    /// Si >, la boucle padderait indefiniment (ou pas du tout). Le canary n'aurait
-    /// pas la bonne longueur.
-    #[test]
-    fn test_kill_mutant_354_canary_cc_pad_loop() {
-        // id tres petit (1) avec longueur 16 : le seed sera "4000000000000001"
-        // mais le format fait width=14, donc pas de padding normalement.
-        // Testons un cas ou le seed est tres court.
-        let canary = generate_canary_cc("4111111111111111", 1);
-        assert_eq!(canary.len(), 16);
-        assert!(luhn_check(&canary), "Canary pad doit passer Luhn: {canary}");
-        // Verifie que chaque char est un ASCII digit (tue L356 + -> -).
-        for c in canary.chars() {
-            assert!(c.is_ascii_digit(), "Char '{c}' n'est pas un digit");
-        }
-    }
-
-    /// Tue : L362:34 + -> - ((b'0' + d) as char).
-    /// Si -, les chars ne seraient plus des digits ASCII valides.
-    #[test]
-    fn test_kill_mutant_362_canary_cc_ascii_digits() {
-        let canary = generate_canary_cc("5425233430109903", 999);
-        assert_eq!(canary.len(), 16);
-        for c in canary.chars() {
-            assert!(
-                c.is_ascii_digit(),
-                "Attendu digit, got '{c}' (U+{:04X})",
-                c as u32
-            );
-        }
-        assert!(luhn_check(&canary), "Canary doit passer Luhn: {canary}");
-    }
-
-    // -- luhn_check_digit : arithmetique du check digit --
-
-    /// Tue : L364 *= -> += et L365-366 > / -= (meme pattern que luhn_check).
-    #[test]
-    fn test_kill_mutant_364_luhn_check_digit_correct() {
-        let digits = vec![4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
-        let check = luhn_check_digit(&digits);
-        let mut full: Vec<u8> = digits;
-        full.push(check);
-        let s: String = full.iter().map(|d| (b'0' + d) as char).collect();
-        assert!(luhn_check(&s));
-    }
-
-    /// Tue : L372 % -> / dans ((10 - (sum % 10)) % 10).
-    #[test]
-    fn test_kill_mutant_372_luhn_check_digit_modulo() {
-        // Teste avec plusieurs sequences pour que le % et le - comptent.
-        for prefix in [
-            vec![5, 4, 2, 5, 2, 3, 3, 4, 3, 0, 1, 0, 9, 9, 0],
-            vec![3, 7, 4, 2, 4, 5, 4, 5, 5, 4, 0, 0, 1, 2],
-        ] {
-            let check = luhn_check_digit(&prefix);
-            let mut full = prefix;
-            full.push(check);
-            let s: String = full.iter().map(|d| (b'0' + d) as char).collect();
-            assert!(luhn_check(&s), "Luhn check digit failed for {s}");
-        }
-    }
-
     // -- generate_canary_iban : conversion lettres et mod97 --
 
     /// Tue : L405:49 % -> + dans le calcul remainder % 97 de generate_canary_iban.
@@ -1229,16 +974,6 @@ mod tests {
     }
 
     proptest::proptest! {
-        /// Luhn check digit generation always produces valid numbers.
-        #[test]
-        fn prop_luhn_check_digit_valid(digits in proptest::collection::vec(0u8..10, 12..18)) {
-            let check = luhn_check_digit(&digits);
-            let mut full: Vec<u8> = digits;
-            full.push(check);
-            let s: String = full.iter().map(|d| (b'0' + d) as char).collect();
-            proptest::prop_assert!(luhn_check(&s), "Generated number must pass Luhn: {s}");
-        }
-
         /// IBAN mod97 validation rejects random alphanumeric strings.
         #[test]
         fn prop_iban_rejects_random(body in "[A-Z]{2}[0-9]{2}[A-Z0-9]{15,28}") {

--- a/src/features/dlp/pii.rs
+++ b/src/features/dlp/pii.rs
@@ -1,13 +1,13 @@
 use super::cards::{self, CC_REGEX};
 use super::config::{PiiAction, PiiConfig};
+use super::iban::{self, IBAN_REGEX};
 use regex::Regex;
 use std::sync::LazyLock;
 
 pub use cards::luhn_check;
+pub use iban::iban_mod97_check;
 
-// SAFETY: patterns are compile-time constants; unwrap cannot fail.
-static IBAN_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\b[A-Z]{2}\d{2}[A-Z0-9]{12,30}\b").unwrap());
+// SAFETY: pattern is a compile-time constant; unwrap cannot fail.
 static BIC_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b").unwrap());
 
@@ -236,49 +236,6 @@ impl PiiScanner {
     }
 }
 
-/// Validates an IBAN using ISO 7064 mod-97 arithmetic.
-///
-/// Rearranges country+check to end, converts letters to digits, then
-/// verifies the remainder equals 1. Returns false for strings shorter
-/// than 15 characters or containing non-alphanumeric characters.
-///
-/// # Examples
-///
-/// ```
-/// use grob::features::dlp::pii::iban_mod97_check;
-///
-/// // Valid French IBAN
-/// assert!(iban_mod97_check("FR7630006000011234567890189"));
-/// // Invalid (modified check digits)
-/// assert!(!iban_mod97_check("FR0030006000011234567890189"));
-/// // Too short
-/// assert!(!iban_mod97_check("FR76300060"));
-/// ```
-pub fn iban_mod97_check(iban: &str) -> bool {
-    if iban.len() < 15 {
-        return false;
-    }
-
-    // Rearrange: move first 4 chars to end
-    let rearranged = format!("{}{}", &iban[4..], &iban[..4]);
-
-    // Convert letters to digits (A=10, B=11, ..., Z=35) and compute mod 97
-    let mut remainder: u64 = 0;
-    for ch in rearranged.chars() {
-        if let Some(d) = ch.to_digit(10) {
-            remainder = (remainder * 10 + d as u64) % 97;
-        } else if ch.is_ascii_uppercase() {
-            let val = (ch as u64) - b'A' as u64 + 10;
-            // Two-digit number: shift by 2 decimal places
-            remainder = (remainder * 100 + val) % 97;
-        } else {
-            return false; // invalid character
-        }
-    }
-
-    remainder == 1
-}
-
 /// Validates a BIC/SWIFT code format.
 ///
 /// Checks 4-letter bank code, 2-letter ISO 3166 country code, 2-character
@@ -368,39 +325,9 @@ fn generate_pii_canary(pii_type: &PiiType, original: &str) -> String {
 
     match pii_type {
         PiiType::CreditCard => cards::generate_canary_cc(original, id),
-        PiiType::Iban => generate_canary_iban(original, id),
+        PiiType::Iban => iban::generate_canary_iban(original, id),
         PiiType::Bic => format!("GROB{}{}", &original[4..6], &original[6..]),
     }
-}
-
-/// Generates a fake IBAN with the same country code and length.
-fn generate_canary_iban(original: &str, id: u64) -> String {
-    let country = if original.len() >= 2 {
-        &original[..2]
-    } else {
-        "XX"
-    };
-    let body_len = original.len().saturating_sub(4); // minus country(2) + check(2)
-    let body = format!("{:0>width$}", id, width = body_len);
-
-    // Compute mod97 check digits (ISO 7064)
-    let rearranged = format!("{}{}00", body, country);
-    let mut remainder: u64 = 0;
-    for ch in rearranged.chars() {
-        let val = if ch.is_ascii_uppercase() {
-            (ch as u64) - 55 // A=10, B=11, ...
-        } else {
-            ch.to_digit(10).unwrap_or(0) as u64
-        };
-        if val >= 10 {
-            remainder = (remainder * 100 + val) % 97;
-        } else {
-            remainder = (remainder * 10 + val) % 97;
-        }
-    }
-    let check = 98 - remainder;
-
-    format!("{}{:02}{}", country, check, body)
 }
 
 #[cfg(test)]
@@ -415,29 +342,6 @@ mod tests {
             action: PiiAction::Redact,
         })
         .unwrap()
-    }
-
-    // ── IBAN ──────────────────────────────────────────────────
-
-    #[test]
-    fn test_iban_valid_fr() {
-        assert!(iban_mod97_check("FR7630006000011234567890189"));
-    }
-
-    #[test]
-    fn test_iban_valid_de() {
-        assert!(iban_mod97_check("DE89370400440532013000"));
-    }
-
-    #[test]
-    fn test_iban_valid_gb() {
-        assert!(iban_mod97_check("GB29NWBK60161331926819"));
-    }
-
-    #[test]
-    fn test_iban_invalid() {
-        assert!(!iban_mod97_check("FR7630006000011234567890188")); // wrong check
-        assert!(!iban_mod97_check("XX000000000000")); // too short / invalid
     }
 
     // ── BIC ───────────────────────────────────────────────────
@@ -744,46 +648,6 @@ mod tests {
         assert!(scanner.might_contain_pii("1234 56789"));
     }
 
-    // -- iban_mod97_check : longueur, conversion lettres, calcul mod --
-
-    /// Tue : L228:19 < -> == (si ==, un IBAN de 14 chars passerait le guard).
-    /// Tue : L228:19 < -> <= (si <=, un IBAN valide de 15 chars serait rejete).
-    #[test]
-    fn test_kill_mutant_228_iban_length_guard() {
-        // 14 chars : doit retourner false (< 15).
-        // Tue < -> == : car avec ==, len(14) != 15 donc le guard ne rejette PAS, et on
-        // continue vers le mod97 check qui pourrait retourner true sur un input crafted.
-        assert!(!iban_mod97_check("FR123456789012"));
-        // 13 chars : aussi rejete.
-        assert!(!iban_mod97_check("FR1234567890"));
-        // 15 chars VALIDE (Norway NO9386011117947) : doit retourner true.
-        // Tue < -> <= : car avec <=, len(15) <= 15 rejetterait ce IBAN valide.
-        assert!(iban_mod97_check("NO9386011117947"));
-    }
-
-    /// Tue : L239:53 % -> / et L239:41 + -> - dans remainder calc.
-    #[test]
-    fn test_kill_mutant_239_iban_remainder_arithmetic() {
-        // DE89370400440532013000 valide : remainder DOIT etre 1.
-        assert!(iban_mod97_check("DE89370400440532013000"));
-        // Changer un digit casse le mod97.
-        assert!(!iban_mod97_check("DE89370400440532013001"));
-    }
-
-    /// Tue : L243 replace * 100 avec autre chose dans letter conversion.
-    #[test]
-    fn test_kill_mutant_243_iban_letter_two_digit_shift() {
-        // GB82WEST12345698765432 — utilise des lettres (W, E, S, T) dans le BBAN.
-        assert!(iban_mod97_check("GB82WEST12345698765432"));
-    }
-
-    /// Tue : L249 == -> != (remainder == 1 final check).
-    #[test]
-    fn test_kill_mutant_249_iban_remainder_must_be_1() {
-        assert!(iban_mod97_check("FR7630006000011234567890189"));
-        assert!(!iban_mod97_check("FR0030006000011234567890189")); // check digits wrong
-    }
-
     // -- bic_format_check : validations structurelles --
 
     /// Tue : L257 != 8 && != 11 (accept only 8 or 11).
@@ -883,54 +747,6 @@ mod tests {
         assert!(scanner.redact("card 1234567890123456 done").is_none());
     }
 
-    // -- generate_canary_iban : conversion lettres et mod97 --
-
-    /// Tue : L405:49 % -> + dans le calcul remainder % 97 de generate_canary_iban.
-    /// Multiple ids pour eviter les coincidences sur un seul id.
-    #[test]
-    fn test_kill_mutant_405_canary_iban_mod97_valid_multiple() {
-        for id in [1, 7, 42, 99, 123, 9999, 100_000] {
-            let canary = generate_canary_iban("FR7630006000011234567890189", id);
-            assert!(canary.starts_with("FR"));
-            assert_eq!(canary.len(), 27);
-            assert!(
-                iban_mod97_check(&canary),
-                "Canary IBAN id={id} doit etre mod97-valide"
-            );
-        }
-    }
-
-    /// Tue : L377 len >= 2 guard et L382 saturating_sub.
-    #[test]
-    fn test_kill_mutant_377_canary_iban_short_input() {
-        let canary = generate_canary_iban("X", 1);
-        // Court input : country = "XX" fallback, body_len = 0.
-        assert!(!canary.is_empty());
-    }
-
-    /// Tue : L394/397 val >= 10 branch (lettres vs digits dans le calcul).
-    #[test]
-    fn test_kill_mutant_394_canary_iban_letter_digit_branch() {
-        // GB (lettres G=16, B=11) teste le branch >= 10 dans la boucle.
-        let canary = generate_canary_iban("GB29NWBK60161331926819", 42);
-        assert!(canary.starts_with("GB"));
-        assert!(
-            iban_mod97_check(&canary),
-            "Canary GB doit etre mod97-valide"
-        );
-    }
-
-    /// Tue : L400 - -> + (check = 98 - remainder).
-    #[test]
-    fn test_kill_mutant_400_canary_iban_check_digit_subtraction() {
-        // Si 98 + remainder au lieu de 98 - remainder, le check digit serait faux.
-        let canary = generate_canary_iban("DE89370400440532013000", 7);
-        assert!(
-            iban_mod97_check(&canary),
-            "Canary DE doit etre mod97-valide"
-        );
-    }
-
     // -- generate_pii_canary : dispatch par type --
 
     /// Tue : L318 replace generate_pii_canary -> String.
@@ -971,15 +787,5 @@ mod tests {
         assert!(!is_valid_country_code("XX"));
         assert!(!is_valid_country_code("QQ"));
         assert!(!is_valid_country_code(""));
-    }
-
-    proptest::proptest! {
-        /// IBAN mod97 validation rejects random alphanumeric strings.
-        #[test]
-        fn prop_iban_rejects_random(body in "[A-Z]{2}[0-9]{2}[A-Z0-9]{15,28}") {
-            // Overwhelming majority of random strings fail mod97.
-            // We just verify no panics and check the function is total.
-            let _ = iban_mod97_check(&body);
-        }
     }
 }

--- a/src/features/dlp/pii.rs
+++ b/src/features/dlp/pii.rs
@@ -1,15 +1,12 @@
+use super::bic::{self, BIC_REGEX};
 use super::cards::{self, CC_REGEX};
 use super::config::{PiiAction, PiiConfig};
 use super::iban::{self, IBAN_REGEX};
 use regex::Regex;
-use std::sync::LazyLock;
 
+pub use bic::bic_format_check;
 pub use cards::luhn_check;
 pub use iban::iban_mod97_check;
-
-// SAFETY: pattern is a compile-time constant; unwrap cannot fail.
-static BIC_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\b[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b").unwrap());
 
 /// Type of PII detected.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -236,86 +233,6 @@ impl PiiScanner {
     }
 }
 
-/// Validates a BIC/SWIFT code format.
-///
-/// Checks 4-letter bank code, 2-letter ISO 3166 country code, 2-character
-/// alphanumeric location, and optional 3-character branch code.
-///
-/// # Examples
-///
-/// ```
-/// use grob::features::dlp::pii::bic_format_check;
-///
-/// // Valid 8-char BIC (BNP Paribas, France)
-/// assert!(bic_format_check("BNPAFRPP"));
-/// // Valid 11-char BIC with branch
-/// assert!(bic_format_check("BNPAFRPP123"));
-/// // Invalid: wrong length
-/// assert!(!bic_format_check("BNPA"));
-/// // Invalid: lowercase
-/// assert!(!bic_format_check("bnpafrpp"));
-/// ```
-pub fn bic_format_check(bic: &str) -> bool {
-    let len = bic.len();
-    if len != 8 && len != 11 {
-        return false;
-    }
-
-    // First 4: letters (bank code)
-    if !bic[..4].chars().all(|c| c.is_ascii_uppercase()) {
-        return false;
-    }
-
-    // Next 2: ISO 3166 country code
-    let country = &bic[4..6];
-    if !is_valid_country_code(country) {
-        return false;
-    }
-
-    // Next 2: location (alphanumeric)
-    if !bic[6..8]
-        .chars()
-        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
-    {
-        return false;
-    }
-
-    // Optional 3: branch (alphanumeric)
-    if len == 11
-        && !bic[8..11]
-            .chars()
-            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
-    {
-        return false;
-    }
-
-    true
-}
-
-/// Validate ISO 3166-1 alpha-2 country code against a static table.
-fn is_valid_country_code(code: &str) -> bool {
-    const COUNTRY_CODES: &[&str] = &[
-        "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AS", "AT", "AU", "AW", "AX",
-        "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ",
-        "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CA", "CC", "CD", "CF", "CG", "CH", "CI", "CK",
-        "CL", "CM", "CN", "CO", "CR", "CU", "CV", "CW", "CX", "CY", "CZ", "DE", "DJ", "DK", "DM",
-        "DO", "DZ", "EC", "EE", "EG", "EH", "ER", "ES", "ET", "FI", "FJ", "FK", "FM", "FO", "FR",
-        "GA", "GB", "GD", "GE", "GF", "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS",
-        "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IM", "IN",
-        "IO", "IQ", "IR", "IS", "IT", "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN",
-        "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV",
-        "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MQ",
-        "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NC", "NE", "NF", "NG", "NI",
-        "NL", "NO", "NP", "NR", "NU", "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL", "PM",
-        "PN", "PR", "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS", "RU", "RW", "SA", "SB", "SC",
-        "SD", "SE", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST", "SV",
-        "SX", "SY", "SZ", "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO", "TR",
-        "TT", "TV", "TW", "TZ", "UA", "UG", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI",
-        "VN", "VU", "WF", "WS", "XK", "YE", "YT", "ZA", "ZM", "ZW",
-    ];
-    COUNTRY_CODES.contains(&code)
-}
-
 /// Generates a syntactically valid fake PII value (canary) for transparent replacement.
 /// The fake value has the same length and format as the original but different digits.
 fn generate_pii_canary(pii_type: &PiiType, original: &str) -> String {
@@ -326,7 +243,7 @@ fn generate_pii_canary(pii_type: &PiiType, original: &str) -> String {
     match pii_type {
         PiiType::CreditCard => cards::generate_canary_cc(original, id),
         PiiType::Iban => iban::generate_canary_iban(original, id),
-        PiiType::Bic => format!("GROB{}{}", &original[4..6], &original[6..]),
+        PiiType::Bic => bic::generate_canary_bic(original),
     }
 }
 
@@ -342,29 +259,6 @@ mod tests {
             action: PiiAction::Redact,
         })
         .unwrap()
-    }
-
-    // ── BIC ───────────────────────────────────────────────────
-
-    #[test]
-    fn test_bic_valid_8() {
-        assert!(bic_format_check("DEUTDEFF")); // Deutsche Bank Frankfurt
-    }
-
-    #[test]
-    fn test_bic_valid_11() {
-        assert!(bic_format_check("BNPAFRPP75A")); // BNP Paribas Paris
-    }
-
-    #[test]
-    fn test_bic_invalid_country() {
-        assert!(!bic_format_check("DEUTXXFF")); // XX is not a valid country
-    }
-
-    #[test]
-    fn test_bic_invalid_length() {
-        assert!(!bic_format_check("DEUTDE")); // too short
-        assert!(!bic_format_check("DEUTDEFFAAAA")); // too long (12)
     }
 
     // ── Pre-filter ────────────────────────────────────────────
@@ -648,51 +542,6 @@ mod tests {
         assert!(scanner.might_contain_pii("1234 56789"));
     }
 
-    // -- bic_format_check : validations structurelles --
-
-    /// Tue : L257 != 8 && != 11 (accept only 8 or 11).
-    #[test]
-    fn test_kill_mutant_257_bic_length_strict() {
-        assert!(!bic_format_check("DEUTD")); // 5 chars
-        assert!(!bic_format_check("DEUTDEFF1")); // 9 chars
-        assert!(!bic_format_check("DEUTDEFF12")); // 10 chars
-        assert!(bic_format_check("DEUTDEFF")); // 8 exact
-        assert!(bic_format_check("BNPAFRPP75A")); // 11 exact
-    }
-
-    /// Tue : L262 !...all(uppercase) first 4 bank code.
-    #[test]
-    fn test_kill_mutant_262_bic_bank_code_uppercase_only() {
-        assert!(!bic_format_check("dEUTDEFF")); // lowercase first char
-        assert!(!bic_format_check("DEuTDEFF")); // lowercase third char
-        assert!(!bic_format_check("D3UTDEFF")); // digit in bank code
-    }
-
-    /// Tue : L268 is_valid_country_code negation.
-    #[test]
-    fn test_kill_mutant_268_bic_country_validation() {
-        assert!(!bic_format_check("DEUTXXFF")); // XX invalid country
-        assert!(!bic_format_check("DEUTQQFF")); // QQ invalid
-        assert!(bic_format_check("DEUTDEFF")); // DE valid
-        assert!(bic_format_check("BNPAFRPP")); // FR valid
-    }
-
-    /// Tue : L273-278 location alphanumeric check.
-    #[test]
-    fn test_kill_mutant_273_bic_location_alphanum() {
-        assert!(!bic_format_check("DEUTDE!!")); // special chars in location
-        assert!(bic_format_check("DEUTDE5F")); // digit in location ok
-        assert!(bic_format_check("DEUTDEFF")); // letters in location ok
-    }
-
-    /// Tue : L281-287 branch alphanumeric check (11-char BIC).
-    #[test]
-    fn test_kill_mutant_281_bic_branch_alphanum() {
-        assert!(!bic_format_check("DEUTDEFF!!!")); // special chars in branch
-        assert!(bic_format_check("DEUTDEFF123")); // digits in branch ok
-        assert!(bic_format_check("DEUTDEFFABC")); // letters in branch ok
-    }
-
     // -- redact : mode Log vs Redact vs Canary, overlap detection --
 
     /// Tue : L168 == -> != (PiiAction::Log check inverted).
@@ -774,18 +623,5 @@ mod tests {
         assert_eq!(format!("{}", PiiType::CreditCard), "credit_card");
         assert_eq!(format!("{}", PiiType::Iban), "iban");
         assert_eq!(format!("{}", PiiType::Bic), "bic");
-    }
-
-    // -- is_valid_country_code --
-
-    /// Tue : L293 replace -> true/false (country code validation).
-    #[test]
-    fn test_kill_mutant_293_country_code_validation() {
-        assert!(is_valid_country_code("FR"));
-        assert!(is_valid_country_code("DE"));
-        assert!(is_valid_country_code("US"));
-        assert!(!is_valid_country_code("XX"));
-        assert!(!is_valid_country_code("QQ"));
-        assert!(!is_valid_country_code(""));
     }
 }


### PR DESCRIPTION
## Summary

Split monolithic `src/features/dlp/pii.rs` by PII type per audit item #10 Tier 2.

- Extract `CreditCard` regex, Luhn check, canary generator → `cards.rs`
- Extract `Iban` regex, ISO 7064 mod-97 check, canary generator → `iban.rs`
- Extract `Bic` regex, ISO 9362 format check, country codes table, canary generator → `bic.rs`
- `pii.rs` keeps the `PiiType` enum, `PiiScanner` orchestrator, canary dispatch, and integration tests

## Notes

Initial audit suggested extracting emails and names, but those already live in separate modules (`dlp::names`). Actual decomposable content was the three validators above.

All mutation-testing-targeted tests (\`test_kill_mutant_*\`) are preserved — structural tests moved with their subject, dispatch tests stay in `pii.rs`.

LOC before: `pii.rs` 1143. After: `pii.rs` 627, `cards.rs` 256, `iban.rs` 193, `bic.rs` 187.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy --all-features -- -D warnings\`
- [x] \`cargo test --all-features --lib\` (959 passed)
- [x] Doc tests for \`bic.rs\` and \`pii.rs\`