### PR TITLE
chore(scripts): add --help + getopts + usage() on 7 scripts (#34)

### DIFF
--- a/scripts/build-podman.sh
+++ b/scripts/build-podman.sh
@@ -1,67 +1,118 @@
-#!/bin/bash
-# Build Grob container image with Podman (rootless)
-# Usage: ./scripts/build-podman.sh [tag]
+#!/usr/bin/env bash
+#
+# Build Grob container image with Podman (rootless).
+#
+# Usage: see --help
 
-set -e
+set -euo pipefail
 
-TAG=${1:-latest}
-CONTAINERFILE="Containerfile"
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
+readonly CONTAINERFILE="Containerfile"
 
-# Colors (gated on TTY + NO_COLOR)
-if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
-    RED='\033[0;31m'
-    GREEN='\033[0;32m'
-    YELLOW='\033[1;33m'
-    NC='\033[0m'
-else
-    RED='' GREEN='' YELLOW='' NC=''
-fi
+usage() {
+  cat <<EOF
+${SCRIPT_NAME} - Build Grob container image with Podman (rootless)
 
-echo -e "${GREEN}Building Grob container image with Podman...${NC}"
-echo "Tag: ${TAG}"
-echo "Containerfile: ${CONTAINERFILE}"
-echo ""
+Usage: ${SCRIPT_NAME} [options] [tag]
 
-# Check Podman is available
-if ! command -v podman &> /dev/null; then
-    echo -e "${RED}Error: Podman is not installed${NC}"
+Arguments:
+  tag              Image tag (default: latest)
+
+Options:
+  -h, --help       Show this help and exit
+  -v, --verbose    Enable verbose output (shell trace)
+
+Examples:
+  ${SCRIPT_NAME}
+  ${SCRIPT_NAME} v0.1.0
+  ${SCRIPT_NAME} --verbose latest
+
+Exit codes:
+  0  success
+  1  error (missing podman, wrong directory, build failure)
+EOF
+}
+
+main() {
+  local verbose=0
+  while getopts "hv-:" opt; do
+    case "${opt}" in
+      h) usage; exit 0 ;;
+      v) verbose=1 ;;
+      -)
+        case "${OPTARG}" in
+          help) usage; exit 0 ;;
+          verbose) verbose=1 ;;
+          *) echo "Unknown option --${OPTARG}" >&2; usage >&2; exit 1 ;;
+        esac
+        ;;
+      *) usage >&2; exit 1 ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+
+  if [[ "${verbose}" -eq 1 ]]; then
+    set -x
+  fi
+
+  local tag="${1:-latest}"
+
+  local red green yellow nc
+  if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+    red='\033[0;31m'
+    green='\033[0;32m'
+    yellow='\033[1;33m'
+    nc='\033[0m'
+  else
+    red='' green='' yellow='' nc=''
+  fi
+
+  echo -e "${green}Building Grob container image with Podman...${nc}"
+  echo "Tag: ${tag}"
+  echo "Containerfile: ${CONTAINERFILE}"
+  echo ""
+
+  if ! command -v podman &> /dev/null; then
+    echo -e "${red}Error: Podman is not installed${nc}"
     echo "Install with: sudo apt install podman  # Debian/Ubuntu"
     echo "             : sudo dnf install podman  # Fedora"
     echo "             : brew install podman      # macOS"
     exit 1
-fi
+  fi
 
-# Check we're in the project root
-if [ ! -f "Cargo.toml" ]; then
-    echo -e "${RED}Error: Must run from project root${NC}"
+  if [ ! -f "Cargo.toml" ]; then
+    echo -e "${red}Error: Must run from project root${nc}"
     exit 1
-fi
+  fi
 
-# Build with Podman
-echo -e "${YELLOW}Building image (this may take a few minutes)...${NC}"
-podman build \
-    --tag "grob:${TAG}" \
+  echo -e "${yellow}Building image (this may take a few minutes)...${nc}"
+  podman build \
+    --tag "grob:${tag}" \
     --file "${CONTAINERFILE}" \
     --format oci \
     --layers \
     .
 
