### PR TITLE
docs: fix 12 broken internal links (relative-path drift)

### DIFF
--- a/docs/decisions/0018-nature-inspired-routing.md
+++ b/docs/decisions/0018-nature-inspired-routing.md
@@ -369,8 +369,8 @@ Compliance with this ADR will be verified by:
 
 ### Internal discussion threads
 
-- [Backlog PO — Phase RE (section complète)](../../../obsidian/grob/30%20-%20Roadmap/Backlog%20PO.md#phase-re) — source of the phase breakdown, effort estimates, and schema examples.
-- [Decisions Architecte — D-12 nature-inspired routing](../../../obsidian/grob/30%20-%20Roadmap/Decisions%20Architecte.md) — architect brief referencing this ADR.
+- Backlog PO — Phase RE (section complète) — internal Obsidian vault; source of the phase breakdown, effort estimates, and schema examples.
+- Decisions Architecte — D-12 nature-inspired routing — internal Obsidian vault; architect brief referencing this ADR.
 - Sprint S5 shared-state — T-R0 delivery, commis-3 assignment, 3/3 unanimity required on `docs/decisions/**`.
 
 ### Target schema examples

--- a/docs/how-to/auto-tune-routing.md
+++ b/docs/how-to/auto-tune-routing.md
@@ -123,4 +123,3 @@ disk space.
 
 - [Configuration reference](../reference/configuration.md) -- full list of config keys
 - [Observability reference](../reference/observability.md) -- Prometheus metrics and SSE stream
-- [Complexity scoring](../explanation/complexity-scoring.md) -- how the heuristic works

--- a/docs/how-to/providers.md
+++ b/docs/how-to/providers.md
@@ -53,7 +53,7 @@ oauth_provider = "anthropic-max"
 
 On first `grob start`, a browser window opens for OAuth login. Tokens are stored as encrypted files in `~/.grob/tokens/` (AES-256-GCM) and refreshed automatically.
 
-See [OAuth Setup](how-to/oauth-setup.md) for details.
+See [OAuth Setup](oauth-setup.md) for details.
 
 ---
 
@@ -171,7 +171,7 @@ ollama pull qwen2.5-coder:7b
 
 ## Gemini
 
-See [Gemini Integration](how-to/gemini-integration.md) for full details including Vertex AI.
+See [Gemini Integration](gemini-integration.md) for full details including Vertex AI.
 
 ### API key
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -341,7 +341,7 @@ poll_interval = "1h"
 verify_signature = false
 ```
 
-DLP scanning uses prefix-gated DFA matching with Aho-Corasick pre-filtering for O(n) performance. 25 built-in rules cover AWS keys, API tokens, private keys, database URIs, and more. See the [DLP Reference](reference/dlp.md) for the complete configuration guide.
+DLP scanning uses prefix-gated DFA matching with Aho-Corasick pre-filtering for O(n) performance. 25 built-in rules cover AWS keys, API tokens, private keys, database URIs, and more. See the [DLP Reference](dlp.md) for the complete configuration guide.
 
 ## Tap (Webhook Events)
 
@@ -379,7 +379,7 @@ escalation_threshold = "high"      # Minimum risk level to escalate: low, medium
 escalation_webhook = ""            # Webhook URL for risk escalation notifications
 ```
 
-The `eu-ai-act` preset enables all compliance features. See [ADR-0005](decisions/0005-anthropic-native-provider-trait.md) for the Anthropic-native design that enables transparent model attribution.
+The `eu-ai-act` preset enables all compliance features. See [ADR-0005](../decisions/0005-anthropic-native-provider-trait.md) for the Anthropic-native design that enables transparent model attribution.
 
 ## MCP (Tool Matrix)
 

--- a/docs/reference/openai-compatibility.md
+++ b/docs/reference/openai-compatibility.md
@@ -32,7 +32,7 @@ All requests are translated to Grob's canonical format internally, routed throug
 
 ## Translation pipeline
 
-See [API Compatibility Reference — OpenAI pipeline](reference/api-compatibility.md#translation-pipeline) for the full diagram.
+See [API Compatibility Reference — OpenAI pipeline](api-compatibility.md#translation-pipeline) for the full diagram.
 
 For streaming, the `AnthropicToOpenAIStream` state machine converts Anthropic SSE events into OpenAI-format `chat.completion.chunk` events on the fly.
 

--- a/docs/reference/responses-api-compatibility.md
+++ b/docs/reference/responses-api-compatibility.md
@@ -32,7 +32,7 @@ All requests are translated to Grob's canonical format internally, routed throug
 
 ## Translation pipeline
 
-See [API Compatibility Reference — Responses pipeline](reference/api-compatibility.md#translation-pipeline-1) for the full diagram.
+See [API Compatibility Reference — Responses pipeline](api-compatibility.md#translation-pipeline-1) for the full diagram.
 
 For streaming, the `AnthropicToResponsesStream` state machine converts Anthropic SSE events into Responses API named-event SSE events on the fly.
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -56,7 +56,7 @@ grob doctor     # Full diagnostic check
 
 ## Next steps
 
-- [Architecture overview](explanation/architecture.md) -- how the request pipeline works
-- [Troubleshooting](how-to/troubleshooting.md) -- common errors and fixes
-- [Configuration reference](reference/configuration.md) -- all TOML options
-- [OpenAPI spec](openapi.yaml) -- full API reference
+- [Architecture overview](../explanation/architecture.md) -- how the request pipeline works
+- [Troubleshooting](../how-to/troubleshooting.md) -- common errors and fixes
+- [Configuration reference](../reference/configuration.md) -- all TOML options
+- [OpenAPI spec](../openapi.yaml) -- full API reference


### PR DESCRIPTION
## Summary

Final cleanup follow-up to #261/#263/#264. Validated locally with `lychee --offline --include-fragments docs/**/*.md README.md CLAUDE.md` (0 errors after fix, was 12).

Three recurring patterns:

1. **Doubled subdirectory** in relative links (e.g. `how-to/oauth-setup.md` written from inside `docs/how-to/` → resolves to `docs/how-to/how-to/oauth-setup.md`):
   - `docs/how-to/providers.md` (oauth-setup, gemini-integration)
   - `docs/reference/configuration.md` (dlp)
   - `docs/reference/openai-compatibility.md` (api-compatibility)
   - `docs/reference/responses-api-compatibility.md` (api-compatibility)

2. **Missing parent traversal** (link from one Diátaxis category to another without `../`):
   - `docs/tutorials/quickstart.md` (4 next-step links to explanation/, how-to/, reference/, openapi.yaml)
   - `docs/reference/configuration.md` (ADR-0005 link)

3. **Stale or out-of-tree references**:
   - `docs/how-to/auto-tune-routing.md`: removed link to `docs/explanation/complexity-scoring.md` (file was never created).
   - `docs/decisions/0018-nature-inspired-routing.md`: unlinked two internal Obsidian-vault references (path was absolute to the author's machine, never resolvable in CI). Text retained as non-hyperlinked references.

## Test plan

- [x] `lychee --offline --include-fragments docs/**/*.md README.md CLAUDE.md` → `0 Errors`
- [ ] CI: `Broken link check (lychee)` finally green on `main`