### PR TITLE
feat(routing): allow tuning classifier weights via grob_configure (T-P5a)

### DIFF
--- a/src/features/mcp/server/types.rs
+++ b/src/features/mcp/server/types.rs
@@ -242,6 +242,8 @@ pub enum ConfigSection {
     Dlp,
     /// LLM response cache settings.
     Cache,
+    /// Complexity classifier scoring weights and tier thresholds.
+    Classifier,
 }
 
 impl std::fmt::Display for ConfigSection {
@@ -251,6 +253,7 @@ impl std::fmt::Display for ConfigSection {
             ConfigSection::Budget => f.write_str("budget"),
             ConfigSection::Dlp => f.write_str("dlp"),
             ConfigSection::Cache => f.write_str("cache"),
+            ConfigSection::Classifier => f.write_str("classifier"),
         }
     }
 }

--- a/src/server/config_guard.rs
+++ b/src/server/config_guard.rs
@@ -48,6 +48,7 @@ pub fn is_key_denied(section: &ConfigSection, key: &str) -> bool {
         ConfigSection::Budget => "budget",
         ConfigSection::Dlp => "dlp",
         ConfigSection::Cache => "cache",
+        ConfigSection::Classifier => "classifier",
     };
     is_section_or_key_denied(section_str, key)
 }

--- a/src/server/mcp_handlers.rs
+++ b/src/server/mcp_handlers.rs
@@ -200,7 +200,7 @@ fn inject_builtin_tools(resp: &mut JsonRpcResponse) {
         }));
         tools.push(serde_json::json!({
             "name": "grob_configure",
-            "description": "Read or update safe configuration sections (router, budget, cache). Credentials and security settings are denied.",
+            "description": "Read or update safe configuration sections (router, budget, cache, classifier). Credentials and security settings are denied.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -210,7 +210,7 @@ fn inject_builtin_tools(resp: &mut JsonRpcResponse) {
                     },
                     "section": {
                         "type": "string",
-                        "enum": ["router", "budget", "dlp", "cache"]
+                        "enum": ["router", "budget", "dlp", "cache", "classifier"]
                     },
                     "key": { "type": "string" },
                     "value": {}
@@ -399,6 +399,22 @@ fn read_config_section(
             "ttl_secs": config.cache.ttl_secs,
             "max_entry_bytes": config.cache.max_entry_bytes,
         }),
+        ConfigSection::Classifier => {
+            let cfg = config.classifier.clone().unwrap_or_default();
+            serde_json::json!({
+                "weights": {
+                    "max_tokens": cfg.weights.max_tokens,
+                    "tools": cfg.weights.tools,
+                    "context_size": cfg.weights.context_size,
+                    "keywords": cfg.weights.keywords,
+                    "system_prompt": cfg.weights.system_prompt,
+                },
+                "thresholds": {
+                    "medium_threshold": cfg.thresholds.medium_threshold,
+                    "complex_threshold": cfg.thresholds.complex_threshold,
+                },
+            })
+        }
     }
 }
 
@@ -486,6 +502,23 @@ fn apply_config_update(
             }
             _ => return Err(format!("unknown cache key: {key}")),
         },
+        ConfigSection::Classifier => {
+            let cfg = config.classifier.get_or_insert_with(Default::default);
+            let v = value
+                .as_f64()
+                .ok_or_else(|| format!("expected number for classifier.{key}"))?
+                as f32;
+            match key {
+                "weights.max_tokens" => cfg.weights.max_tokens = v,
+                "weights.tools" => cfg.weights.tools = v,
+                "weights.context_size" => cfg.weights.context_size = v,
+                "weights.keywords" => cfg.weights.keywords = v,
+                "weights.system_prompt" => cfg.weights.system_prompt = v,
+                "thresholds.medium_threshold" => cfg.thresholds.medium_threshold = v,
+                "thresholds.complex_threshold" => cfg.thresholds.complex_threshold = v,
+                _ => return Err(format!("unknown classifier key: {key}")),
+            }
+        }
     }
     Ok(())
 }
