### PR TITLE
feat(routing): add grob_autotune MCP tool for offline classifier calibration (T-P5b)

### DIFF
--- a/src/routing/classify/autotune.rs
+++ b/src/routing/classify/autotune.rs
@@ -1,0 +1,141 @@
+//! Offline auto-tuning helper for the complexity classifier.
+//!
+//! Pairs with the `grob_autotune` MCP tool. Two modes:
+//!
+//! - **suggest** — returns the current classifier weights and thresholds as
+//!   [`TuneSuggestion`] entries. The MVP does not yet infer patches from
+//!   observed traffic, so `proposed == current` and the rationale points
+//!   the operator at the manual tuning guide.
+//! - **apply** — accepts a list of [`AutotunePatch`] entries and applies
+//!   them via the existing `grob_configure` pipeline. This is sugar over
+//!   batching multiple `grob_configure update` calls into one MCP round-trip.
+//!
+//! See `docs/how-to/auto-tune-routing.md` for the recommended workflow.
+
+use serde::{Deserialize, Serialize};
+
+use super::ScoringConfig;
+
+/// A single tuning suggestion for the classifier scoring config.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TuneSuggestion {
+    /// Whitelisted classifier key (e.g. `weights.tools`, `thresholds.medium_threshold`).
+    pub key: String,
+    /// Current value in the running config.
+    pub current: f32,
+    /// Suggested value (equal to `current` for the MVP no-op autotune).
+    pub proposed: f32,
+    /// Human-readable explanation for the suggestion (or its absence).
+    pub rationale: String,
+}
+
+/// Operator-supplied patch consumed by `grob_autotune action=apply`.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct AutotunePatch {
+    /// Whitelisted classifier key (same set as `grob_configure section=classifier`).
+    pub key: String,
+    /// New value (f32, accepted as JSON number).
+    pub value: f32,
+}
+
+/// Returns the current classifier values as a vector of suggestions.
+///
+/// Each weight and threshold is reported with `proposed == current` and a
+/// rationale that asks the operator to tune manually. Future revisions
+/// will replace this with inference from trace data and observed metrics.
+pub fn current_snapshot(config: &ScoringConfig) -> Vec<TuneSuggestion> {
+    let rationale = "current value; manual tuning recommended (see auto-tune-routing.md)";
+
+    vec![
+        TuneSuggestion {
+            key: "weights.max_tokens".into(),
+            current: config.weights.max_tokens,
+            proposed: config.weights.max_tokens,
+            rationale: rationale.into(),
+        },
+        TuneSuggestion {
+            key: "weights.tools".into(),
+            current: config.weights.tools,
+            proposed: config.weights.tools,
+            rationale: rationale.into(),
+        },
+        TuneSuggestion {
+            key: "weights.context_size".into(),
+            current: config.weights.context_size,
+            proposed: config.weights.context_size,
+            rationale: rationale.into(),
+        },
+        TuneSuggestion {
+            key: "weights.keywords".into(),
+            current: config.weights.keywords,
+            proposed: config.weights.keywords,
+            rationale: rationale.into(),
+        },
+        TuneSuggestion {
+            key: "weights.system_prompt".into(),
+            current: config.weights.system_prompt,
+            proposed: config.weights.system_prompt,
+            rationale: rationale.into(),
+        },
+        TuneSuggestion {
+            key: "thresholds.medium_threshold".into(),
+            current: config.thresholds.medium_threshold,
+            proposed: config.thresholds.medium_threshold,
+            rationale: rationale.into(),
+        },
+        TuneSuggestion {
+            key: "thresholds.complex_threshold".into(),
+            current: config.thresholds.complex_threshold,
+            proposed: config.thresholds.complex_threshold,
+            rationale: rationale.into(),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_reports_all_seven_keys() {
+        let cfg = ScoringConfig::default();
+        let snapshot = current_snapshot(&cfg);
+        assert_eq!(snapshot.len(), 7);
+    }
+
+    #[test]
+    fn snapshot_proposed_equals_current_in_mvp() {
+        let cfg = ScoringConfig::default();
+        for entry in current_snapshot(&cfg) {
+            assert_eq!(
+                entry.proposed, entry.current,
+                "MVP autotune must not propose patches"
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_uses_running_values_not_defaults() {
+        let mut cfg = ScoringConfig::default();
+        cfg.weights.tools = 7.5;
+        cfg.thresholds.complex_threshold = 9.0;
+        let snapshot = current_snapshot(&cfg);
+
+        let tools = snapshot.iter().find(|s| s.key == "weights.tools").unwrap();
+        assert_eq!(tools.current, 7.5);
+
+        let complex = snapshot
+            .iter()
+            .find(|s| s.key == "thresholds.complex_threshold")
+            .unwrap();
+        assert_eq!(complex.current, 9.0);
+    }
+
+    #[test]
+    fn patch_deserialises_from_json() {
+        let json = r#"{"key":"weights.tools","value":4.5}"#;
+        let p: AutotunePatch = serde_json::from_str(json).unwrap();
+        assert_eq!(p.key, "weights.tools");
+        assert_eq!(p.value, 4.5);
+    }
+}

--- a/src/routing/classify/mod.rs
+++ b/src/routing/classify/mod.rs
@@ -6,6 +6,8 @@
 //! parent alongside the nature-inspired primitives (circuit breaker, health
 //! check) introduced by ADR-0018.
 
+/// Offline auto-tuning helper for the complexity classifier.
+pub mod autotune;
 /// Stateless complexity classifier for tier-based provider selection.
 // NOTE: `classify` inside `classify/` is intentional — the outer module hosts
 // the full classification engine (router, inference, rules, tier_match), and

--- a/src/server/mcp_handlers.rs
+++ b/src/server/mcp_handlers.rs
@@ -41,6 +41,7 @@ pub async fn handle_mcp_rpc(
         "tool_matrix/calibrate" => methods::handle_calibrate(mcp, req.params, req.id.clone()).await,
         "tool_matrix/report" => methods::handle_report(mcp, req.id.clone()).await,
         "grob_configure" => handle_configure(&state, req.params, req.id.clone()).await,
+        "grob_autotune" => handle_autotune(&state, req.params, req.id.clone()).await,
         "grob_hint" => handle_hint(&state, req.params, req.id.clone()).await,
         "grob_keys" => handle_control_tool(&state, "grob/keys", req.params, req.id.clone()).await,
         "grob_tools" => handle_control_tool(&state, "grob/tools", req.params, req.id.clone()).await,
@@ -216,6 +217,31 @@ fn inject_builtin_tools(resp: &mut JsonRpcResponse) {
                     "value": {}
                 },
                 "required": ["action", "section"]
+            }
+        }));
+        tools.push(serde_json::json!({
+            "name": "grob_autotune",
+            "description": "Inspect or batch-apply complexity classifier weight/threshold changes. action=suggest returns current values; action=apply takes a list of {key, value} patches and persists them via the grob_configure pipeline.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["suggest", "apply"]
+                    },
+                    "patches": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "key": { "type": "string" },
+                                "value": { "type": "number" }
+                            },
+                            "required": ["key", "value"]
+                        }
+                    }
+                },
+                "required": ["action"]
             }
         }));
         tools.push(serde_json::json!({
@@ -603,6 +629,104 @@ pub async fn handle_configure(
                 }),
             ))
         }