-echo ""
-echo -e "${GREEN}Build successful!${NC}"
-echo ""
-echo "Image: grob:${TAG}"
-echo ""
-echo "To run (rootless):"
-echo "  podman play kube grob-kube.yml"
-echo ""
-echo "Or with Quadlet (systemd):"
-echo "  mkdir -p ~/.config/containers/systemd"
-echo "  cp grob.container ~/.config/containers/systemd/"
-echo "  cp grob.volume ~/.config/containers/systemd/"
-echo "  systemctl --user daemon-reload"
-echo "  systemctl --user enable --now grob"
-echo ""
-echo "To check status:"
-echo "  podman ps"
-echo "  podman logs grob"
-echo "  curl http://localhost:8080/health"
+  echo ""
+  echo -e "${green}Build successful!${nc}"
+  echo ""
+  echo "Image: grob:${tag}"
+  echo ""
+  echo "To run (rootless):"
+  echo "  podman play kube grob-kube.yml"
+  echo ""
+  echo "Or with Quadlet (systemd):"
+  echo "  mkdir -p ~/.config/containers/systemd"
+  echo "  cp grob.container ~/.config/containers/systemd/"
+  echo "  cp grob.volume ~/.config/containers/systemd/"
+  echo "  systemctl --user daemon-reload"
+  echo "  systemctl --user enable --now grob"
+  echo ""
+  echo "To check status:"
+  echo "  podman ps"
+  echo "  podman logs grob"
+  echo "  curl http://localhost:8080/health"
+}
+
+main "$@"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,16 +1,69 @@
 #!/usr/bin/env bash
-# Build script for Grob with security modules
+#
+# Build script for Grob with security modules.
+#
+# Usage: see --help
+
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "${SCRIPT_DIR}/.."
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
 
-echo "Building Grob with full security stack..."
+usage() {
+  cat <<EOF
+${SCRIPT_NAME} - Build Grob with full security stack
 
-echo "Running security tests..."
-cargo test --lib security:: 2>&1 | head -50
+Usage: ${SCRIPT_NAME} [options]
 
-echo "Checking compilation..."
-cargo check --release --features tls
+Options:
+  -h, --help       Show this help and exit
+  -v, --verbose    Enable verbose output (shell trace)
 
-echo "Build complete!"
+Examples:
+  ${SCRIPT_NAME}
+  ${SCRIPT_NAME} --verbose
+
+Exit codes:
+  0  success
+  1  error
+EOF
+}
+
+main() {
+  local verbose=0
+  while getopts "hv-:" opt; do
+    case "${opt}" in
+      h) usage; exit 0 ;;
+      v) verbose=1 ;;
+      -)
+        case "${OPTARG}" in
+          help) usage; exit 0 ;;
+          verbose) verbose=1 ;;
+          *) echo "Unknown option --${OPTARG}" >&2; usage >&2; exit 1 ;;
+        esac
+        ;;
+      *) usage >&2; exit 1 ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+
+  if [[ "${verbose}" -eq 1 ]]; then
+    set -x
+  fi
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  cd "${script_dir}/.."
+
+  echo "Building Grob with full security stack..."
+
+  echo "Running security tests..."
+  cargo test --lib security:: 2>&1 | head -50
+
+  echo "Checking compilation..."
+  cargo check --release --features tls
+
+  echo "Build complete!"
+}
+
+main "$@"

--- a/scripts/cleancode-audit.sh
+++ b/scripts/cleancode-audit.sh
@@ -1,29 +1,76 @@
 #!/usr/bin/env bash
-# cleancode-audit.sh — Static clean code analysis for Rust projects.
-# Generates a Markdown plan of violations to fix.
 #
-# Usage: ./scripts/cleancode-audit.sh [src_dir] [output_file]
-#   src_dir     — directory to scan (default: src/)
-#   output_file — markdown output (default: cleancode-plan.md)
+# Static clean code analysis for Rust projects. Generates a Markdown
+# plan of violations to fix.
 #
