### PR TITLE
fix(pricing,profile): add 2026 models + revert cache values to code defaults

### DIFF
--- a/profiles/full-opti-v5.toml
+++ b/profiles/full-opti-v5.toml
@@ -228,16 +228,26 @@ provider = "groq"
 
 # ── Cache (Phase P : exact + SimHash fuzzy) ──────────────────────
 #
-# 10k entries (~20 MiB) × 4h TTL = couvre une journée de Claude Code.
-# simhash_threshold = 4 favorise les hits sur paraphrases/whitespace
-# (default 3 est strict ; 4 capture mieux le boilerplate sans collisions).
+# Defaults justifiés par le code source :
+# - max_capacity=2000 entries (~4 MiB à 2 KiB avg) suffit pour une
+#   journée de tâches Claude Code déterministes.
+# - ttl_secs=3600 (1h) balance freshness vs hit rate. Au-delà,
+#   risque de servir des réponses stales après update provider.
+# - simhash_threshold=3 ≈ 5% Hamming radius sur 64 bits, capture les
+#   paraphrases sans collisions sur prompts courts.
+#
+# IMPORTANT : le cache hit principalement sur temperature=0
+# (background tasks, summaries, MCP tools/list, tests). Pour les
+# conversations user normales, le hit rate est ~0% car la clé inclut
+# l'history complète. Mesurer grob_cache_hits_total / total via
+# Prometheus avant de bumper.
 
 [cache]
 enabled = true
-max_capacity = 10000
-ttl_secs = 14400
+max_capacity = 2000
+ttl_secs = 3600
 max_entry_bytes = 4194304
-simhash_threshold = 4
+simhash_threshold = 3
 
 # ── Budget ───────────────────────────────────────────────────────
 

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -132,6 +132,12 @@ pub static KNOWN_PRICING: &[ModelPricing] = &[
         input_per_million: 0.14,
         output_per_million: 0.14,
     },
+    // GLM-4.7-Flash (Z.ai, released 2026-01-19) — free tier per Z.ai pricing
+    ModelPricing {
+        model: "glm-4.7-flash",
+        input_per_million: 0.0,
+        output_per_million: 0.0,
+    },
     ModelPricing {
         model: "MiniMax-M2",
         input_per_million: 0.30,
@@ -141,6 +147,28 @@ pub static KNOWN_PRICING: &[ModelPricing] = &[
         model: "minimax-m2",
         input_per_million: 0.30,
         output_per_million: 1.20,
+    },
+    // MiniMax M2.5 (released 2026-02-12) — same input price as M2, same output
+    ModelPricing {
+        model: "MiniMax-M2.5",
+        input_per_million: 0.30,
+        output_per_million: 1.20,
+    },
+    ModelPricing {
+        model: "minimax-m2.5",
+        input_per_million: 0.30,
+        output_per_million: 1.20,
+    },
+    // M2.5-Lightning: identical capability, 2x throughput, 2x output cost
+    ModelPricing {
+        model: "MiniMax-M2.5-Lightning",
+        input_per_million: 0.30,
+        output_per_million: 2.40,
+    },
+    ModelPricing {
+        model: "minimax-m2.5-lightning",
+        input_per_million: 0.30,
+        output_per_million: 2.40,
     },
     ModelPricing {
         model: "kimi-k2",
@@ -162,6 +190,24 @@ pub static KNOWN_PRICING: &[ModelPricing] = &[
         model: "llama-3.1-8b",
         input_per_million: 0.05,
         output_per_million: 0.08,
+    },
+    // Llama 3.3 70B (Groq versatile endpoint)
+    ModelPricing {
+        model: "llama-3.3-70b-versatile",
+        input_per_million: 0.59,
+        output_per_million: 0.79,
+    },
+    // Inception Labs (diffusion LLM, fast)
+    ModelPricing {
+        model: "mercury-coder-small",
+        input_per_million: 0.25,
+        output_per_million: 1.25,
+    },
+    // Google Gemini
+    ModelPricing {
+        model: "gemini-2.5-pro",
+        input_per_million: 1.25,
+        output_per_million: 5.00,
     },
 ];
 
@@ -185,4 +231,58 @@ pub fn pricing(model: &str) -> Option<&'static ModelPricing> {
         let lower = model.to_lowercase();
         KNOWN_PRICING.iter().find(|p| lower.contains(p.model))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minimax_m25_lookup() {
+        let p = pricing("MiniMax-M2.5").expect("M2.5 listed");
+        assert_eq!(p.input_per_million, 0.30);
+        assert_eq!(p.output_per_million, 1.20);
+    }
+
+    #[test]
+    fn minimax_m25_lightning_double_output_cost() {
+        let p = pricing("MiniMax-M2.5-Lightning").expect("Lightning listed");
+        assert_eq!(p.input_per_million, 0.30);
+        assert_eq!(p.output_per_million, 2.40);
+    }
+
+    #[test]
+    fn glm_47_flash_is_free_tier() {
+        let p = pricing("glm-4.7-flash").expect("glm-4.7-flash listed");
+        assert_eq!(p.input_per_million, 0.0);
+        assert_eq!(p.output_per_million, 0.0);
+    }
+
+    #[test]
+    fn llama_33_70b_versatile_uses_groq_pricing() {
+        let p = pricing("llama-3.3-70b-versatile").expect("listed");
+        assert_eq!(p.input_per_million, 0.59);
+        assert_eq!(p.output_per_million, 0.79);
+    }
+
+    #[test]
+    fn mercury_coder_small_listed() {
+        let p = pricing("mercury-coder-small").expect("listed");
+        assert_eq!(p.input_per_million, 0.25);
+        assert_eq!(p.output_per_million, 1.25);
+    }
+
+    #[test]
+    fn gemini_25_pro_listed() {
+        let p = pricing("gemini-2.5-pro").expect("listed");
+        assert_eq!(p.input_per_million, 1.25);
+        assert_eq!(p.output_per_million, 5.00);
+    }
+
+    #[test]
+    fn calculate_one_million_input() {
+        let p = pricing("MiniMax-M2.5").unwrap();
+        let cost = p.calculate(1_000_000, 0);
+        assert!((cost - 0.30).abs() < 1e-9);
+    }
 }