+    }
+}
+
+// ── grob_autotune ──────────────────────────────────────────────────────────
+
+/// Handles `grob_autotune` — exposes the classifier as a batchable tuning surface.
+///
+/// `action=suggest` returns the current weights and thresholds with a no-op
+/// proposed value (the MVP does not infer patches; future revisions will).
+/// `action=apply` accepts a list of `{key, value}` patches and persists them
+/// via the same pipeline as `grob_configure update section=classifier`.
+pub async fn handle_autotune(
+    state: &Arc<AppState>,
+    params: serde_json::Value,
+    id: serde_json::Value,
+) -> Result<JsonRpcResponse, JsonRpcError> {
+    use crate::routing::classify::autotune::{current_snapshot, AutotunePatch};
+
+    let action = params
+        .get("action")
+        .and_then(|v| v.as_str())
+        .unwrap_or("suggest");
+
+    match action {
+        "suggest" => {
+            let snapshot = state.snapshot();
+            let cfg = snapshot.config.classifier.clone().unwrap_or_default();
+            let suggestions = current_snapshot(&cfg);
+
+            tracing::info!(count = suggestions.len(), "MCP: grob_autotune suggest");
+
+            Ok(JsonRpcResponse::ok(
+                id,
+                serde_json::json!({
+                    "action": "suggest",
+                    "suggestions": suggestions,
+                }),
+            ))
+        }
+        "apply" => {
+            let patches: Vec<AutotunePatch> = match params.get("patches") {
+                Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+                    JsonRpcError::invalid_params(id.clone(), &format!("invalid patches: {e}"))
+                })?,
+                None => {
+                    return Err(JsonRpcError::invalid_params(
+                        id,
+                        "action=apply requires a 'patches' array",
+                    ))
+                }
+            };
+
+            if patches.is_empty() {
+                return Err(JsonRpcError::invalid_params(
+                    id,
+                    "'patches' must contain at least one entry",
+                ));
+            }
+
+            let mut new_config = state.snapshot().config.clone();
+            for patch in &patches {
+                if is_key_denied(&ConfigSection::Classifier, &patch.key) {
+                    return Err(JsonRpcError::invalid_params(
+                        id,
+                        &format!("denied: classifier.{} cannot be modified", patch.key),
+                    ));
+                }
+                apply_config_update(
+                    &mut new_config,
+                    &ConfigSection::Classifier,
+                    &patch.key,
+                    &serde_json::json!(patch.value),
+                )
+                .map_err(|e| JsonRpcError::invalid_params(id.clone(), &e))?;
+            }
+
+            super::config_guard::persist_and_reload(state, &new_config)
+                .await
+                .map_err(|e| JsonRpcError::internal(id.clone(), &e.to_string()))?;
+
+            tracing::info!(
+                applied = patches.len(),
+                "MCP: grob_autotune apply + hot-reload"
+            );
+
+            Ok(JsonRpcResponse::ok(
+                id,
+                serde_json::json!({
+                    "action": "apply",
+                    "applied_count": patches.len(),
+                    "status": "applied",
+                }),
+            ))
+        }
+        other => Err(JsonRpcError::invalid_params(
+            id,
+            &format!("unknown action '{other}' (expected 'suggest' or 'apply')"),
+        )),
     }
 }
 