-# Rules covered (19):
-#   Structure:  file length, items after test module
-#   Functions:  function length, parameter count
-#   Naming:     magic numbers
-#   DRY:        (basic — repeated error patterns)
-#   Error:      unwrap, expect, panic/unreachable, swallowed errors, poisoned locks
-#   Idioms:     dead_code, clippy suppression, wildcard imports, &String/&Vec params
-#   Tests:      missing test modules
-#   Cognitive:  nesting depth
-#   Docs:       missing pub doc comments
-#   Markers:    TODO/FIXME/HACK
+# Usage: see --help
 
-# Note: not using set -e because grep returns exit 1 on no matches,
-# which is expected and frequent in an analysis script.
+# Note: deliberately not using `set -e` — grep returns exit 1 on no
+# matches, which is expected and frequent in an analysis script.
+# `set -o pipefail` is also avoided for the same reason.
 set -u
 
-SRC_DIR="${1:-src}"
-OUTPUT="${2:-cleancode-plan.md}"
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
+
+usage() {
+  cat <<EOF
+${SCRIPT_NAME} - Static clean code analysis for Rust projects
+
+Scans a Rust source tree and generates a Markdown plan listing clean
+code violations grouped by severity (critical, flag, info).
+
+Rules covered (19):
+  Structure:  file length, items after test module
+  Functions:  function length, parameter count
+  Naming:     magic numbers
+  DRY:        repeated error patterns
+  Error:      unwrap, expect, panic/unreachable, swallowed errors, poisoned locks
+  Idioms:     dead_code, clippy suppression, wildcard imports, &String/&Vec params
+  Tests:      missing test modules
+  Cognitive:  nesting depth
+  Docs:       missing pub doc comments
+  Markers:    TODO/FIXME/HACK
+
+Usage: ${SCRIPT_NAME} [options] [src_dir] [output_file]
+
+Arguments:
+  src_dir          Directory to scan (default: src)
+  output_file      Markdown output path (default: cleancode-plan.md)
+
+Options:
+  -h, --help       Show this help and exit
+  -v, --verbose    Enable verbose output (shell trace)
+
+Examples:
+  ${SCRIPT_NAME}
+  ${SCRIPT_NAME} src/providers
+  ${SCRIPT_NAME} src audit.md
+
+Exit codes:
+  0  success (plan written; violations may still exist)
+  1  argument parsing error
+EOF
+}
+
+verbose=0
+positional=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    -v|--verbose) verbose=1; shift ;;
+    --) shift; while [ $# -gt 0 ]; do positional+=("$1"); shift; done ;;
+    -*) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    *) positional+=("$1"); shift ;;
+  esac
+done
+
+if [ "${verbose}" -eq 1 ]; then
+  set -x
+fi
+
+SRC_DIR="${positional[0]:-src}"
+OUTPUT="${positional[1]:-cleancode-plan.md}"
 
 # --- Thresholds ---
 FILE_LINES_FLAG=500

--- a/scripts/codeql-check.sh
+++ b/scripts/codeql-check.sh
@@ -1,42 +1,97 @@
 #!/usr/bin/env bash
-# CodeQL security analysis for grob.
-# Usage: ./scripts/codeql-check.sh [--sarif results.sarif]
 #
-# Creates a fresh CodeQL database, runs security-extended queries,
-# and reports findings. Exit code 0 = no alerts, 1 = alerts found.
+# CodeQL security analysis for grob.
+#
+# Usage: see --help
 
 set -euo pipefail
 
-DB_DIR="${CODEQL_DB:-codeql-db}"
-OUTPUT="${1:---format=csv}"
-SARIF_FILE=""
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
 
