### PR TITLE
ci(docs-lint): accept 303 in lychee

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -74,7 +74,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --no-progress
-            --accept 200,204,206,301,302,308,403,429
+            --accept 200,204,206,301,302,303,308,403,429
             docs/**/*.md README.md CLAUDE.md
           fail: true
         env:


### PR DESCRIPTION
## Summary

Follow-up to #261/#263. After the previous two PRs unblocked Docs Lint, lychee revealed a final stale failure on `https://console.mistral.ai/`, which legitimately returns **303 See Other** (redirecting to login). The other 3xx codes already accepted (301/302/308) are equivalent in intent for a docs link checker — accepting 303 closes the gap and turns Docs Lint fully green on main.

## Test plan

- [x] Diff is a 1-character change (`303` added to the `--accept` list)
- [ ] CI: `Broken link check (lychee)` green