### PR TITLE
chore: release v0.36.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.31](https://github.com/azerozero/grob/compare/v0.36.30...v0.36.31) - 2026-04-21
+
+### Added
+
+- *(wizard)* --edit tools/endpoints sections ([#26](https://github.com/azerozero/grob/pull/26)) ([#255](https://github.com/azerozero/grob/pull/255))
+- *(wizard)* skip credential prompt when env var present ([#24](https://github.com/azerozero/grob/pull/24)) ([#254](https://github.com/azerozero/grob/pull/254))
+- *(doctor)* actionable fix hints on each check ([#23](https://github.com/azerozero/grob/pull/23)) ([#252](https://github.com/azerozero/grob/pull/252))
+- *(wizard)* schema drift auto-migration prompt ([#25](https://github.com/azerozero/grob/pull/25)) ([#251](https://github.com/azerozero/grob/pull/251))
+- *(mcp)* wizard config/doctor MCP surface per ADR-0011 ([#21](https://github.com/azerozero/grob/pull/21)) ([#249](https://github.com/azerozero/grob/pull/249))
+- *(wizard)* headless OAuth device-code RFC 8628 ([#22](https://github.com/azerozero/grob/pull/22)) ([#248](https://github.com/azerozero/grob/pull/248))
+
+### Other
+
+- non-tautological doc summaries across 5 domains ([#29](https://github.com/azerozero/grob/pull/29)) ([#250](https://github.com/azerozero/grob/pull/250))
+
 ## [0.36.30](https://github.com/azerozero/grob/compare/v0.36.29...v0.36.30) - 2026-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.30"
+version = "0.36.31"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.30"
+version = "0.36.31"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.30 -> 0.36.31

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.31](https://github.com/azerozero/grob/compare/v0.36.30...v0.36.31) - 2026-04-21

### Added

- *(wizard)* --edit tools/endpoints sections ([#26](https://github.com/azerozero/grob/pull/26)) ([#255](https://github.com/azerozero/grob/pull/255))
- *(wizard)* skip credential prompt when env var present ([#24](https://github.com/azerozero/grob/pull/24)) ([#254](https://github.com/azerozero/grob/pull/254))
- *(doctor)* actionable fix hints on each check ([#23](https://github.com/azerozero/grob/pull/23)) ([#252](https://github.com/azerozero/grob/pull/252))
- *(wizard)* schema drift auto-migration prompt ([#25](https://github.com/azerozero/grob/pull/25)) ([#251](https://github.com/azerozero/grob/pull/251))
- *(mcp)* wizard config/doctor MCP surface per ADR-0011 ([#21](https://github.com/azerozero/grob/pull/21)) ([#249](https://github.com/azerozero/grob/pull/249))
- *(wizard)* headless OAuth device-code RFC 8628 ([#22](https://github.com/azerozero/grob/pull/22)) ([#248](https://github.com/azerozero/grob/pull/248))

### Other

- non-tautological doc summaries across 5 domains ([#29](https://github.com/azerozero/grob/pull/29)) ([#250](https://github.com/azerozero/grob/pull/250))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).