### PR TITLE
feat(wizard): --edit tools/endpoints sections (#26)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -220,7 +220,8 @@ pub enum Commands {
         /// Preview changes without writing to disk
         #[arg(long)]
         dry_run: bool,
-        /// Reconfigure a single section (providers, budget, compliance, fallback)
+        /// Reconfigure a single section
+        /// (providers, auth, budget, compliance, fallback, endpoints, tools)
         #[arg(long, alias = "reconfigure", value_name = "SECTION")]
         edit: Option<String>,
     },

--- a/src/commands/setup/mod.rs
+++ b/src/commands/setup/mod.rs
@@ -84,7 +84,9 @@ pub async fn run_setup_wizard(config_path: &Path, flags: &SetupFlags) -> Result<
         println!("  [2] Replace from scratch");
         println!("  [3] Cancel");
         println!();
-        println!("  Tip: use `grob setup --edit providers` to reconfigure a single section.");
+        println!(
+            "  Tip: `grob setup --edit <section>` (providers, auth, budget, compliance, fallback, endpoints, tools)"
+        );
         if prompt_choice(3) == 3 {
             return Ok(false);
         }
@@ -268,9 +270,26 @@ async fn run_edit_section(config_path: &Path, section: &str, flags: &SetupFlags)
                 }
             }
         }
+        "tools" => {
+            // Re-run the tool picker. Screen_tools infers the preset from the
+            // tool selection; we rewrite [presets].active so a subsequent
+            // `grob setup` re-runs pick up the new preset as default.
+            let (_tools, preset, _desc) = match screen_tools() {
+                Some(t) => t,
+                None => {
+                    println!("  No tools selected — leaving config unchanged.");
+                    return Ok(false);
+                }
+            };
+            patch(&mut config, "presets", &[("active", preset.clone().into())])?;
+            println!("  Preset switched to '{}'.", preset);
+            println!(
+                "  Note: provider list is tied to the preset — run `grob setup --edit providers` if credentials need updating."
+            );
+        }
         _ => {
             println!(
-                "  Unknown section '{}'. Available: providers, budget, compliance, fallback, endpoints",
+                "  Unknown section '{}'. Available: providers, auth, budget, compliance, fallback, endpoints, tools",
                 section
             );
             return Ok(false);

--- a/src/commands/setup/types.rs
+++ b/src/commands/setup/types.rs
@@ -185,6 +185,9 @@ pub struct SetupFlags {
     pub yes: bool,
     /// Previews changes without writing to disk.
     pub dry_run: bool,
-    /// Restricts the wizard to a single section (providers, budget, compliance, fallback).
+    /// Restricts the wizard to a single section.
+    ///
+    /// Accepted values: `providers`, `auth`, `budget`, `compliance`,
+    /// `fallback`, `endpoints`, `tools`.
     pub edit_section: Option<String>,
 }


### PR DESCRIPTION
## Summary
- Adds the \`tools\` section to \`grob setup --edit\`: re-runs the tool picker and rewrites \`[presets].active\` based on the new selection.
- Updates the unknown-section error message and the startup tip to list the full set: providers, auth, budget, compliance, fallback, endpoints, tools.
- CLI \`--help\` entry for \`--edit\` now shows the full list (endpoints was already implemented but missing from docs).

## Test plan
- [x] Existing wizard unit tests still pass
- [x] \`cargo clippy --lib --all-features -- -D warnings\` clean
- [ ] Manual: \`grob setup --edit tools\` on a fresh config

Audit item #26 (routine, N=3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)