### PR TITLE
chore: release v0.36.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.32](https://github.com/azerozero/grob/compare/v0.36.31...v0.36.32) - 2026-04-25
+
+### Fixed
+
+- *(ci,openai)* relocate codex_instructions to provider dir + drop lychee --exclude-mail
+
+### Other
+
+- *(deps)* bump rustls-webpki 0.103.12 -> 0.103.13 (RUSTSEC-2026-0104)
+- *(docs,tier0)* hygiene structurelle — ADR 0007 + codex move + CONTRIBUTING + SECURITY + RTM (#36 #37 #38 #39) ([#259](https://github.com/azerozero/grob/pull/259))
+- *(traits)* # Examples on 3 core public traits ([#28](https://github.com/azerozero/grob/pull/28)) ([#258](https://github.com/azerozero/grob/pull/258))
+- cli.md missing flags + prose lint jobs (#13 #27) ([#257](https://github.com/azerozero/grob/pull/257))
+- *(deploy)* switch grob.container to Type=exec ([#20](https://github.com/azerozero/grob/pull/20)) ([#256](https://github.com/azerozero/grob/pull/256))
+
 ## [0.36.31](https://github.com/azerozero/grob/compare/v0.36.30...v0.36.31) - 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.31"
+version = "0.36.32"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.31"
+version = "0.36.32"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.31 -> 0.36.32

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.32](https://github.com/azerozero/grob/compare/v0.36.31...v0.36.32) - 2026-04-25

### Fixed

- *(ci,openai)* relocate codex_instructions to provider dir + drop lychee --exclude-mail

### Other

- *(deps)* bump rustls-webpki 0.103.12 -> 0.103.13 (RUSTSEC-2026-0104)
- *(docs,tier0)* hygiene structurelle — ADR 0007 + codex move + CONTRIBUTING + SECURITY + RTM (#36 #37 #38 #39) ([#259](https://github.com/azerozero/grob/pull/259))
- *(traits)* # Examples on 3 core public traits ([#28](https://github.com/azerozero/grob/pull/28)) ([#258](https://github.com/azerozero/grob/pull/258))
- cli.md missing flags + prose lint jobs (#13 #27) ([#257](https://github.com/azerozero/grob/pull/257))
- *(deploy)* switch grob.container to Type=exec ([#20](https://github.com/azerozero/grob/pull/20)) ([#256](https://github.com/azerozero/grob/pull/256))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).