-if [[ "${1:-}" == "--sarif" ]]; then
-    SARIF_FILE="${2:-results.sarif}"
-    OUTPUT="--format=sarif-latest --output=$SARIF_FILE"
-fi
+usage() {
+  cat <<EOF
+${SCRIPT_NAME} - CodeQL security analysis for grob
 
-echo "Creating CodeQL database..."
-codeql database create "$DB_DIR" \
+Creates a fresh CodeQL database, runs security-extended queries,
+and reports findings.
+
+Usage: ${SCRIPT_NAME} [options]
+       ${SCRIPT_NAME} --sarif [file]
+
+Options:
+  -h, --help            Show this help and exit
+  -v, --verbose         Enable verbose output (shell trace)
+  --sarif [file]        Emit SARIF output (default file: results.sarif)
+
+Environment:
+  CODEQL_DB             Database directory (default: codeql-db)
+
+Examples:
+  ${SCRIPT_NAME}
+  ${SCRIPT_NAME} --sarif
+  ${SCRIPT_NAME} --sarif custom.sarif
+
+Exit codes:
+  0  no alerts (or CSV run completed)
+  1  alerts found (SARIF mode) or error
+EOF
+}
+
+main() {
+  local verbose=0
+  local sarif_file=""
+  local output="--format=csv"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -v|--verbose) verbose=1; shift ;;
+      --sarif)
+        shift
+        sarif_file="${1:-results.sarif}"
+        if [[ -n "${1:-}" && ! "$1" =~ ^-- ]]; then
+          shift
+        fi
+        output="--format=sarif-latest --output=${sarif_file}"
+        ;;
+      *)
+        echo "Unknown option: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ "${verbose}" -eq 1 ]]; then
+    set -x
+  fi
+
+  local db_dir="${CODEQL_DB:-codeql-db}"
+
+  echo "Creating CodeQL database..."
+  codeql database create "${db_dir}" \
     --language=rust \
     --source-root=. \
     --overwrite \
     --threads=0 \
     2>&1 | tail -3
 
-echo ""
-echo "Running security analysis..."
+  echo ""
+  echo "Running security analysis..."
 
-# shellcheck disable=SC2086
-RESULTS=$(codeql database analyze "$DB_DIR" \
+  local results
+  # shellcheck disable=SC2086
+  results=$(codeql database analyze "${db_dir}" \
     --threads=0 \
-    $OUTPUT \
+    ${output} \
     2>&1)
 
-echo "$RESULTS"
+  echo "${results}"
 
-if [[ -n "$SARIF_FILE" ]] && [[ -f "$SARIF_FILE" ]]; then
-    ALERT_COUNT=$(SARIF_FILE="$SARIF_FILE" python3 -c "
+  if [[ -n "${sarif_file}" ]] && [[ -f "${sarif_file}" ]]; then
+    local alert_count
+    alert_count=$(SARIF_FILE="${sarif_file}" python3 -c "
 import json, os
 with open(os.environ['SARIF_FILE']) as f:
     d = json.load(f)
@@ -44,9 +99,12 @@ with open(os.environ['SARIF_FILE']) as f:
     print(total)
 " 2>/dev/null || echo "?")
     echo ""
-    echo "Alerts found: $ALERT_COUNT"
-    echo "SARIF saved to: $SARIF_FILE"
-    if [[ "$ALERT_COUNT" != "0" ]] && [[ "$ALERT_COUNT" != "?" ]]; then
-        exit 1
+    echo "Alerts found: ${alert_count}"
+    echo "SARIF saved to: ${sarif_file}"
+    if [[ "${alert_count}" != "0" ]] && [[ "${alert_count}" != "?" ]]; then
+      exit 1
     fi
-fi
+  fi
+}
+
+main "$@"

--- a/scripts/install-rootless.sh
+++ b/scripts/install-rootless.sh
@@ -1,40 +1,85 @@
-#!/bin/bash
-# Install Grob as a rootless Podman container with systemd
-# Usage: ./scripts/install-rootless.sh
+#!/usr/bin/env bash
+#
+# Install Grob as a rootless Podman container with systemd.
+#
+# Usage: see --help
 
-set -e
+set -euo pipefail
 
-GROB_DIR="${HOME}/.grob"
-CONFIG_DIR="${GROB_DIR}/config"
-DATA_DIR="${GROB_DIR}/data"
-QUADLET_DIR="${HOME}/.config/containers/systemd"
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
+readonly GROB_DIR="${HOME}/.grob"
+readonly CONFIG_DIR="${GROB_DIR}/config"
+readonly DATA_DIR="${GROB_DIR}/data"
+readonly QUADLET_DIR="${HOME}/.config/containers/systemd"
 
-# Colors (gated on TTY + NO_COLOR)
-if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
-    RED='\033[0;31m'
-    GREEN='\033[0;32m'
-    YELLOW='\033[1;33m'
-    NC='\033[0m'
-else
-    RED='' GREEN='' YELLOW='' NC=''
-fi
+usage() {
+  cat <<EOF
+${SCRIPT_NAME} - Install Grob as a rootless Podman container
 
-echo -e "${GREEN}Installing Grob as rootless Podman container...${NC}"
+Creates ~/.grob/{config,data} and installs systemd Quadlet units.
+Generates a default config.toml if none exists.
 
-# Check Podman
-if ! command -v podman &> /dev/null; then
-    echo -e "${RED}Podman not found. Please install first.${NC}"
+Usage: ${SCRIPT_NAME} [options]
+
+Options:
+  -h, --help       Show this help and exit
+  -v, --verbose    Enable verbose output (shell trace)
+
+Examples:
+  ${SCRIPT_NAME}
+  ${SCRIPT_NAME} --verbose
+
+Exit codes:
+  0  success
+  1  error (missing podman)
+EOF
+}
+
+main() {
+  local verbose=0
+  while getopts "hv-:" opt; do
+    case "${opt}" in
+      h) usage; exit 0 ;;
+      v) verbose=1 ;;
+      -)
+        case "${OPTARG}" in
+          help) usage; exit 0 ;;
+          verbose) verbose=1 ;;
+          *) echo "Unknown option --${OPTARG}" >&2; usage >&2; exit 1 ;;
+        esac
+        ;;
+      *) usage >&2; exit 1 ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+
+  if [[ "${verbose}" -eq 1 ]]; then
+    set -x
+  fi
+
+  local red green nc
+  if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+    red='\033[0;31m'
+    green='\033[0;32m'
+    nc='\033[0m'
+  else
+    red='' green='' nc=''
+  fi
+
+  echo -e "${green}Installing Grob as rootless Podman container...${nc}"
+
+  if ! command -v podman &> /dev/null; then
+    echo -e "${red}Podman not found. Please install first.${nc}"
     exit 1