@@ -609,6 +642,7 @@ pub async fn handle_wizard_get_config(
             "budget": read_config_section(config, &ConfigSection::Budget),
             "dlp": read_config_section(config, &ConfigSection::Dlp),
             "cache": read_config_section(config, &ConfigSection::Cache),
+            "classifier": read_config_section(config, &ConfigSection::Classifier),
         }),
     };
 
@@ -793,6 +827,61 @@ mod tests {
         let result = read_config_section(&config, &ConfigSection::Cache);
         assert_eq!(result["enabled"], false);
         assert_eq!(result["ttl_secs"], 3600);
+    }
+
+    #[test]
+    fn test_configure_read_classifier_defaults() {
+        let config = test_app_config();
+        let result = read_config_section(&config, &ConfigSection::Classifier);
+        assert_eq!(result["weights"]["tools"].as_f64().unwrap(), 1.0);
+        assert_eq!(result["weights"]["max_tokens"].as_f64().unwrap(), 1.0);
+        assert_eq!(
+            result["thresholds"]["medium_threshold"].as_f64().unwrap(),
+            2.0
+        );
+        assert_eq!(
+            result["thresholds"]["complex_threshold"].as_f64().unwrap(),
+            5.0
+        );
+    }
+
+    #[test]
+    fn test_configure_update_classifier_weight() {
+        let mut config = test_app_config();
+        apply_config_update(
+            &mut config,
+            &ConfigSection::Classifier,
+            "weights.tools",
+            &serde_json::json!(5.0),
+        )
+        .unwrap();
+        assert_eq!(config.classifier.unwrap().weights.tools, 5.0);
+    }
+
+    #[test]
+    fn test_configure_update_classifier_threshold() {
+        let mut config = test_app_config();
+        apply_config_update(
+            &mut config,
+            &ConfigSection::Classifier,
+            "thresholds.complex_threshold",
+            &serde_json::json!(7.5),
+        )
+        .unwrap();
+        assert_eq!(config.classifier.unwrap().thresholds.complex_threshold, 7.5);
+    }
+
+    #[test]
+    fn test_configure_update_classifier_unknown_key() {
+        let mut config = test_app_config();
+        let err = apply_config_update(
+            &mut config,
+            &ConfigSection::Classifier,
+            "weights.bogus",
+            &serde_json::json!(1.0),
+        )
+        .unwrap_err();
+        assert!(err.contains("unknown classifier key"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds \`Classifier\` variant to \`ConfigSection\` so MCP clients can read and update \`[classifier.weights]\` (5 signals) and \`[classifier.thresholds]\` (2 tier boundaries) at runtime.
- Hot-reload reuses the existing \`config_guard::reload_state()\` pipeline — \`Router::new(config)\` rebuilds the scorer, in-flight requests continue on the old snapshot.
- Unblocks the auto-tune MCP tool (T-P5b).

## Whitelisted keys
- \`weights.max_tokens\`, \`weights.tools\`, \`weights.context_size\`, \`weights.keywords\`, \`weights.system_prompt\` (f32)
- \`thresholds.medium_threshold\`, \`thresholds.complex_threshold\` (f32)

Other keys → \`unknown classifier key: <key>\`. The deny-list (anything containing \`api_key\`) still blocks credential-shaped names.

## Files changed
- \`src/features/mcp/server/types.rs\` — \`ConfigSection::Classifier\` variant + \`Display\`
- \`src/server/mcp_handlers.rs\` — \`read_config_section\` + \`apply_config_update\` branches; tool description JSON updated; \`tools/list\` JSON enum extended; \`wizard_get_config\` includes classifier
- \`src/server/config_guard.rs\` — exhaustive match arm

## Test plan
- [x] \`cargo check --lib\` clean
- [x] \`cargo clippy --lib --tests -- -D warnings\` clean
- [x] \`cargo test server::mcp_handlers::tests::test_configure_\` — 23 passed (4 new for classifier)
- [x] All prek pre-commit + pre-push hooks green
- [ ] CI green (auto-merge enabled below)

## Example MCP call
\`\`\`json
{
  "method": "grob_configure",
  "params": {
    "action": "update",
    "section": "classifier",
    "key": "weights.tools",
    "value": 5.0
  }
}
\`\`\`