### PR TITLE
fix(profiles): rename silently-ignored fields + wire Phase P in full-opti-v5

### DIFF
--- a/profiles/full-opti-v5.toml
+++ b/profiles/full-opti-v5.toml
@@ -29,7 +29,7 @@ max_files = 5
 default = "claude-sonnet-4-6"
 think = "claude-opus-4-6"
 background = "background-model"
-web_search = "claude-sonnet-4-6"
+websearch = "claude-sonnet-4-6"
 
 # ── Classifier (seuils du scorer heuristique) ───────────────────
 
@@ -226,18 +226,24 @@ actual_model = "llama-3.1-8b-instant"
 priority = 2
 provider = "groq"
 
-# ── Cache ────────────────────────────────────────────────────────
+# ── Cache (Phase P : exact + SimHash fuzzy) ──────────────────────
+#
+# 10k entries (~20 MiB) × 4h TTL = couvre une journée de Claude Code.
+# simhash_threshold = 4 favorise les hits sur paraphrases/whitespace
+# (default 3 est strict ; 4 capture mieux le boilerplate sans collisions).
 
 [cache]
 enabled = true
-ttl_seconds = 3600
-max_entries = 1000
+max_capacity = 10000
+ttl_secs = 14400
+max_entry_bytes = 4194304
+simhash_threshold = 4
 
 # ── Budget ───────────────────────────────────────────────────────
 
 [budget]
 monthly_limit_usd = 100.0
-warning_threshold_percent = 80
+warn_at_percent = 80
 
 # ── DLP ──────────────────────────────────────────────────────────
 
@@ -247,6 +253,11 @@ scan_input = true
 scan_output = true
 
 # ── Security ─────────────────────────────────────────────────────
+#
+# 2 req/s avec burst 30 ≈ 120 req/min soutenu, mais tolère des
+# salves (parallel tool calls Claude Code peut envoyer 5-10 reqs
+# en même temps).
 
 [security]
-rate_limit_rpm = 120
+rate_limit_rps = 2
+rate_limit_burst = 30


### PR DESCRIPTION
## Summary
The \`profiles/full-opti-v5.toml\` profile had **five field names that serde silently ignored**, so the profile shipped with default values for those keys instead of the values written. Discovered while wiring the new Phase P SimHash threshold.

## Renames (silently dropped → operational)

| Section | Was | Should be |
|---|---|---|
| \`[router]\` | \`web_search\` | \`websearch\` |
| \`[cache]\` | \`ttl_seconds\` | \`ttl_secs\` |
| \`[cache]\` | \`max_entries\` | \`max_capacity\` |
| \`[budget]\` | \`warning_threshold_percent\` | \`warn_at_percent\` |
| \`[security]\` | \`rate_limit_rpm = 120\` | \`rate_limit_rps = 2\` + \`rate_limit_burst = 30\` |

The security split keeps the same sustained rate (2 rps × 60 = 120 rpm) but adds a 30-request burst tolerance — Claude Code routinely fires 5–10 parallel tool calls in a single turn.

## Phase P additions

- \`cache.simhash_threshold = 4\` — slightly more permissive than the default 3 to favor cache hits on paraphrases / whitespace edits without colliding unrelated prompts.
- \`cache.max_entry_bytes = 4 MiB\` — explicit (was unset, falling back to 2 MiB default).
- \`cache.max_capacity\` 1000 → 10000 — 10× window, ~20 MiB total memory.
- \`cache.ttl_secs\` 3600 → 14400 — 4h covers a full Claude Code day.

## Validation
\`\`\`sh
grob --config profiles/full-opti-v5.toml doctor
\`\`\`
returns \`🎉 All checks passed!\` and prints \`rate_limit=2rps\` — proof that the renamed field is now read by the parser (before this PR, the value was silently the default).

## Test plan
- [x] \`grob doctor\` on the patched profile returns success
- [x] Doctor reports \`rate_limit=2rps\` (confirms the renamed field is parsed)
- [ ] CI green (auto-merge enabled below)