### PR DESCRIPTION
## Summary
Two unrelated cleanups (small enough to bundle):

### 1. Pricing — add 6 model entries actually in use today (April 2026)

Without these, the spend tracker either returned the wrong cost (fuzzy fallback to the older version) or `None` (no cost recorded at all):

| Model | Input $/M | Output $/M | Source |
|---|---|---|---|
| MiniMax-M2.5 | 0.30 | 1.20 | MiniMax news Feb 2026 |
| MiniMax-M2.5-Lightning | 0.30 | 2.40 | 2x throughput, 2x output cost |
| glm-4.7-flash | 0.0 | 0.0 | Z.ai docs — free tier |
| llama-3.3-70b-versatile | 0.59 | 0.79 | Groq versatile endpoint |
| mercury-coder-small | 0.25 | 1.25 | Inception API |
| gemini-2.5-pro | 1.25 | 5.00 | Google AI Studio |

Both `MiniMax-M2.5` and lowercase `minimax-m2.5` are listed (mirrors the existing M2 entry style).

### 2. Profile cache values — revert to code defaults

PR #273 bumped these without empirical data. Reverting:

| Key | PR #273 | This PR |
|---|---|---|
| max_capacity | 10000 | **2000** (default) |
| ttl_secs | 14400 | **3600** (default) |
| simhash_threshold | 4 | **3** (default) |
| max_entry_bytes | 4 MiB | 4 MiB (kept) |

The profile comment now reflects reality: the cache hits primarily on `temperature=0` work (background tasks, summaries, MCP `tools/list`, tests). For normal user conversations the hit rate is ~0% because the cache key includes the full message history. Operators should measure `grob_cache_hits_total / total` via Prometheus before bumping.

## Test plan
- [x] `cargo test --lib pricing::tests` — 7 new tests pass
- [x] `cargo clippy --lib --tests -- -D warnings` clean
- [x] All prek pre-commit + pre-push hooks green
- [ ] CI (auto-merge enabled below)