-fi
+  fi
 
-# Create directories
-echo "Creating directories..."
-mkdir -p "${CONFIG_DIR}"
-mkdir -p "${DATA_DIR}"
-mkdir -p "${QUADLET_DIR}"
+  echo "Creating directories..."
+  mkdir -p "${CONFIG_DIR}"
+  mkdir -p "${DATA_DIR}"
+  mkdir -p "${QUADLET_DIR}"
 
-# Generate default config if not exists
-if [ ! -f "${CONFIG_DIR}/config.toml" ]; then
+  if [ ! -f "${CONFIG_DIR}/config.toml" ]; then
     echo "Creating default config..."
     cat > "${CONFIG_DIR}/config.toml" << 'EOF'
 # Grob Configuration
@@ -67,36 +112,36 @@ encrypt = true
 level = "info"
 format = "json"
 EOF
-fi
+  fi
 
-# Install Quadlet files
-echo "Installing systemd unit files..."
-if [ -f "grob.container" ]; then
+  echo "Installing systemd unit files..."
+  if [ -f "grob.container" ]; then
     cp grob.container "${QUADLET_DIR}/"
-fi
+  fi
 
-if [ -f "grob.volume" ]; then
+  if [ -f "grob.volume" ]; then
     cp grob.volume "${QUADLET_DIR}/"
-fi
+  fi
 
-# Reload systemd
-echo "Reloading systemd..."
-systemctl --user daemon-reload
+  echo "Reloading systemd..."
+  systemctl --user daemon-reload
 
-# Enable service
-echo "Enabling Grob service..."
-systemctl --user enable grob 2>/dev/null || true
+  echo "Enabling Grob service..."
+  systemctl --user enable grob 2>/dev/null || true
 
