### PR TITLE
chore: release v0.36.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.30](https://github.com/azerozero/grob/compare/v0.36.29...v0.36.30) - 2026-04-21
+
+### Fixed
+
+- *(dispatch,router)* wire grob_hint + doc drift (#5 #6 #14) ([#245](https://github.com/azerozero/grob/pull/245))
+
 ## [0.36.29](https://github.com/azerozero/grob/compare/v0.36.28...v0.36.29) - 2026-04-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.29"
+version = "0.36.30"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.29"
+version = "0.36.30"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.29 -> 0.36.30

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.30](https://github.com/azerozero/grob/compare/v0.36.29...v0.36.30) - 2026-04-21

### Fixed

- *(dispatch,router)* wire grob_hint + doc drift (#5 #6 #14) ([#245](https://github.com/azerozero/grob/pull/245))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).