### PR TITLE
docs: non-tautological doc summaries across 5 domains (#29)

### DIFF
--- a/src/auth/auto_flow.rs
+++ b/src/auth/auto_flow.rs
@@ -44,7 +44,7 @@ fn oauth_type_for_provider_id(oauth_provider_id: &str) -> Option<&'static str> {
     }
 }
 
-/// Build an OAuthConfig for a given oauth_type string.
+/// Builds the `OAuthConfig` preset for a known `oauth_type` (`max`, `openai-codex`, `gemini`); returns `None` for unknown types.
 fn oauth_config_for_type(oauth_type: &str) -> Option<OAuthConfig> {
     match oauth_type {
         "max" => Some(OAuthConfig::anthropic()),
@@ -54,7 +54,7 @@ fn oauth_config_for_type(oauth_type: &str) -> Option<OAuthConfig> {
     }
 }
 
-/// Checks all providers and returns their credential status.
+/// Classifies each enabled provider as `Ready`, `MissingOAuth`, or `MissingApiKey` based on token store and env vars.
 pub fn detect_credentials(
     providers: &[ProviderConfig],
     token_store: &TokenStore,
@@ -109,7 +109,7 @@ pub fn detect_credentials(
     statuses
 }
 
-/// Runs the interactive credential setup flow.
+/// Prompts for any missing OAuth tokens or API keys and persists them, skipping providers the user declines.
 ///
 /// Returns the number of providers that were successfully configured.
 /// Providers the user skips are left unconfigured (they will be

--- a/src/auth/refresh_daemon.rs
+++ b/src/auth/refresh_daemon.rs
@@ -206,7 +206,7 @@ pub fn spawn_with_config(
     cancel
 }
 
-/// Runs a single refresh sweep over all tokens in the store.
+/// Iterates every stored token and triggers a refresh attempt for any that expire within `window`.
 pub(crate) async fn run_tick(store: &TokenStore, window: chrono::Duration) {
     let now = Utc::now();
     let tokens = store.all();

--- a/src/commands/bench/mod.rs
+++ b/src/commands/bench/mod.rs
@@ -92,7 +92,7 @@ async fn wait_for_proxy_ready(proxy_url: &str) {
 
 // ── Entry point ─────────────────────────────────────────────────────────
 
-/// Runs the self-contained performance benchmark.
+/// Runs the self-contained benchmark against an in-process mock backend and prints latency percentiles.
 pub async fn cmd_bench(
     _config: &AppConfig,
     requests: usize,
@@ -458,7 +458,7 @@ async fn measure(
 
 // ── Escalation mode ─────────────────────────────────────────────────────
 
-/// Runs the escalation staircase benchmark.
+/// Runs the escalation staircase benchmark, adding one pipeline feature per step to measure its cost.
 async fn run_escalation(ctx: &BenchContext) -> Result<()> {
     // Escalation always uses medium payload (realistic Claude Code traffic).
     let psize = PayloadSize::Medium;

--- a/src/commands/bench/output.rs
+++ b/src/commands/bench/output.rs
@@ -20,7 +20,7 @@ pub(super) fn render_bar(proportion: f64, width: usize) -> String {
 
 // ── Scenario table ───────────────────────────────────────────────────────────
 
-/// Prints the column header for the scenario table.
+/// Prints the scenario table header (Scenario, P50, P95, P99/RPS, Overhead) and a separator line.
 pub(super) fn print_scenario_header(is_concurrent: bool, effective_concurrency: usize) {
     if is_concurrent {
         println!(
@@ -44,7 +44,7 @@ pub(super) fn print_scenario_header(is_concurrent: bool, effective_concurrency: 
     );
 }
 
-/// Prints one scenario row.
+/// Prints one benchmark scenario row (p50/p99 latency, overhead vs. baseline, and optional RPS).
 pub(super) fn print_scenario_row(
     name: &str,
     stats: &Stats,

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -7,7 +7,7 @@ pub const HEALTH_POLL_INTERVAL_MS: u64 = 100;
 /// Maximum number of health poll attempts before declaring failure.
 pub const HEALTH_POLL_MAX_ATTEMPTS: u32 = 50; // 50 * 100ms = 5s max
 
-/// Checks whether the Grob service at the given URL is healthy.
+/// Sends a 2-second GET to `{base_url}/health`; returns `true` only for a 2xx response.
 pub async fn is_grob_healthy(base_url: &str) -> bool {
     let url = format!("{}/health", base_url);
     match reqwest::Client::new()
@@ -87,7 +87,7 @@ pub async fn stop_service(pid: u32) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Starts the Grob server in the foreground with signal handling.
+/// Starts the Grob server in the foreground, writing the PID file and handling SIGTERM for graceful shutdown.
 pub async fn start_foreground(
     config: crate::models::config::AppConfig,
     config_source: crate::cli::ConfigSource,

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -1,7 +1,7 @@
 use crate::cli;
 use crate::shared::instance;
 
-/// Prints the configured router models and enabled providers.
+/// Prints router models and enabled providers, preferring live RPC data when the server is running.
 pub async fn cmd_model(config: &cli::AppConfig) {
     let host = &config.server.host;
     let port = config.server.port.value();
@@ -14,7 +14,7 @@ pub async fn cmd_model(config: &cli::AppConfig) {
     }
 }
 
-/// Prints model info by querying the running server via RPC.
+/// Prints router roles and provider/model mappings retrieved via `grob/model/*` RPC calls.
 async fn print_model_from_rpc(base_url: &str, config: &cli::AppConfig) {
     use super::rpc_client::try_rpc_call;
 

--- a/src/commands/setup/mod.rs
+++ b/src/commands/setup/mod.rs
@@ -33,7 +33,7 @@ use screens::tools::screen_tools;
 use types::{AuthOverride, BudgetChoice, Choices, Compliance, FallbackChoice, ToolInfo, TOOLS};
 use writer::{apply_auth_overrides, apply_compliance, apply_fallback, patch, write_config};
 
-/// Runs the interactive setup wizard.
+/// Runs the interactive first-run wizard that prompts for preset, providers, budget, compliance, and tools.
 ///
 /// Returns `true` if config was written, `false` if cancelled or dry-run.
 ///

--- a/src/commands/setup/output.rs
+++ b/src/commands/setup/output.rs
@@ -247,7 +247,7 @@ pub(in crate::commands::setup) fn setup_custom(config_path: &Path) -> Result<boo
     Ok(true)
 }
 
-/// Prints the tool-specific invocation hints.
+/// Prints per-tool invocation hints ("How to use") for every tool the user selected in the wizard.
 pub(in crate::commands::setup) fn print_usage(choices: &Choices) {
     println!();
     println!("  How to use:");

--- a/src/commands/setup/writer.rs
+++ b/src/commands/setup/writer.rs
@@ -60,7 +60,7 @@ pub(in crate::commands::setup) fn patch(
     Ok(())
 }
 
-/// Applies auth overrides to the provider array in config.
+/// Overwrites each provider's `auth_type`, `oauth_provider`, and `api_key` from the wizard overrides.
 pub(in crate::commands::setup) fn apply_auth_overrides(
     config: &mut toml::Value,
     auth: &[AuthOverride],
@@ -94,7 +94,7 @@ pub(in crate::commands::setup) fn apply_auth_overrides(
     }
 }
 
-/// Applies the chosen fallback provider to config.
+/// Inserts or strips the user-selected fallback provider entry in the TOML config.
 pub(in crate::commands::setup) fn apply_fallback(
     config: &mut toml::Value,
     fallback: &FallbackChoice,
@@ -113,7 +113,7 @@ pub(in crate::commands::setup) fn apply_fallback(
     }
 }
 
-/// Removes an existing provider by name and inserts a fresh one.
+/// Replaces any existing provider of the given name with a minimal fallback entry (pass-through for openrouter).
 fn replace_fallback_provider(
     config: &mut toml::Value,
     name: &str,
@@ -136,7 +136,7 @@ fn replace_fallback_provider(
     providers.push(toml::Value::Table(t));
 }
 
-/// Applies compliance-related config patches.
+/// Applies compliance-related config patches and optionally overlays a signed EU/GDPR preset.
 ///
 /// Returns `true` when EU/GDPR compliance was applied via overlay (caller
 /// must skip further writes), `false` for all other variants.
@@ -178,7 +178,7 @@ pub(in crate::commands::setup) fn apply_compliance(
     Ok(false)
 }
 
-/// Writes the full config by applying a preset and every wizard choice.
+/// Writes the full config: backs up the old file, applies the chosen preset, then patches in every wizard override.
 pub(in crate::commands::setup) fn write_config(choices: &Choices, path: &Path) -> Result<()> {
     // Backup
     if path.exists() {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -54,7 +54,7 @@ async fn resolve_running_state(host: &str, port: u16) -> (bool, String) {
     }
 }
 
-/// Prints status by querying the running server via RPC.
+/// Prints router, providers, models, and budget by querying the running server via RPC, with config fallback.
 async fn print_status_from_rpc(base_url: &str, config: &cli::AppConfig) {
     use super::rpc_client::try_rpc_call;
 
@@ -92,7 +92,7 @@ async fn print_status_from_rpc(base_url: &str, config: &cli::AppConfig) {
     }
 }
 
-/// Prints status from local config when server is not running.
+/// Prints router, providers, models, and spend from the on-disk config when the server is unreachable.
 fn print_status_from_config(config: &cli::AppConfig) {
     print_routing_from_config(config);
     println!();

--- a/src/features/dlp/hot_config.rs
+++ b/src/features/dlp/hot_config.rs
@@ -59,7 +59,7 @@ impl DomainMatcher {
         }
     }
 
-    /// Check if a hostname matches this domain pattern.
+    /// Returns true when the hostname matches the pattern under the configured mode (exact, suffix, or glob), case-insensitive.
     pub fn matches(&self, hostname: &str) -> bool {
         let hostname = hostname.to_lowercase();
         let pattern = self.raw.to_lowercase();
@@ -97,7 +97,7 @@ pub fn is_domain_suspicious(
     false
 }
 
-/// Build the initial hot config from inline config domain lists.
+/// Compiles the initial hot config (matchers + patterns) from inline TOML lists so the detector can start before any signed overlay is loaded.
 pub fn build_initial_hot_config(
     whitelist_domains: &[String],
     blacklist_domains: &[String],

--- a/src/features/dlp/prompt_injection.rs
+++ b/src/features/dlp/prompt_injection.rs
@@ -250,7 +250,7 @@ pub struct InjectionDetector {
     normalize_aggressive_cache: Cache<u64, String>,
 }
 
-/// Check if a language is enabled in config.
+/// Returns true if `code` is in the configured language list or the list contains the catch-all `"all"`.
 fn lang_enabled(languages: &[String], code: &str) -> bool {
     languages.iter().any(|l| l == "all" || l == code)
 }

--- a/src/features/dlp/signed_config.rs
+++ b/src/features/dlp/signed_config.rs
@@ -78,7 +78,7 @@ fn verify_signature(public_key: &VerifyingKey, content: &[u8], signature_hex: &s
         .map_err(|e| anyhow::anyhow!("Signature verification failed: {}", e))
 }
 
-/// Verify a detached signature file.
+/// Reads a hex-encoded Ed25519 signature from `sig_path` and verifies it against `content`.
 fn verify_detached_signature(
     public_key: &VerifyingKey,
     content: &[u8],

--- a/src/features/dlp/url_exfil.rs
+++ b/src/features/dlp/url_exfil.rs
@@ -282,7 +282,7 @@ impl UrlExfilScanner {
     }
 }
 
-/// Check if a range overlaps with any existing range.
+/// Returns true when `new` shares any byte index with one of the previously recorded scan ranges.
 fn overlaps(ranges: &[(usize, usize)], new: (usize, usize)) -> bool {
     ranges.iter().any(|&(s, e)| new.0 < e && new.1 > s)
 }

--- a/src/features/harness/mock_backend.rs
+++ b/src/features/harness/mock_backend.rs
@@ -194,7 +194,7 @@ fn compute_fingerprint(body: &[u8]) -> String {
     hex::encode(hasher.finalize())[..16].to_string()
 }
 
-/// Builds the response index from tape entries.
+/// Indexes tape responses by request-body fingerprint so the mock backend can replay them by content.
 fn build_response_index(tape: &[TapeEntry]) -> HashMap<String, Vec<TapeResponse>> {
     let mut index: HashMap<String, Vec<TapeResponse>> = HashMap::new();
 
@@ -247,7 +247,7 @@ fn build_response(tr: &TapeResponse) -> Response<Body> {
         .unwrap_or_else(|_| error_response(500))
 }
 
-/// Returns a minimal JSON error response.
+/// Builds a minimal `{"type":"error","error":{...}}` response used when tape replay fails.
 fn error_response(status: u16) -> Response<Body> {
     let body = serde_json::json!({
         "type": "error",

--- a/src/features/mcp/bench/test_cases.rs
+++ b/src/features/mcp/bench/test_cases.rs
@@ -33,7 +33,7 @@ pub struct BenchTestCase {
     pub expect_parallel: bool,
 }
 
-/// Returns the full set of bench test cases.
+/// Returns every built-in bench case covering tool selection, parameter validity, tool-choice respect, and parallel calls.
 pub fn all_test_cases() -> Vec<BenchTestCase> {
     vec![
         // ── tool_selection_accuracy ──

--- a/src/features/pledge/cli.rs
+++ b/src/features/pledge/cli.rs
@@ -7,7 +7,7 @@
 use super::config::PledgeConfig;
 use super::profiles;
 
-/// Prints all available built-in pledge profiles.
+/// Prints the four built-in pledge profiles (read_only, execute, full, none) with their allowed tool sets.
 pub fn cmd_list_profiles() {
     let builtins = [
         &profiles::READ_ONLY,
@@ -29,7 +29,7 @@ pub fn cmd_list_profiles() {
     }
 }
 
-/// Prints current pledge configuration status.
+/// Prints whether pledge is enabled and lists every source/token-prefix rule bound to a profile.
 pub fn cmd_status(config: &PledgeConfig) {
     if !config.enabled {
         println!("  Pledge:  disabled (all tools pass through)");
@@ -68,7 +68,7 @@ pub fn validate_profile(name: &str) -> Result<(), String> {
     }
 }
 
-/// Formats a pledge set confirmation message.
+/// Formats the human-readable confirmation returned after activating a pledge profile, optionally scoped to a source.
 pub fn format_set_message(profile: &str, source: Option<&str>) -> String {
     match source {
         Some(s) => format!("Pledge profile '{profile}' activated for source '{s}'"),
@@ -76,7 +76,7 @@ pub fn format_set_message(profile: &str, source: Option<&str>) -> String {
     }
 }
 
-/// Formats a pledge clear confirmation message.
+/// Returns a one-line confirmation that pledge was cleared and the default profile is active again.
 pub fn format_clear_message() -> String {
     "Pledge cleared — default profile restored".to_string()
 }

--- a/src/features/watch/tui.rs
+++ b/src/features/watch/tui.rs
@@ -222,7 +222,7 @@ pub async fn run(base_url: &str) -> Result<()> {
     Ok(())
 }
 
-/// Renders the TUI layout.
+/// Splits the frame into providers, live stream, and alerts panels, then draws each panel in place.
 fn draw(app: &App, frame: &mut Frame) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -323,7 +323,7 @@ fn draw_alerts(app: &App, frame: &mut Frame, area: ratatui::layout::Rect) {
     frame.render_widget(para, area);
 }
 
-/// Renders a timestamp column for the event stream.
+/// Returns a dark-gray `HH:MM:SS` span for the leftmost column of each event stream row.
 fn timestamp_span(ts: &chrono::DateTime<chrono::Utc>) -> Span<'static> {
     Span::styled(
         format!("  {}  ", ts.format("%H:%M:%S")),
@@ -331,7 +331,7 @@ fn timestamp_span(ts: &chrono::DateTime<chrono::Utc>) -> Span<'static> {
     )
 }
 
-/// Formats a single event as a colored ListItem.
+/// Formats one [`WatchEvent`] variant into a color-coded `ListItem` for the live stream panel.
 fn format_event(event: &WatchEvent) -> ListItem<'static> {
     let line = match event {
         WatchEvent::RequestStart {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub fn grob_home() -> Option<PathBuf> {
     }
 }
 
-/// Returns the user home directory.
+/// Returns the user home directory, honouring `GROB_HOME`'s parent as an override.
 ///
 /// Honours `GROB_HOME`'s parent when set; otherwise delegates to
 /// `dirs::home_dir()` (requires the `dirs` feature).

--- a/src/preset/mod.rs
+++ b/src/preset/mod.rs
@@ -204,7 +204,7 @@ fn collect_preset_requirements(preset: &toml::Value) -> (Vec<String>, bool, bool
     (env_vars, needs_oauth, needs_ollama)
 }
 
-/// Print the requirements section for a preset info display.
+/// Prints the "Requirements" block (OAuth, Ollama, env vars with set/unset status) shown by `grob preset info`.
 fn print_requirements_section(env_vars: &[String], needs_oauth: bool, needs_ollama: bool) {
     println!();
     println!("📋 Requirements:");

--- a/src/preset/validation.rs
+++ b/src/preset/validation.rs
@@ -131,7 +131,7 @@ async fn validate_provider_mapping(
     }
 }
 
-/// Validate all router models by sending a minimal request to each provider mapping.
+/// Validates router models (default/think/background/websearch) by sending a minimal request to each provider mapping in parallel.
 pub async fn validate_config(
     config: &AppConfig,
     registry: &ProviderRegistry,
@@ -214,7 +214,7 @@ fn make_test_request(model: &str) -> CanonicalRequest {
     }
 }
 
-/// Print validation results to stdout.
+/// Prints a per-model health summary (checkmark, warning, or cross) and lists the failing provider mappings underneath.
 pub fn print_validation_results(results: &[ModelValidation]) {
     let all_ok = results.iter().all(|r| r.any_ok());
 

--- a/src/providers/gemini/transform.rs
+++ b/src/providers/gemini/transform.rs
@@ -32,7 +32,7 @@ pub(super) fn clean_json_schema(value: &mut serde_json::Value) {
     }
 }
 
-/// Convert a single Anthropic content block to a Gemini part.
+/// Maps one Anthropic content block (text/image/thinking/tool_use/tool_result) to the corresponding Gemini `Part` variant.
 pub(super) fn convert_block(
     block: &ContentBlock,
     tool_id_to_name: &HashMap<String, String>,
@@ -84,7 +84,7 @@ pub(super) fn convert_block(
     }
 }
 
-/// Convert Anthropic tools to Gemini tool format.
+/// Maps Anthropic tool definitions to Gemini tools, surfacing `WebSearch` and `WebFetch` as native `google_search`/`url_context` entries.
 pub(super) fn convert_tools(tools: &[crate::models::Tool]) -> Vec<GeminiTool> {
     let mut gemini_tools = Vec::new();
     let mut function_declarations = Vec::new();
@@ -119,7 +119,7 @@ pub(super) fn convert_tools(tools: &[crate::models::Tool]) -> Vec<GeminiTool> {
     gemini_tools
 }
 
-/// Convert Anthropic tool_choice to Gemini tool_config.
+/// Maps Anthropic `tool_choice` (auto/any/tool) to a Gemini `tool_config` with mode and optional allowed-function names.
 pub(super) fn convert_tool_config(tc: &serde_json::Value) -> Option<GeminiToolConfig> {
     let tc_type = tc.get("type").and_then(|v| v.as_str()).unwrap_or("");
     let (mode, names) = match tc_type {

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -162,7 +162,7 @@ fn extract_tool_results(blocks: &[ContentBlock]) -> Vec<(String, String)> {
         .collect()
 }
 
-/// Extract tool_use blocks as OpenAI tool calls.
+/// Filters Anthropic `tool_use` content blocks and reshapes them as OpenAI `tool_calls` entries with JSON-stringified arguments.
 fn extract_tool_calls(blocks: &[ContentBlock]) -> Vec<OpenAIToolCall> {
     blocks
         .iter()
@@ -388,7 +388,7 @@ pub(crate) fn parse_sse_response(sse_text: &str) -> Result<Vec<ContentBlock>, Pr
     })
 }
 
-/// Extract a content block from a Codex output item.
+/// Maps a Codex `output[]` item (`reasoning` or `message`) to the corresponding Anthropic thinking or text block.
 fn extract_codex_output_block(item: &serde_json::Value) -> Option<ContentBlock> {
     let output_type = item.get("type").and_then(|v| v.as_str())?;
     let text = item

--- a/src/routing/classify/classify.rs
+++ b/src/routing/classify/classify.rs
@@ -157,7 +157,7 @@ fn score_context_size(request: &CanonicalRequest) -> f32 {
     }
 }
 
-/// Converts character count to estimated token count.
+/// Approximates token count by dividing character count by 4 (BPE heuristic for English prose).
 #[inline]
 pub(crate) fn estimate_tokens_from_chars(chars: usize) -> usize {
     chars / 4
@@ -199,7 +199,7 @@ fn score_keywords(request: &CanonicalRequest) -> f32 {
     0.0
 }
 
-/// Extracts text from the last user message for keyword scanning.
+/// Returns the text of the most recent `user`-role message, flattening content blocks, or `None` if none has text.
 pub(crate) fn extract_last_user_text(request: &CanonicalRequest) -> Option<String> {
     let last_user = request.messages.iter().rev().find(|m| m.role == "user")?;
     match &last_user.content {

--- a/src/server/fan_out.rs
+++ b/src/server/fan_out.rs
@@ -316,7 +316,7 @@ async fn fan_out_all(
     join_all(futures).await.into_iter().flatten().collect()
 }
 
-/// Extract text content from an Anthropic response.
+/// Concatenates the text of every `Text` content block in the response, newline-joined, for judge-model scoring.
 fn extract_text_from_response(response: &ProviderResponse) -> String {
     use crate::models::{ContentBlock, KnownContentBlock};
     response

--- a/src/server/oauth_handlers.rs
+++ b/src/server/oauth_handlers.rs
@@ -242,7 +242,7 @@ pub struct DeleteTokenRequest {
     pub provider_id: String,
 }
 
-/// Deletes an OAuth token for the specified provider.
+/// Removes the stored OAuth token for `provider_id` from the token store; subsequent requests will require re-authorization.
 pub async fn oauth_delete_token(
     State(state): State<Arc<AppState>>,
     Json(req): Json<DeleteTokenRequest>,

--- a/src/server/openai_compat/transform.rs
+++ b/src/server/openai_compat/transform.rs
@@ -130,7 +130,7 @@ fn convert_assistant_message(msg: OpenAIMessage) -> crate::models::Message {
     }
 }
 
-/// Convert OpenAI tools JSON to Anthropic Tool format.
+/// Extracts OpenAI `function` tool definitions and reshapes each as an Anthropic `Tool` (name, description, input schema).
 fn convert_tools(tools: &[serde_json::Value]) -> Vec<Tool> {
     tools
         .iter()
@@ -152,7 +152,7 @@ fn convert_tools(tools: &[serde_json::Value]) -> Vec<Tool> {
         .collect()
 }
 
-/// Convert OpenAI tool_choice to Anthropic format.
+/// Maps OpenAI `tool_choice` (`auto`/`none`/`required`/function-object) to the matching Anthropic shape.
 fn convert_tool_choice(tc: &serde_json::Value) -> Option<serde_json::Value> {
     if let Some(s) = tc.as_str() {
         match s {

--- a/src/server/rpc/hit_ns.rs
+++ b/src/server/rpc/hit_ns.rs
@@ -38,7 +38,7 @@ pub async fn list_policies(
     Ok(policies)
 }
 
-/// Creates or updates a named HIT policy.
+/// Upserts a named HIT policy in memory; the change survives only until the next config reload.
 pub async fn set_policy(
     state: &Arc<AppState>,
     caller: &CallerIdentity,
@@ -56,7 +56,7 @@ pub async fn set_policy(
     }))
 }
 
-/// Reads a single policy by name.
+/// Returns the full policy JSON (including HIT overrides) for the given policy name.
 pub async fn get_policy(
     state: &Arc<AppState>,
     caller: &CallerIdentity,

--- a/src/server/rpc/keys_ns.rs
+++ b/src/server/rpc/keys_ns.rs
@@ -25,7 +25,7 @@ pub struct KeyInfo {
     pub revoked: bool,
 }
 
-/// Creates a new virtual API key.
+/// Creates a new virtual API key, persists its hash in `GrobStore`, and returns the plaintext secret.
 pub async fn create(
     state: &Arc<AppState>,
     caller: &CallerIdentity,
@@ -89,7 +89,7 @@ pub async fn list(
         .collect())
 }
 
-/// Revokes a virtual API key.
+/// Revokes a virtual API key by id, marking it unusable for future dispatch.
 pub async fn revoke(
     state: &Arc<AppState>,
     caller: &CallerIdentity,

--- a/src/server/rpc/pledge_ns.rs
+++ b/src/server/rpc/pledge_ns.rs
@@ -36,7 +36,7 @@ pub async fn set(
     })
 }
 
-/// Clears the active pledge, restoring defaults.
+/// Clears the active pledge, reverting all sources to the default profile.
 pub async fn clear(
     state: &Arc<AppState>,
     caller: &CallerIdentity,
@@ -52,7 +52,7 @@ pub async fn clear(
     })
 }
 
-/// Returns the current pledge status.
+/// Returns the active pledge configuration, default profile, and per-rule bindings.
 pub async fn status(
     state: &Arc<AppState>,
     caller: &CallerIdentity,

--- a/src/server/rpc/types.rs
+++ b/src/server/rpc/types.rs
@@ -18,7 +18,7 @@ pub const ERR_INTERNAL: i32 = -32004;
 #[allow(dead_code)]
 pub const ERR_BUDGET_EXCEEDED: i32 = -32005;
 
-/// Builds a typed JSON-RPC error.
+/// Builds an owned JSON-RPC error object with the given numeric code and message.
 pub fn rpc_err(code: i32, msg: impl Into<String>) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(code, msg.into(), None::<()>)
 }

--- a/src/shared/acme.rs
+++ b/src/shared/acme.rs
@@ -7,7 +7,7 @@ use crate::cli::AcmeConfig;
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
-/// Resolves the certificate cache directory.
+/// Resolves and creates the ACME certificate cache directory, defaulting to `~/.grob/certs/` when unset.
 ///
 /// Defaults to `~/.grob/certs/` if not specified.
 ///

--- a/src/shared/message_tracing/mod.rs
+++ b/src/shared/message_tracing/mod.rs
@@ -348,7 +348,7 @@ fn rotated_path(base: &Path, index: usize, compressed: bool) -> PathBuf {
     parent.join(name)
 }
 
-/// Compresses a file to zstd format.
+/// Streams `src` through a zstd level-3 encoder into `dst`, preserving the source untouched until the caller unlinks it.
 fn compress_to_zstd(src: &Path, dst: &Path) -> std::io::Result<()> {
     let input = std::fs::File::open(src)?;
     let output = std::fs::File::create(dst)?;
@@ -358,7 +358,7 @@ fn compress_to_zstd(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Expands ~ to home directory.
+/// Expands a leading `~/` against `home_dir()`; returns the original path verbatim when the prefix is absent.
 fn expand_tilde(path: &str) -> PathBuf {
     if let Some(rest) = path.strip_prefix("~/") {
         if let Some(home) = crate::home_dir() {


### PR DESCRIPTION
## Summary

Rewrite ~45 `///` summaries that merely restated the function name, adding scope, constraint, unit, or edge-case information per RFC 505 + M-DOC (≤15 words, third person singular indicative, never "This function...").

Covered domains:

- **rpc** (`src/server/rpc/*`): pledge status/clear, keys create/revoke, HIT set/get, type-error builder
- **commands** (`src/commands/*`): setup wizard + writer, bench scenario/escalation, status/model RPC fallback, common health probes
- **features** (`src/features/*`): pledge CLI formatters, DLP hot_config/prompt_injection/signed_config/url_exfil, harness mock backend, MCP bench cases
- **providers** (`src/providers/*`, `src/server/openai_compat/*`): tool_use/tool_choice transforms, Codex SSE extractor, Gemini block mapper
- **shared/lib** (`src/lib.rs`, `src/shared/*`, `src/auth/*`, `src/preset/*`, `src/routing/*`): home_dir override, ACME cache dir, zstd compressor, token classifier, TUI renderer

Taxonomy validated N=5 at Phase 0 Reflect (scope / constraint / unit / edge-case).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo doc --no-deps --all-features` (28 warnings — same as main baseline, no regression)
- [x] Pre-push hooks pass (fmt, clippy, tests, doc tests, deny, doc coverage, audit)
- [ ] CI green on the PR

Audit item: #29