-echo ""
-echo -e "${GREEN}Installation complete!${NC}"
-echo ""
-echo "To start Grob:"
-echo "  systemctl --user start grob"
-echo ""
-echo "To check status:"
-echo "  systemctl --user status grob"
-echo "  podman logs grob"
-echo "  curl http://localhost:8080/health"
-echo ""
-echo "Config directory: ${CONFIG_DIR}"
-echo "Data directory: ${DATA_DIR}"
+  echo ""
+  echo -e "${green}Installation complete!${nc}"
+  echo ""
+  echo "To start Grob:"
+  echo "  systemctl --user start grob"
+  echo ""
+  echo "To check status:"
+  echo "  systemctl --user status grob"
+  echo "  podman logs grob"
+  echo "  curl http://localhost:8080/health"
+  echo ""
+  echo "Config directory: ${CONFIG_DIR}"
+  echo "Data directory: ${DATA_DIR}"
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,60 @@
 #!/bin/sh
-# Grob installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install.sh | sh
+#
+# Grob installer — POSIX sh compatible for curl|sh usage.
+#
+# Usage: see --help
+#
+# Note: this script intentionally targets POSIX sh (not bash) so it can
+# be piped through `curl ... | sh`. Bashisms (set -o pipefail, getopts
+# long-opts, [[ ]]) must not be used here.
 set -eu
 
+SCRIPT_NAME=$(basename "$0")
 BINARY_NAME="grob"
 REPO="azerozero/grob"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+usage() {
+    cat <<EOF
+${SCRIPT_NAME} - Grob installer
+
+Downloads the latest release binary from GitHub and installs it to
+\${INSTALL_DIR} (default: \$HOME/.local/bin).
+
+Usage: ${SCRIPT_NAME} [options]
+
+Options:
+  -h, --help       Show this help and exit
+  -v, --verbose    Enable verbose output (shell trace)
+
+Environment:
+  INSTALL_DIR      Install destination (default: \$HOME/.local/bin)
+  VERSION          Specific version tag to install (default: latest)
+
+Examples:
+  ${SCRIPT_NAME}
+  curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install.sh | sh
+  INSTALL_DIR=/usr/local/bin ${SCRIPT_NAME}
+  VERSION=v0.36.0 ${SCRIPT_NAME}
+
+Exit codes:
+  0  success
+  1  error (unsupported platform, download failure, checksum mismatch)
+EOF
+}
+
+verbose=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        -v|--verbose) verbose=1; shift ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [ "${verbose}" -eq 1 ]; then
+    set -x
+fi
 
 detect_target() {
     OS="$(uname -s)"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,57 +1,107 @@
-#!/bin/bash
-# TDD Test Runner for Claude Code Mux
+#!/usr/bin/env bash
+#
+# TDD test runner for Grob (unit + doc tests).
+#
+# Usage: see --help
 
-set -e
+set -euo pipefail
 
-echo "Running Claude Code Mux Test Suite"
-echo "=================================="
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
 
-# Colors (gated on TTY + NO_COLOR)
-if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+usage() {
+  cat <<EOF
+${SCRIPT_NAME} - TDD test runner for Grob
+
+Runs unit tests and doc tests via cargo test. Returns non-zero if any
+test type fails.
+
+Usage: ${SCRIPT_NAME} [options]
+
+Options:
+  -h, --help       Show this help and exit
+  -v, --verbose    Enable verbose output (shell trace)
+
+Examples:
+  ${SCRIPT_NAME}
+  ${SCRIPT_NAME} --verbose
+
+Exit codes:
+  0  all tests passed
+  1  one or more test suites failed
+EOF
+}
+
+# Color vars are set in main() and consumed here via globals.
+run_tests() {
+  local test_type=$1
+  local color=$2
+
+  echo -e "${color}Running ${test_type} tests...${NC}"
+
+  if cargo test "${test_type}" -- --nocapture; then
+    echo -e "${GREEN}PASS: ${test_type} tests passed${NC}"
+    return 0
+  else
+    echo -e "${RED}FAIL: ${test_type} tests failed${NC}"
+    return 1
+  fi
+}
+
+main() {
+  local verbose=0
+  while getopts "hv-:" opt; do
+    case "${opt}" in
+      h) usage; exit 0 ;;
+      v) verbose=1 ;;
+      -)
+        case "${OPTARG}" in
+          help) usage; exit 0 ;;
+          verbose) verbose=1 ;;
+          *) echo "Unknown option --${OPTARG}" >&2; usage >&2; exit 1 ;;
+        esac
+        ;;
+      *) usage >&2; exit 1 ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+
+  if [[ "${verbose}" -eq 1 ]]; then
+    set -x
+  fi
+
+  echo "Running Grob Test Suite"
+  echo "=================================="
+
+  if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
     RED='\033[0;31m'
     GREEN='\033[0;32m'
     YELLOW='\033[1;33m'
     NC='\033[0m'
