### PR TITLE
docs,ci: cli.md missing flags + prose lint jobs (#13 #27)

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,82 @@
+# Docs lint pipeline: markdownlint + lychee (broken-link check).
+#
+# Scoped to docs/**, README.md, and top-level *.md. Runs on push to main
+# and on PRs that touch docs so broken links and style regressions are
+# caught before merge. Rust doctests (`cargo test --doc`) already run in
+# the main CI pipeline (see ci.yml tests job).
+
+name: Docs Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "**.md"
+      - ".markdownlint.json"
+      - ".lycheeignore"
+      - ".github/workflows/docs-lint.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "**.md"
+      - ".markdownlint.json"
+      - ".lycheeignore"
+      - ".github/workflows/docs-lint.yml"
+
+concurrency:
+  group: docs-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v6
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: |
+            docs/**/*.md
+            README.md
+            CLAUDE.md
+          config: .markdownlint.json
+
+  lychee:
+    name: Broken link check (lychee)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v6
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # --offline would skip network checks; we keep live checking
+          # but cache results to avoid hammering external hosts.
+          args: >-
+            --cache
+            --max-cache-age 1d
+            --no-progress
+            --exclude-mail
+            --accept 200,204,206,301,302,308,403,429
+            docs/**/*.md README.md CLAUDE.md
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+^https?://(localhost|127\.0\.0\.1|\[::1\]|0\.0\.0\.0)(:\d+)?(/.*)?$
+^https?://[^/]+\.example\.(com|org|net)(/.*)?$
+^https?://grob-(qa|prod|dev|staging)\.example\.com(/.*)?$
+^https?://.*\.internal(/.*)?$
+^https?://grob\.sh(/.*)?$

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,16 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD022": false,
+  "MD024": { "siblings_only": true },
+  "MD029": false,
+  "MD031": false,
+  "MD032": false,
+  "MD033": false,
+  "MD034": false,
+  "MD036": false,
+  "MD040": false,
+  "MD041": false,
+  "MD045": false,
+  "MD060": false
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -152,8 +152,8 @@ Manage configuration presets.
 |------------|-------------|
 | `grob preset list` | Show available presets (built-in + installed) |
 | `grob preset info <name>` | Show providers, models, env vars, router config, and requirements |
-| `grob preset apply <name> [-r\|--reload]` | Apply a preset (backs up current config). With `--reload`, hot-reloads the running server. |
-| `grob preset export <name>` | Save current config as a reusable preset (strips `[server]`, replaces API keys with env var references) |
+| `grob preset apply <name> [-r\|--reload] [--dry-run]` | Apply a preset (backs up current config). With `--reload`, hot-reloads the running server. With `--dry-run`, previews changes without writing to disk. |
+| `grob preset export <name> [--env <ENV>]` | Save current config as a reusable preset (strips `[server]`, replaces API keys with env var references). With `--env`, saves as `{name}.{env}.toml` for per-environment presets. |
 | `grob preset install <source>` | Install presets from a git repo or local path |
 | `grob preset sync` | Sync presets from configured remote |
 
@@ -161,7 +161,9 @@ Manage configuration presets.
 grob preset list
 grob preset info perf
 grob preset apply medium --reload
+grob preset apply medium --dry-run          # Preview without writing
 grob preset export my-setup
+grob preset export my-setup --env qa        # Saves as my-setup.qa.toml
 grob preset install https://github.com/org/presets.git
 ```
 
@@ -310,9 +312,14 @@ grob record --output <tape.jsonl>
 
 Interactive credential setup for providers. Without arguments, checks all providers. With a provider name, sets up that specific provider only.
 
+| Flag | Description |
+|------|-------------|
+| `--force-reauth` | Discard existing OAuth tokens and initiate a fresh OAuth flow. Use when `grob connect` reports a revoked token. |
+
 ```bash
-grob connect              # Check all providers
-grob connect anthropic    # Set up Anthropic credentials
+grob connect                          # Check all providers
+grob connect anthropic                # Set up Anthropic credentials
+grob connect anthropic --force-reauth # Re-authenticate after token revocation
 ```
 
 ### `grob init`
@@ -344,6 +351,19 @@ Interactive first-run setup wizard (auto-triggered when no `config.toml` exists)
 4. Compliance mode (Standard, DLP only, GDPR, EU AI Act, Enterprise security, Local-only)
 5. Monthly budget cap
 6. Provider status validation
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Accept all defaults without prompting (non-interactive scripted setup) |
+| `--dry-run` | Preview changes without writing to disk |
+| `--edit <SECTION>` | Reconfigure a single section. Valid sections: `providers`, `auth`, `budget`, `compliance`, `fallback`, `endpoints`, `tools` |
+
+```bash
+grob setup                        # Full interactive wizard
+grob setup --yes                  # Accept all defaults (scripts/CI)
+grob setup --dry-run              # Preview without writing
+grob setup --edit budget          # Reconfigure just the budget section
+```
 
 ### `grob upgrade`
 


### PR DESCRIPTION
## Summary

Two small follow-up items bundled into one PR.

### #13 — Document missing CLI flags in \`docs/reference/cli.md\`

Audited every subcommand's \`--help\` output against the CLI reference. Found **6** flags that were implemented but not documented (task said 5 — documenting all I found):

- \`grob connect --force-reauth\`
- \`grob setup --yes\`
- \`grob setup --dry-run\`
- \`grob setup --edit <SECTION>\`
- \`grob preset apply --dry-run\`
- \`grob preset export --env <ENV>\`

Also extended the preset summary table and examples so the new flags are discoverable from the top of the Preset section.

### #27 — Docs lint CI (\`lychee\` + \`markdownlint\`)

New workflow: \`.github/workflows/docs-lint.yml\`. Runs only when markdown changes:

- **markdownlint-cli2** over \`docs/**/*.md\`, \`README.md\`, \`CLAUDE.md\` with a lenient \`.markdownlint.json\` baseline (style rules that would require rewriting existing docs are disabled; semantic rules like duplicate headings and malformed lists stay on).
- **lychee** broken-link check with a \`.lycheecache\` and a \`.lycheeignore\` that excludes \`localhost\`, \`example.com\` placeholders, and \`*.internal\` hosts.

\`cargo test --doc\` is already wired in \`ci.yml\` and \`nightly.yml\`, so no duplicate doctest job was added.

## Test plan

- [x] \`grob --help\` + every subcommand \`--help\` diffed against \`cli.md\`
- [x] \`npx markdownlint-cli2 "docs/**/*.md" "README.md" "CLAUDE.md"\` → 0 errors locally
- [ ] GitHub Actions \`Docs Lint\` workflow passes (markdownlint + lychee) on this PR
- [ ] Existing CI (fmt, clippy, tests) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)