### PR TITLE
chore: release v0.36.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.33](https://github.com/azerozero/grob/compare/v0.36.32...v0.36.33) - 2026-04-25
+
+### Fixed
+
+- *(cache)* make simhash hamming threshold configurable via TOML (T-P4-fix)
+
+### Other
+
+- Merge pull request #272 from azerozero/feat/grob-autotune
+- *(how-to)* document grob_hint, classifier tuning, and simhash cache (Phase P)
+- *(docs,ci)* point install script to raw GitHub + add lychee pre-commit hook
+- fix 12 broken internal links (relative-path drift)
+- *(docs-lint)* accept 303 See Other in lychee link checker
+
 ## [0.36.32](https://github.com/azerozero/grob/compare/v0.36.31...v0.36.32) - 2026-04-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.32"
+version = "0.36.33"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.32"
+version = "0.36.33"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.32 -> 0.36.33

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.33](https://github.com/azerozero/grob/compare/v0.36.32...v0.36.33) - 2026-04-25

### Fixed

- *(cache)* make simhash hamming threshold configurable via TOML (T-P4-fix)

### Other

- Merge pull request #272 from azerozero/feat/grob-autotune
- *(how-to)* document grob_hint, classifier tuning, and simhash cache (Phase P)
- *(docs,ci)* point install script to raw GitHub + add lychee pre-commit hook
- fix 12 broken internal links (relative-path drift)
- *(docs-lint)* accept 303 See Other in lychee link checker
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).