### PR TITLE
fix(dispatch,router): wire grob_hint + doc drift (#5 #6 #14)

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -24,25 +24,38 @@ flowchart TB
         h3["OpenAI → Anthropic internal format"]
     end
 
-    subgraph router["Router"]
-        r1["1. WebSearch — web_search tool detected"]
-        r2["2. Background — model matches background_regex"]
-        r3["3. Auto-map regex — transform model name"]
-        r4["4. Subagent — GROB-SUBAGENT-MODEL tag"]
-        r5["5. Prompt rules — regex on user message"]
-        r6["6. Think — thinking/reasoning enabled"]
-        r7["7. Default model — fallback"]
-        rd["RouteDecision { model, route_type }"]
+    subgraph routing["routing/ (ADR-0018)"]
+        direction TB
+        subgraph classify["routing::classify (request classification)"]
+            r1["1. WebSearch — web_search tool detected"]
+            r2["2. Background — model matches background_regex"]
+            r3["3. Auto-map regex — transform model name"]
+            r4["4. Subagent — GROB-SUBAGENT-MODEL tag"]
+            r5["5. Prompt rules — regex on user message"]
+            r6["6. Think — thinking/reasoning enabled"]
+            r7["7. Declarative tier match — [[tiers.match]] globs + keywords"]
+            r8["8. Algorithmic scoring — heuristic complexity (fallback)"]
+            r9["9. Default model — fallback"]
+        end
+        rd["RouteDecision { model, route_type, complexity_tier }"]
+        cb1["routing::circuit_breaker<br/>RE-1a passive per-endpoint CB<br/>(max_fails + fail_duration)"]
+        hc["routing::health_check<br/>RE-1b active per-provider probe<br/>(health_uri, health_interval)"]
+        gate["ProviderRegistry::is_endpoint_healthy<br/>AND-gate: RE-1a ∧ RE-1b"]
+        cb1 --> gate
+        hc --> gate
     end
 
     subgraph dispatch["Provider Dispatch"]
-        cb{"Circuit Breaker"}
-        cb -->|Closed| call["Provider call<br/>(Anthropic, OpenAI, Gemini, ...)"]
-        cb -->|Open| skip["Skip → next provider"]
-        cb -->|HalfOpen| probe["Limited probe requests"]
-        call -->|success| rec_ok["record_success"]
+        direction TB
+        gate2{"Healthy endpoint?<br/>(RE-1a ∧ RE-1b)"}
+        gate2 -->|Yes| cbsec{"Global CB<br/>(security::circuit_breaker)"}
+        gate2 -->|No| skip1["Skip → next provider"]
+        cbsec -->|Closed| call["Provider call<br/>(Anthropic, OpenAI, Gemini, ...)"]
+        cbsec -->|Open| skip2["Skip → next provider"]
+        cbsec -->|HalfOpen| probe["Limited probe requests"]
+        call -->|success| rec_ok["record_success<br/>(endpoint + global)"]
         call -->|failure| rec_fail["record_failure → try next"]
-        note["Strategies: fallback (sequential) · fan_out (parallel)"]
+        note["Strategies: fallback (sequential) · fan_out (parallel) · tier fan-out"]
     end
 
     subgraph dlp["DLP (Data Loss Prevention)"]
@@ -62,8 +75,8 @@ flowchart TB
 
     client -->|"POST /v1/messages\nPOST /v1/chat/completions"| server
     server --> handler
-    handler --> router
-    router --> dispatch
+    handler --> routing
+    routing --> dispatch
     dispatch --> dlp
     dlp --> response
     response --> client

--- a/src/routing/classify/mod.rs
+++ b/src/routing/classify/mod.rs
@@ -266,12 +266,19 @@ impl Router {
     /// Routes an incoming request to the appropriate model.
     ///
     /// Priority order (highest to lowest):
-    /// 1. WebSearch - tool-based detection (web_search tool present)
-    /// 2. Background - model name regex match (e.g., haiku) - checked early to save costs
-    /// 3. Subagent - GROB-SUBAGENT-MODEL tag in system prompt
-    /// 4. Prompt Rules - regex pattern matching on user prompt (after background for cost savings)
-    /// 5. Think - Plan Mode / reasoning enabled
-    /// 6. Default - auto-mapped or original model name
+    /// 1. WebSearch - tool-based detection (`web_search` tool present)
+    /// 2. Background - model name regex match (e.g., haiku), checked early to save costs
+    /// 3. Auto-map - regex-driven model-name rewrite (falls through to later steps)
+    /// 4. Subagent - GROB-SUBAGENT-MODEL tag in system prompt
+    /// 5. Prompt Rules - regex pattern matching on user prompt
+    /// 6. Think - Plan Mode / reasoning enabled
+    /// 7. Declarative tier match - `[[tiers.match]]` conditions (globs + keywords)
+    /// 8. Algorithmic complexity scoring - heuristic fallback when `[[scoring]]` is set
+    /// 9. Default - auto-mapped or original model name, with tier from steps 7-8
+    ///
+    /// Steps 3 (auto-map) mutates `request.model` but does not short-circuit;
+    /// steps 7-8 populate `complexity_tier` without choosing a model. All other
+    /// steps return early with the matched model.
     ///
     /// # Errors
     ///
@@ -352,8 +359,8 @@ impl Router {
             }
         }
 
-        // 8. Declarative tier match (checked FIRST, before algorithmic scorer)
-        // 9. Fallback: algorithmic complexity scoring
+        // 7. Declarative tier match (checked FIRST, before algorithmic scorer)
+        // 8. Fallback: algorithmic complexity scoring
         let tier = tier_match::evaluate_tier_matches(&self.tier_matchers, request).or_else(|| {
             self.scoring_config.as_ref().map(|cfg| {
                 let t = classify::classify_complexity(request, cfg);

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -246,15 +246,10 @@ pub(crate) async fn dispatch(
     request: &mut CanonicalRequest,
 ) -> Result<DispatchResult, AppError> {
     // ── Step 0: Resolve complexity hint ──
+    // Resolved up-front (borrows `request` immutably) but applied post-routing
+    // so the client-declared tier overrides the algorithmic scorer.
     #[cfg(feature = "mcp")]
-    {
-        let grob_hint = resolve_grob_hint(ctx, request);
-        if let Some(ref hint) = grob_hint {
-            tracing::debug!(hint = %hint, "dispatch: grob_hint resolved");
-        }
-        // NOTE: `grob_hint` will be consumed by T-P1 scoring heuristics.
-        let _ = grob_hint;
-    }
+    let grob_hint = resolve_grob_hint(ctx, request);
 
     // ── Step 1: DLP input scanning ──
     scan_dlp_input(ctx, request)?;
@@ -291,11 +286,31 @@ pub(crate) async fn dispatch(
         });
 
     // ── Step 3: Route ──
-    let decision = ctx
+    #[cfg_attr(not(feature = "mcp"), allow(unused_mut))]
+    let mut decision = ctx
         .inner
         .router
         .route(request)
         .map_err(|e| AppError::RoutingError(e.to_string()))?;
+
+    // ── Step 3.5: Apply client-declared complexity hint ──
+    // The hint (header / body metadata / MCP one-shot) overrides whatever tier
+    // the algorithmic scorer produced, so a client that knows its task is
+    // trivial can opt out of `[[tiers]]` fan-out for this request.
+    #[cfg(feature = "mcp")]
+    if let Some(hint) = grob_hint {
+        let tier = match hint {
+            ComplexityHint::Trivial => crate::routing::classify::ComplexityTier::Trivial,
+            ComplexityHint::Medium => crate::routing::classify::ComplexityTier::Medium,
+            ComplexityHint::Complex => crate::routing::classify::ComplexityTier::Complex,
+        };
+        tracing::debug!(
+            hint = %hint,
+            previous_tier = ?decision.complexity_tier,
+            "dispatch: grob_hint overrides complexity tier"
+        );
+        decision.complexity_tier = Some(tier);
+    }
 
     // ── Step 4: Resolve provider mappings ──
     let sorted_mappings = resolve_provider_mappings(ctx.inner, ctx.headers, &decision)?;


### PR DESCRIPTION
## Summary

Two quick wins from the Tier 2 audit, bundled because they share the dispatch/routing scope.

### DD-1 — audit #5: `let _ = grob_hint` in dispatch
The MCP complexity hint (`X-Grob-Hint` header, `metadata.grob_hint`, or one-shot MCP slot) was resolved and then silently dropped. It now overrides `RouteDecision.complexity_tier` right after routing, so a client that declared `trivial` opts out of `[[tiers]]` fan-out for that request.

### DD-2 — audit #6 + #14: doc drift
- **`src/routing/classify/mod.rs`**: the `route()` doc-comment listed only 6 priority levels while the actual code has 9 (auto-map, declarative tier match, and algorithmic scoring were missing). Inline numbering also had a `// 7.` gap and a duplicated `// 9.` — renumbered.
- **`docs/explanation/architecture.md`**: the request-flow Mermaid still showed the pre-T-VS `router` subgraph and a single generic "Circuit Breaker" box. Updated to the new `routing/` parent (classify + circuit_breaker + health_check), the RE-1a / RE-1b split from ADR-0018, the `is_endpoint_healthy` AND-gate, and the security-layer global CB that runs after it.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo clippy --lib --no-default-features -- -D warnings` (cfg `mcp` off)
- [x] `cargo test --lib` — 950 passed, 0 failed
- [ ] CI green

Note: pushed via GitHub Git Data API — local `git push` was silently reset (see `feedback_commis_push_ghosting.md`).