-else
+  else
     RED='' GREEN='' YELLOW='' NC=''
-fi
+  fi
+  export RED GREEN YELLOW NC
 
-# Function to run tests
-run_tests() {
-    local test_type=$1
-    local color=$2
+  local failed=0
 
-    echo -e "${color}Running $test_type tests...${NC}"
+  if ! run_tests "unit" "${GREEN}"; then
+    failed=1
+  fi
 
-    if cargo test "$test_type" -- --nocapture; then
-        echo -e "${GREEN}✓ $test_type tests passed${NC}"
-        return 0
-    else
-        echo -e "${RED}✗ $test_type tests failed${NC}"
-        return 1
-    fi
+  if ! run_tests "--doc" "${YELLOW}"; then
+    failed=1
+  fi
+
+  echo ""
+  echo "=================================="
+  if [ ${failed} -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+  else
+    echo -e "${RED}Some tests failed${NC}"
+  fi
+
+  exit ${failed}
 }
 
-# Track results
-FAILED=0
-
-# Run unit tests
-if ! run_tests "unit" "$GREEN"; then
-    FAILED=1
-fi
-
-# Run doc tests
-if ! run_tests "--doc" "$YELLOW"; then
-    FAILED=1
-fi
-
-# Summary
-echo ""
-echo "=================================="
-if [ $FAILED -eq 0 ]; then
-    echo -e "${GREEN}All tests passed!${NC}"
-else
-    echo -e "${RED}Some tests failed${NC}"
-fi
-
-exit $FAILED
+main "$@"


### PR DESCRIPTION
## Summary

Aligns `scripts/*.sh` with the Google Shell Style Guide and audit item #34:

- `#!/usr/bin/env bash` + `set -euo pipefail` on every bash script
- `usage()` helper with synopsis, options, examples, exit codes on every script
- Unified `-h`/`--help` and `-v`/`--verbose` parsing via `getopts` (or while-loop where long opts / positional interleave is needed)
- `UPPER_SNAKE_CASE` constants, `lower_snake_case` locals
- Zero emoji in usage output

## Scope

| Script | Strict mode | Parser | Notes |
|---|---|---|---|
| `build.sh` | `set -euo pipefail` | getopts | — |
| `build-podman.sh` | `set -euo pipefail` | getopts | positional `[tag]` preserved |
| `codeql-check.sh` | `set -euo pipefail` | while (long opts) | `--sarif [file]` retained |
| `install-rootless.sh` | `set -euo pipefail` | getopts | — |
| `install.sh` | `set -eu` (POSIX sh, no pipefail) | while | intentionally stays `#!/bin/sh` for `curl \| sh` compatibility |
| `run_tests.sh` | `set -euo pipefail` | getopts | — |
| `cleancode-audit.sh` | `set -u` (no -e, no pipefail) | while | intentionally keeps no-`-e` — grep returns 1 on no match and the analysis depends on that |

## Zero behavior change

Each commit preserves the semantics of the original script: binaries built, installers executed, tests run, analyses produced the same output. Long-option support is additive.

## Test plan

- [x] `bash -n` / `sh -n` on each script
- [x] `shellcheck scripts/*.sh` (bash + POSIX for `install.sh`) — 0 warnings
- [x] `--help` and `-h` emit usage on every script
- [x] Unknown option (`--nonexistent`) returns exit 1 on every script
- [x] `cleancode-audit.sh src output.md` smoke-tested end-to-end