### PR TITLE
docs(traits): # Examples on 3 core public traits (#28)

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -128,11 +128,36 @@ pub fn warn_if_cleartext(url: &str, provider_name: &str) {
     }
 }
 
-/// Core provider trait -- all LLM backends implement this.
+/// Sends chat requests to an LLM backend in Anthropic Messages format.
 ///
-/// Maintains Anthropic Messages API compatibility as the canonical
-/// internal format. Non-Anthropic providers translate to/from their
-/// native formats in their implementations.
+/// Every provider (Anthropic, OpenAI, Gemini, DeepSeek, Ollama, …) implements
+/// this trait. The canonical on-wire format is the Anthropic Messages API;
+/// non-Anthropic providers translate to and from their native formats inside
+/// their `send_message` / `send_message_stream` bodies.
+///
+/// # Errors
+///
+/// Methods return [`ProviderError`] when the upstream API rejects the request,
+/// the network fails, or translation between canonical and provider-native
+/// formats fails.
+///
+/// # Examples
+///
+/// A generic helper that forwards a request to any backend and returns the
+/// served model name:
+///
+/// ```no_run
+/// use grob::providers::LlmProvider;
+/// use grob::models::CanonicalRequest;
+///
+/// async fn served_model_name<P: LlmProvider>(
+///     provider: &P,
+///     request: CanonicalRequest,
+/// ) -> anyhow::Result<String> {
+///     let response = provider.send_message(request).await?;
+///     Ok(response.model)
+/// }
+/// ```
 #[async_trait]
 pub trait LlmProvider: Send + Sync {
     /// Sends a non-streaming message request to the provider.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -67,7 +67,26 @@ pub trait DlpPipeline: Send + Sync {
 
 // ── Request Router ──
 
-/// Routes requests to model names based on rules.
+/// Routes requests to concrete model names based on configured rules.
+///
+/// Implementations inspect a [`CanonicalRequest`] (prompt patterns, tier
+/// hints, explicit model aliases) and return a [`crate::models::RouteDecision`]
+/// identifying the backend model that should serve the request.
+///
+/// # Examples
+///
+/// A thin wrapper that delegates to any router implementation:
+///
+/// ```no_run
+/// use grob::traits::RequestRouter;
+/// use grob::models::{CanonicalRequest, RouteDecision};
+/// use anyhow::Result;
+///
+/// fn pick_model<R: RequestRouter>(router: &R, request: &mut CanonicalRequest) -> Result<String> {
+///     let decision: RouteDecision = router.route(request)?;
+///     Ok(decision.model_name)
+/// }
+/// ```
 pub trait RequestRouter: Send + Sync {
     /// Routes a request and returns a routing decision.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,7 +13,25 @@ use std::collections::HashMap;
 
 // ── DLP Pipeline ──
 
-/// Sanitization pipeline for data loss prevention.
+/// Sanitizes requests and responses for data-loss prevention.
+///
+/// Concrete implementations scrub secrets, PII, and canary tokens from
+/// outgoing requests, reverse any anonymisation on streamed responses,
+/// and flag exfiltration attempts in URL payloads.
+///
+/// # Examples
+///
+/// A generic helper that uses any implementation to redact a response body:
+///
+/// ```no_run
+/// use grob::traits::DlpPipeline;
+/// use std::borrow::Cow;
+///
+/// fn redact<P: DlpPipeline>(pipeline: &P, response: &str) -> String {
+///     let sanitized: Cow<'_, str> = pipeline.sanitize_response_text(response);
+///     sanitized.into_owned()
+/// }
+/// ```
 #[cfg(feature = "dlp")]
 pub trait DlpPipeline: Send + Sync {
     /// Sanitizes an outgoing request (non-blocking, best-effort).


### PR DESCRIPTION
## Summary

Adds compilable `# Examples` doctests to the three core public traits flagged by audit item #28:

- `grob::traits::DlpPipeline` — generic redaction helper
- `grob::traits::RequestRouter` — routing decision wrapper with `?` error propagation
- `grob::providers::LlmProvider` — async `send_message` helper with `?` via `anyhow`

Each trait also gets an expanded summary (third-person singular verb, ≤ 15 words per RFC 505 + M-DOC) and a short body paragraph. `LlmProvider` additionally gains a `# Errors` section pointing at `ProviderError`.

All doctests are `no_run` (runtime I/O required) and use `?` — never `.unwrap()` — per CLAUDE.md.

## Test plan
- [x] `cargo test --doc` passes (22 passed, 0 failed, 1 ignored)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [ ] CI green on PR