@@ -1071,12 +1195,13 @@ mod tests {
         inject_builtin_tools(&mut resp);
         let tools = resp.result["tools"].as_array().unwrap();
         let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
-        assert_eq!(tools.len(), 9);
+        assert_eq!(tools.len(), 10);
         assert_eq!(names[0], "grob_hint");
         assert_eq!(names[1], "grob_configure");
-        assert_eq!(names[2], "grob_keys");
-        assert_eq!(names[3], "grob_tools");
-        assert_eq!(names[4], "grob_hit");
+        assert_eq!(names[2], "grob_autotune");
+        assert_eq!(names[3], "grob_keys");
+        assert_eq!(names[4], "grob_tools");
+        assert_eq!(names[5], "grob_hit");
         assert!(names.contains(&"wizard_get_config"));
         assert!(names.contains(&"wizard_set_section"));
         assert!(names.contains(&"wizard_run_doctor"));
@@ -1093,7 +1218,7 @@ mod tests {
         );
         inject_builtin_tools(&mut resp);
         let tools = resp.result["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 10);
+        assert_eq!(tools.len(), 11);
         assert_eq!(tools[0]["name"], "web_search");
         assert_eq!(tools[1]["name"], "grob_hint");
     }


### PR DESCRIPTION
## Summary
Closes the Phase P routing-intelligence work. Pairs with [#268](https://github.com/azerozero/grob/pull/268) (T-P5a) by exposing a higher-level MCP surface dedicated to classifier tuning.

## Two actions

**\`action=suggest\`** — returns the seven classifier weights/thresholds (5 weights + 2 tier thresholds) as \`TuneSuggestion\` entries:

\`\`\`json
{
  "action": "suggest",
  "suggestions": [
    { "key": "weights.tools", "current": 1.0, "proposed": 1.0,
      "rationale": "current value; manual tuning recommended (see auto-tune-routing.md)" },
    ...
  ]
}
\`\`\`

The MVP reports \`proposed == current\`; future revisions will infer patches from observed traffic. Operators can iterate manually using the rationale field as a placeholder.

**\`action=apply\`** — accepts a list of \`{key, value}\` patches and persists them via the existing \`config_guard::persist_and_reload\` pipeline:

\`\`\`json
{
  "action": "apply",
  "patches": [
    { "key": "weights.tools", "value": 5.0 },
    { "key": "thresholds.complex_threshold", "value": 6.0 }
  ]
}
\`\`\`

This is sugar over batching multiple \`grob_configure\` calls into one MCP round-trip; the same deny-list (\`api_key\`, \`providers\`, \`dlp\`) and whitelist (\`weights.*\`, \`thresholds.*\`) apply.

## Files changed
- \`src/routing/classify/autotune.rs\` — new module with \`TuneSuggestion\`, \`AutotunePatch\`, \`current_snapshot()\` + 4 unit tests.
- \`src/routing/classify/mod.rs\` — registers the autotune module.
- \`src/server/mcp_handlers.rs\` — \`handle_autotune\` handler, dispatch registration, tool description in \`tools/list\`; existing \`test_inject_builtin_tools_*\` tests updated for the new tool count.

## Test plan
- [x] \`cargo check --lib\` clean
- [x] \`cargo clippy --lib --tests -- -D warnings\` clean
- [x] \`cargo test routing::classify::autotune\` — 4 passed
- [x] \`cargo test server::mcp_handlers::tests::test_inject\` — 3 passed
- [x] All prek pre-commit + pre-push hooks green
- [ ] CI green (auto-merge enabled below)

## Note on scope
The implementation intentionally ships the surface without speculating on the inference strategy. The \`proposed\` field is wired and forward-compatible with future inference logic. See \`docs/how-to/auto-tune-routing.md\` for the manual tuning workflow.