### PR TITLE
chore(deploy): Type=exec on grob.container + close Tier 2 CI cluster (#15 #16 #17 #18 #19 #20)

### DIFF
--- a/deploy/grob.container
+++ b/deploy/grob.container
@@ -53,10 +53,13 @@ CPUQuota=100%
 PidsLimit=1024
 
 [Service]
-# NOTE: grob does not call sd_notify itself, so Type=simple is the correct
-# contract. The Quadlet HealthCmd above is what signals readiness to
-# systemd — no user-space sd_notify glue needed.
-Type=simple
+# NOTE: Type=exec over Type=simple — systemd waits for execve() to succeed
+# before considering the unit started, surfacing exec-time failures (missing
+# image, invalid args) as real start failures instead of immediate-exit loops.
+# Type=notify is wrong here: grob does not call sd_notify, so systemd would
+# wait for a notification that never arrives. Readiness is signaled by the
+# Quadlet HealthCmd above.
+Type=exec
 Restart=on-failure
 RestartSec=5
 TimeoutStartSec=60


### PR DESCRIPTION
## Summary

Tier 2 CI/infra audit cluster close-out.

**Only #20 needed a code change** — items #15 through #19 had already landed in #225 (ci/phoenix-tier2-pipeline) before this branch was cut. This PR is scoped to the last remaining item plus a status note so the tracker can close.

### #20 — deploy/grob.container Type=simple → Type=exec

`Type=simple` considers the unit started the instant `fork()` returns, so an immediate `execve()` failure (missing image, bad arg) presents as a restart loop rather than a clean start failure. `Type=exec` waits for `execve()` to succeed, surfacing exec-time failures as real unit failures and letting `Restart=on-failure` do the right thing.

The audit suggested `Type=notify`, but that is wrong for grob: the binary does not call `sd_notify`, so systemd would block forever on a readiness signal that never arrives. Readiness stays with the Quadlet `HealthCmd`. Rationale is inlined in the unit file as a `# NOTE:` so future readers do not retry `notify`.

### Already-landed items (status only, no change in this PR)

| # | Target | Status |
|---|---|---|
| #15 | `ci.yml` retry-masking on hurl/k6 | Landed in #225 — retry removed, `# NOTE: no retry — flaky E2E must be fixed at the source` |
| #16 | `ci-docs-shim.yml` orphan | Already deleted — file is absent from `.github/workflows/` |
| #17 | Daily `rustsec/audit-check` cron | Landed as `audit-cron.yml` with `cron: '17 4 * * *'` |
| #18 | `release-plz.yml` timeouts | Both `release-pr` and `release-tag` jobs already carry `timeout-minutes: 10` |
| #19 | `nightly.yml` multi-OS + alert | Matrix covers ubuntu/macos/windows × beta/nightly, dedicated `alert` job opens/updates a tracking issue on beta failure |

## Test plan

- [ ] CI green on this PR (workflow-only delta, low risk)
- [ ] Manual verify locally: `systemd-analyze verify deploy/grob.container` passes
- [ ] Confirm items #15-#19 can be closed in tracker without further change

🤖 Generated with [Claude Code](https://claude.com/claude-code)