### PR TITLE
chore(docs,ci): point install script to raw GitHub + add lychee pre-commit hook

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -74,7 +74,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --no-progress
-            --accept 200,204,206,301,302,303,308,403,429
+            --accept 200,204,206,301,302,303,307,308,403,429
             docs/**/*.md README.md CLAUDE.md
           fail: true
         env:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,4 +2,3 @@
 ^https?://[^/]+\.example\.(com|org|net)(/.*)?$
 ^https?://grob-(qa|prod|dev|staging)\.example\.com(/.*)?$
 ^https?://.*\.internal(/.*)?$
-^https?://grob\.sh(/.*)?$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Grob is a multi-provider LLM routing proxy written in Rust. It routes requests t
 - **crates.io/crates/grob is a different project** (Coding-Badly/grob, "Growable buffer for Windows API"). Do not confuse or reference it.
 - Container image: `ghcr.io/azerozero/grob:<version>` (scratch, ~6MB)
 - Releases: GitHub Releases via release-plz (auto-bumps version on main push)
-- Install: `brew install azerozero/tap/grob` or `curl -fsSL https://grob.sh | sh`
+- Install: `brew install azerozero/tap/grob` or `curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install.sh | sh`
 
 ### Key Architectural Decisions
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ brew install azerozero/tap/grob
 
 **Without Homebrew** (Linux / CI):
 ```bash
-curl -fsSL https://grob.sh | sh
+curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install.sh | sh
 ```
 
 Then:

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -15,7 +15,7 @@ Choose one of three methods:
 **Option A: Install script (recommended)**
 
 ```bash
-curl -fsSL https://grob.sh | sh
+curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install.sh | sh
 ```
 
 **Option B: Homebrew (macOS / Linux)**

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -7,7 +7,7 @@ Get up and running in 30 seconds.
 ```bash
 brew install azerozero/tap/grob
 # or without Homebrew:
-curl -fsSL https://grob.sh | sh
+curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install.sh | sh
 ```
 
 ## 2. Apply a preset

--- a/prek.toml
+++ b/prek.toml
@@ -42,6 +42,18 @@ entry = "cargo clippy --all-targets -- -D warnings"
 types = ["rust"]
 pass_filenames = false
 
+# Lychee (offline) — catches relative-path drift in markdown links
+# without hitting the network. The CI Docs Lint job runs the online
+# variant; this hook just prevents the obvious internal regressions.
+[[repos.hooks]]
+id = "lychee-offline"
+name = "lychee (offline link check)"
+language = "system"
+entry = "sh"
+args = ["-c", "lychee --offline --no-progress --include-fragments docs/**/*.md README.md CLAUDE.md"]
+types = ["markdown"]
+pass_filenames = false
+
 # Tests — expensive, runs only on pre-push
 [[repos.hooks]]
 id = "cargo-test"


### PR DESCRIPTION
## Summary

The phantom `https://grob.sh` URL never existed and was excluded from lychee. Repointing every `curl | sh` reference to the actual installer that lives in this repo (`scripts/install.sh`, served via `raw.githubusercontent.com`):

```bash
curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install.sh | sh
```

Updated: `README.md`, `CLAUDE.md`, `docs/tutorials/getting-started.md`, `docs/tutorials/quickstart.md`. Removed the corresponding `^https?://grob\.sh` entry from `.lycheeignore` so the install URL is now actively verified by the link checker.

Also:

- **`prek.toml`**: added a `lychee-offline` pre-commit hook. Catches the relative-path drift class of bug we just fought through 5 PRs (#261, #263, #264, #265, this one). `--offline` so it stays under 10 ms and doesn't depend on network at commit time; CI Docs Lint still runs the full online variant.
- **`.github/workflows/docs-lint.yml`**: added `307` to lychee `--accept`. The Mistral console (`https://console.mistral.ai/`) ends its auth-redirect chain on a 307, semantically equivalent to the 301/302/303/308 already accepted.

## Test plan

- [x] `lychee --offline --include-fragments docs/**/*.md README.md CLAUDE.md` → `0 Errors`
- [x] `lychee --no-progress --include-fragments --max-redirects 10 --accept 200,204,206,301,302,303,307,308,403,429 ...` → `0 Errors / 223 OK`
- [x] `curl -I https://raw.githubusercontent.com/azerozero/grob/main/scripts/install.sh` → 200
- [x] Pre-commit `lychee-offline` hook fires on this commit and passes
- [ ] CI: `Broken link check (lychee)` green