### PR TITLE
docs: fix 4 stale external links surfaced by working lychee

### DIFF
--- a/docs/decisions/0018-nature-inspired-routing.md
+++ b/docs/decisions/0018-nature-inspired-routing.md
@@ -359,7 +359,7 @@ Compliance with this ADR will be verified by:
 
 ### External references
 
-- Matt Klein, [Envoy's architectural model](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/arch_overview) — clusters (topology) vs listeners/filters (policy).
+- Matt Klein, [Envoy's architectural model](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/intro) — clusters (topology) vs listeners/filters (policy).
 - Matt Holt, [Caddy `reverse_proxy` directive](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) — the ergonomic benchmark for this ADR. Every example we ship should be benchmarked against Caddy's equivalent in lines of config.
 - Jeffrey Dean & Luiz André Barroso, [The Tail at Scale](https://research.google/pubs/pub40801/), *Communications of the ACM*, Vol. 56, No. 2, 2013 — the canonical reference for hedged requests.
 - Daniel J. Russo, Benjamin Van Roy, Abbas Kazerouni, Ian Osband & Zheng Wen, [A Tutorial on Thompson Sampling](https://arxiv.org/abs/1707.02038), *Foundations and Trends in Machine Learning*, 2018 — Thompson sampling reference.

--- a/docs/how-to/oauth-setup.md
+++ b/docs/how-to/oauth-setup.md
@@ -192,5 +192,5 @@ let response = reqwest::Client::new()
 
 ## Related
 
-- [OpenCode Anthropic Auth](https://github.com/sst/opencode-anthropic-auth) - Inspiration for this implementation
+- [OpenCode](https://github.com/sst/opencode) - Inspiration for this implementation
 - [Anthropic OAuth Docs](https://docs.anthropic.com/claude/reference/oauth)

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -36,10 +36,10 @@ Overhead = P50 proxy − P50 direct baseline, same machine, same conditions.
 
 | Proxy | Instance | vCPU | P50 overhead | req/s | Routing | Auth | Rate limit | Cache | DLP | Source |
 |-------|----------|:----:|-------------:|------:|:-------:|:----:|:----------:|:-----:|:---:|--------|
-| **Grob** | t3.xlarge | 4 | **127 µs** | 17,700 | Yes | Yes | Yes | Yes | — | [grob-bench](https://github.com/azerozero/grob-bench) |
-| **Grob** | t3.xlarge | 4 | **161 µs** | 15,300 | Yes | Yes | Yes | Yes | Yes | [grob-bench](https://github.com/azerozero/grob-bench) |
-| **Grob** | c7g.xlarge | 4 | **67 µs** | 35,500 | Yes | Yes | Yes | Yes | — | [grob-bench](https://github.com/azerozero/grob-bench) |
-| **Grob** | c7g.xlarge | 4 | **90 µs** | 29,500 | Yes | Yes | Yes | Yes | Yes | [grob-bench](https://github.com/azerozero/grob-bench) |
+| **Grob** | t3.xlarge | 4 | **127 µs** | 17,700 | Yes | Yes | Yes | Yes | — | [`benches/`](../../benches/) |
+| **Grob** | t3.xlarge | 4 | **161 µs** | 15,300 | Yes | Yes | Yes | Yes | Yes | [`benches/`](../../benches/) |
+| **Grob** | c7g.xlarge | 4 | **67 µs** | 35,500 | Yes | Yes | Yes | Yes | — | [`benches/`](../../benches/) |
+| **Grob** | c7g.xlarge | 4 | **90 µs** | 29,500 | Yes | Yes | Yes | Yes | Yes | [`benches/`](../../benches/) |
 | Bifrost | t3.xlarge | 4 | 11 µs | — | — | — | — | — | — | [Maxim blog](https://www.getmaxim.ai/blog/bifrost-a-drop-in-llm-proxy-40x-faster-than-litellm/) |
 | TensorZero | c7i.xlarge | 4 | 370 µs | — | Yes | — | — | — | — | [TensorZero docs](https://www.tensorzero.com/docs/gateway/benchmarks) |
 | LiteLLM | 4c / 8 GB | 4 | ~5 ms | — | Yes | Yes | Yes | — | — | [LiteLLM docs](https://docs.litellm.ai/docs/benchmarks) |

--- a/docs/reference/owasp-llm-top10.md
+++ b/docs/reference/owasp-llm-top10.md
@@ -246,5 +246,5 @@ risk_classification = true
 
 - [OWASP Top 10 for LLM Applications 2025](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 - [LLM01: Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
-- [LLM02: Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/)
+- [LLM02: Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/)
 - [Grob Security Model](../explanation/security.md)


### PR DESCRIPTION
## Summary

Follow-up to #261. Now that lychee actually executes (the `--exclude-mail` flag was crashing it before any link check), it surfaces 4 stale references that existed silently on `main` for a while.

- **ADR-0018 (`docs/decisions/0018-nature-inspired-routing.md`)** — Envoy `arch_overview` URL had a duplicated path segment (`/intro/arch_overview/intro/arch_overview` → `/intro/arch_overview/intro/intro`).
- **`docs/how-to/oauth-setup.md`** — `sst/opencode-anthropic-auth` was renamed/absorbed into `sst/opencode`.
- **`docs/reference/owasp-llm-top10.md`** — OWASP renamed LLM02 to `llm022025-*` in their 2025 list. LLM01 is unchanged on their side, so kept as-is.
- **`docs/reference/benchmarks.md`** — replaced 4× `[grob-bench](https://github.com/azerozero/grob-bench)` placeholder (repo doesn't exist) with a relative link to the actual bench code in this repo (`benches/`).

All 4 candidate URLs were probed with `curl -I` to confirm they return 200 before being committed.

## Test plan

- [x] `curl -I` confirms each replacement URL returns 200
- [ ] CI: `Broken link check (lychee)` green
- [ ] CI: `markdownlint` green (no MD changes that affect lint)