### PR TITLE
fix(cache): make simhash hamming threshold configurable via TOML (T-P4-fix)

### DIFF
--- a/src/cache/response_cache.rs
+++ b/src/cache/response_cache.rs
@@ -52,7 +52,12 @@ pub struct ResponseCache {
 
 impl ResponseCache {
     /// Create a new response cache from config.
-    pub fn new(max_capacity: u64, ttl_secs: u64, max_entry_bytes: usize) -> Self {
+    pub fn new(
+        max_capacity: u64,
+        ttl_secs: u64,
+        max_entry_bytes: usize,
+        simhash_threshold: u32,
+    ) -> Self {
         let evictions = std::sync::Arc::new(AtomicU64::new(0));
         let evictions_clone = evictions.clone();
 
@@ -66,7 +71,7 @@ impl ResponseCache {
 
         Self {
             inner: cache,
-            simhash: SimHashCache::new(max_capacity, ttl_secs),
+            simhash: SimHashCache::with_threshold(simhash_threshold, max_capacity, ttl_secs),
             max_entry_bytes,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
@@ -409,7 +414,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_put_get() {
-        let cache = ResponseCache::new(100, 60, 1024 * 1024);
+        let cache = ResponseCache::new(100, 60, 1024 * 1024, 3);
         let key = "test-key".to_string();
         let resp = CachedResponse {
             body: b"hello".to_vec(),
@@ -425,7 +430,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_miss() {
-        let cache = ResponseCache::new(100, 60, 1024 * 1024);
+        let cache = ResponseCache::new(100, 60, 1024 * 1024, 3);
         assert!(cache.get("nonexistent").await.is_none());
         let stats = cache.stats();
         assert_eq!(stats.misses, 1);
@@ -433,7 +438,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_skip_too_large() {
-        let cache = ResponseCache::new(100, 60, 10); // 10 byte limit
+        let cache = ResponseCache::new(100, 60, 10, 3); // 10 byte limit
         let key = "big".to_string();
         let resp = CachedResponse {
             body: vec![0u8; 100],
@@ -481,7 +486,7 @@ mod tests {
     fn test_invalidate_all() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let cache = ResponseCache::new(100, 60, 1024 * 1024);
+            let cache = ResponseCache::new(100, 60, 1024 * 1024, 3);
             let resp = CachedResponse {
                 body: b"data".to_vec(),
                 content_type: "application/json".to_string(),

--- a/src/cli/config/cache.rs
+++ b/src/cli/config/cache.rs
@@ -17,6 +17,9 @@ pub struct CacheConfig {
     /// Maximum single entry size in bytes (skip caching responses larger than this)
     #[serde(default = "default_cache_max_entry_bytes")]
     pub max_entry_bytes: usize,
+    /// Maximum Hamming distance for a SimHash fuzzy cache hit (0 = exact only).
+    #[serde(default = "default_simhash_threshold")]
+    pub simhash_threshold: u32,
 }
 
 impl Default for CacheConfig {
@@ -26,6 +29,7 @@ impl Default for CacheConfig {
             max_capacity: default_cache_max_capacity(),
             ttl_secs: default_cache_ttl(),
             max_entry_bytes: default_cache_max_entry_bytes(),
+            simhash_threshold: default_simhash_threshold(),
         }
     }
 }
@@ -46,4 +50,33 @@ fn default_cache_ttl() -> u64 {
 // (e.g., large code generation) have low cache hit probability anyway.
 fn default_cache_max_entry_bytes() -> usize {
     2 * 1024 * 1024
+}
+
+// NOTE: 3 bits over 64 = ~5% Hamming radius. Empirically catches paraphrases
+// while avoiding false positives between unrelated short prompts.
+fn default_simhash_threshold() -> u32 {
+    3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simhash_threshold_from_toml() {
+        let toml = "enabled = true\nsimhash_threshold = 5";
+        let cfg: CacheConfig = toml::from_str(toml).expect("parse cache config");
+        assert_eq!(cfg.simhash_threshold, 5);
+    }
+
+    #[test]
+    fn defaults_simhash_threshold_when_absent() {
+        let cfg: CacheConfig = toml::from_str("enabled = true").expect("parse cache config");
+        assert_eq!(cfg.simhash_threshold, 3);
+    }
+
+    #[test]
+    fn default_impl_uses_threshold_3() {
+        assert_eq!(CacheConfig::default().simhash_threshold, 3);
+    }
 }

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -309,10 +309,14 @@ pub(crate) fn init_security(config: &AppConfig) -> anyhow::Result<SecurityServic
             config.cache.max_capacity,
             config.cache.ttl_secs,
             config.cache.max_entry_bytes,
+            config.cache.simhash_threshold,
         );
         info!(
-            "💾 Response cache enabled: max_capacity={}, ttl={}s, max_entry={}B",
-            config.cache.max_capacity, config.cache.ttl_secs, config.cache.max_entry_bytes
+            "💾 Response cache enabled: max_capacity={}, ttl={}s, max_entry={}B, simhash_threshold={}",
+            config.cache.max_capacity,
+            config.cache.ttl_secs,
+            config.cache.max_entry_bytes,
+            config.cache.simhash_threshold,
         );
         Some(Arc::new(cache))
     } else {

--- a/tests/integration/cache_test.rs
+++ b/tests/integration/cache_test.rs
@@ -30,7 +30,7 @@ fn test_request(model: &str, text: &str) -> CanonicalRequest {
 
 #[tokio::test]
 async fn test_cache_miss_then_hit() {
-    let cache = ResponseCache::new(100, 60, 1_000_000);
+    let cache = ResponseCache::new(100, 60, 1_000_000, 3);
     let request = test_request("claude-3-5-sonnet", "Hello");
 
     let key =
@@ -60,7 +60,7 @@ async fn test_cache_miss_then_hit() {
 
 #[tokio::test]
 async fn test_cache_different_tenants_independent() {
-    let cache = ResponseCache::new(100, 60, 1_000_000);
+    let cache = ResponseCache::new(100, 60, 1_000_000, 3);
     let request = test_request("claude-3-5-sonnet", "Hello");
 
     let key_a =
@@ -92,7 +92,7 @@ async fn test_cache_different_tenants_independent() {
 
 #[tokio::test]
 async fn test_cache_different_prompts_independent() {
-    let _cache = ResponseCache::new(100, 60, 1_000_000);
+    let _cache = ResponseCache::new(100, 60, 1_000_000, 3);
     let req1 = test_request("claude-3-5-sonnet", "Hello");
     let req2 = test_request("claude-3-5-sonnet", "Goodbye");
 
@@ -109,7 +109,7 @@ async fn test_cache_different_prompts_independent() {
 
 #[tokio::test]
 async fn test_cache_invalidate_all() {
-    let cache = ResponseCache::new(100, 60, 1_000_000);
+    let cache = ResponseCache::new(100, 60, 1_000_000, 3);
     let request = test_request("claude-3-5-sonnet", "Hello");
     let key =
         ResponseCache::compute_key_from_request("tenant", &request).expect("should compute key");
@@ -141,7 +141,7 @@ async fn test_cache_invalidate_all() {
 
 #[tokio::test]
 async fn test_cache_hit_miss_counters() {
-    let cache = ResponseCache::new(100, 60, 1_000_000);
+    let cache = ResponseCache::new(100, 60, 1_000_000, 3);
 
     let request = test_request("claude-3-5-sonnet", "Hello");
     let key =


### PR DESCRIPTION
## Summary
- Adds `[cache].simhash_threshold` (u32, default 3) so operators can trade fuzzy hit rate against false positives without recompiling.
- `SimHashCache::with_threshold()` already existed; `ResponseCache::new()` now takes the threshold and forwards it.
- Closes the T-P4-fix item from Phase P (routing intelligent).

## Changes
- `src/cli/config/cache.rs`: new field with serde default + 3 unit tests (parse, default-when-absent, Default impl)
- `src/cache/response_cache.rs`: constructor signature gains `simhash_threshold: u32`
- `src/server/init.rs`: passes `config.cache.simhash_threshold` and logs it on startup
- `tests/integration/cache_test.rs`: 5 callers updated

## Test plan
- [x] \`cargo check --lib\` — clean
- [x] \`cargo clippy --lib --tests -- -D warnings\` — clean
- [x] \`cargo test --lib cache::\` — 33 passed (incl. 3 new)
- [x] All prek pre-commit + pre-push hooks green
- [ ] CI passes (auto-merge enabled below)

## Migration
Backward compatible: omitting `simhash_threshold` from `[cache]` keeps the previous behavior (threshold = 3).