### PR TITLE
feat(secrets): AES-GCM encrypted upstream api_keys + grob secrets CLI

### DIFF
--- a/docs/how-to/manage-secrets.md
+++ b/docs/how-to/manage-secrets.md
@@ -1,0 +1,142 @@
+# Manage upstream provider secrets
+
+Store API keys for upstream providers (MiniMax, Mercury, OpenRouter,
+DeepInfra, Groq, Z.ai, Gemini, ...) **encrypted at rest** with the same
+AES-256-GCM master key as OAuth tokens. The cleartext value never lives
+in your `config.toml`, your shell history, or your dotfiles.
+
+## When to use this vs alternatives
+
+| Storage | Sensitivity | Reload-friendly | Backup-friendly |
+|---------|-------------|------------------|------------------|
+| `api_key = "secret:<name>"` (this guide) | ✅ encrypted at rest | yes — read on startup | yes — encrypted blob in `~/.grob/secrets/` |
+| `api_key = "$ENV_VAR"` | 🟡 visible to any process via `/proc/<pid>/environ`, shell history, dotfiles | yes (re-export + restart) | depends on env management |
+| `api_key = "sk-..."` plain string | ❌ cleartext on disk, in backups, in version control if `.grob/config.toml` is checked in | yes | dangerous |
+| OAuth via `grob connect` | ✅ encrypted at rest | yes | yes — refresh token blob |
+
+OAuth (Anthropic Max, Gemini Pro) remains the preferred path when the
+provider supports it. Use `grob secrets` for everything else.
+
+## Where the data lives
+
+- Master key: `~/.grob/encryption.key` (32 random bytes, chmod 600)
+- Encrypted secrets: `~/.grob/secrets/<name>.enc`
+
+The master key is generated automatically the first time `grob` opens
+its storage. Back it up — losing the file means every encrypted blob
+(OAuth tokens, virtual keys, secrets) becomes unreadable.
+
+## Add a secret
+
+```sh
+grob secrets add minimax
+# Enter value for 'minimax' (one line, will be encrypted): <paste>
+```
+
+To keep the value out of your shell history, pipe instead:
+
+```sh
+printf '%s' "$YOUR_KEY" | grob secrets add minimax
+```
+
+The trailing newline is stripped. Empty values are rejected.
+
+## Reference the secret in your provider config
+
+Use `secret:<name>` as the `api_key` value:
+
+```toml
+[[providers]]
+name = "minimax"
+provider_type = "openai"
+base_url = "https://api.minimax.chat/v1"
+api_key = "secret:minimax"
+models = ["MiniMax-M2.5"]
+```
+
+On startup, grob resolves the placeholder by looking up `minimax` in the
+encrypted store and substitutes the cleartext into the in-memory provider
+config. The TOML on disk stays clean.
+
+A log line confirms the resolution:
+
+```
+🔐 Resolved api_key for provider 'minimax' from grob secret 'minimax'
+```
+
+If the secret is missing the provider falls back to the unresolved
+placeholder (and the registry warns).
+
+## List
+
+```sh
+grob secrets list
+# Secrets (3 total):
+#   • groq
+#   • minimax
+#   • openrouter
+
+grob secrets list --json
+```
+
+`list` prints names only — never values.
+
+## Show
+
+Default is redacted (`first 4 + last 4` chars):
+
+```sh
+grob secrets show minimax
+# sk-a...XJ7Q
+# (redacted; pass --unsafe-show to reveal)
+```
+
+To reveal the full value (keep it on a private terminal only):
+
+```sh
+grob secrets show minimax --unsafe-show
+```
+
+## Remove
+
+```sh
+grob secrets rm minimax
+# Remove secret 'minimax'? [y/N] y
+# ✅ Removed 'minimax'
+
+grob secrets rm minimax --force        # skip prompt
+```
+
+## Migrate from env vars
+
+Replace each `api_key = "$X_API_KEY"` line with `api_key = "secret:x"`,
+then move the value:
+
+```sh
+printf '%s' "$MINIMAX_API_KEY"  | grob secrets add minimax
+printf '%s' "$DEEPINFRA_API_KEY" | grob secrets add deepinfra
+printf '%s' "$MERCURY_API_KEY"   | grob secrets add mercury
+printf '%s' "$GLM_API_KEY"       | grob secrets add glm
+printf '%s' "$GROQ_API_KEY"      | grob secrets add groq
+printf '%s' "$OPENROUTER_API_KEY" | grob secrets add openrouter
+printf '%s' "$GEMINI_API_KEY"    | grob secrets add gemini
+
+# Then unset the env vars and remove them from your shell rc.
+```
+
+Restart `grob` and confirm the resolution lines in the logs.
+
+## What is **not** here yet (tracked)
+
+- **Master key backup/restore CLI**: `grob secrets export-key --to <file> --password <prompt>` and `import-key`. Today the master key is a raw file — back it up manually.
+- **Pluggable backend** (Vault, Kubernetes Secret, AWS Secrets Manager). Coming via the `SecretBackend` trait — see [PR #276](https://github.com/azerozero/grob/pull/276) (Vault Agent strategy will work via a `File` backend reading from a mounted directory).
+
+## Trade-offs
+
+- The encrypted store is **single-user, single-host**. If you need
+  multi-host or multi-user, prefer a real secret manager (Vault,
+  cloud KMS) and surface it via the upcoming File backend.
+- A compromised local user account can read both the master key
+  (chmod 600) and the encrypted blobs. The store protects against
+  *backups* and *casual disk inspection*, not against an attacker who
+  already has your shell.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -234,6 +234,12 @@ pub enum Commands {
         #[command(subcommand)]
         action: KeyAction,
     },
+    /// Manage encrypted upstream provider secrets (add, list, show, rm)
+    Secrets {
+        /// Secrets management subcommand
+        #[command(subcommand)]
+        action: SecretsAction,
+    },
     /// Manage trace logs (decrypt encrypted traces)
     Logs {
         /// Logs subcommand
@@ -366,6 +372,38 @@ pub enum KeyAction {
     Revoke {
         /// Key UUID or prefix to revoke
         id_or_prefix: String,
+    },
+}
+
+/// Subcommands for managing encrypted upstream provider secrets.
+#[derive(Subcommand)]
+pub enum SecretsAction {
+    /// Add a secret. Reads the value from stdin (one line).
+    Add {
+        /// Secret name (referenced as `secret:<name>` in provider config)
+        name: String,
+    },
+    /// List secret names (no values).
+    List {
+        /// Output as JSON array
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a secret. Redacted by default.
+    Show {
+        /// Secret name
+        name: String,
+        /// Reveal the full value (use with caution)
+        #[arg(long)]
+        unsafe_show: bool,
+    },
+    /// Remove a secret.
+    Rm {
+        /// Secret name
+        name: String,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        force: bool,
     },
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -41,6 +41,8 @@ pub mod restart;
 pub mod rpc_client;
 /// Starts the server in foreground (non-daemonized) mode.
 pub mod run;
+/// Encrypted upstream provider secrets (add, list, show, rm).
+pub mod secrets;
 /// Interactive first-run setup wizard.
 pub mod setup;
 /// Installs shell completion scripts to standard locations.

--- a/src/commands/secrets.rs
+++ b/src/commands/secrets.rs
@@ -1,0 +1,172 @@
+//! Manage upstream provider secrets stored encrypted in `~/.grob/secrets/`.
+//!
+//! Each secret is a single AES-256-GCM encrypted blob keyed by name.
+//! Reuses the same `StorageCipher` as OAuth tokens and virtual keys —
+//! the master key lives at `~/.grob/encryption.key` (chmod 600).
+//!
+//! Three modes for `[[providers]] api_key`:
+//!
+//! - `secret:<name>`     → looked up in this store at startup
+//! - `$ENV_VAR`          → resolved from process env at startup
+//! - `<plain string>`    → used as-is (least secure, accepted for dev)
+
+use crate::storage::GrobStore;
+use secrecy::ExposeSecret;
+use std::io::{self, BufRead, Write};
+
+/// Adds a secret. Reads the value from stdin (one line, trimmed).
+///
+/// Pipe to keep it out of shell history:
+///
+/// ```sh
+/// printf '%s' "$MY_KEY" | grob secrets add minimax
+/// ```
+pub fn cmd_secrets_add(name: &str) {
+    if name.is_empty() {
+        eprintln!("error: secret name is required");
+        std::process::exit(2);
+    }
+    let store = match open_store() {
+        Some(s) => s,
+        None => return,
+    };
+
+    print!("Enter value for '{name}' (one line, will be encrypted): ");
+    let _ = io::stdout().flush();
+
+    let mut value = String::new();
+    if io::stdin().lock().read_line(&mut value).is_err() {
+        eprintln!("error: failed to read value from stdin");
+        std::process::exit(1);
+    }
+    let value = value.trim_end_matches(['\n', '\r']);
+    if value.is_empty() {
+        eprintln!("error: empty secret rejected");
+        std::process::exit(2);
+    }
+
+    if let Err(e) = store.set_secret(name, value) {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    }
+    println!("✅ Secret '{name}' stored encrypted at ~/.grob/secrets/{name}.enc");
+}
+
+/// Lists all secret names. No values are displayed.
+pub fn cmd_secrets_list(json: bool) {
+    let store = match open_store() {
+        Some(s) => s,
+        None => return,
+    };
+    let names = store.list_secrets();
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&names).unwrap_or_else(|_| "[]".into())
+        );
+        return;
+    }
+
+    if names.is_empty() {
+        println!("No secrets stored. Use `grob secrets add <name>` to create one.");
+        return;
+    }
+    println!("Secrets ({} total):", names.len());
+    for n in &names {
+        println!("  • {n}");
+    }
+}
+
+/// Shows a secret. Redacted by default; pass `--unsafe-show` to reveal.
+pub fn cmd_secrets_show(name: &str, unsafe_show: bool) {
+    let store = match open_store() {
+        Some(s) => s,
+        None => return,
+    };
+    let secret = match store.get_secret(name) {
+        Some(s) => s,
+        None => {
+            eprintln!("error: secret '{name}' not found");
+            std::process::exit(1);
+        }
+    };
+
+    let value = secret.expose_secret();
+    if unsafe_show {
+        println!("{value}");
+    } else {
+        println!("{}", redact(value));
+        eprintln!("(redacted; pass --unsafe-show to reveal)");
+    }
+}
+
+/// Removes a secret.
+pub fn cmd_secrets_rm(name: &str, force: bool) {
+    let store = match open_store() {
+        Some(s) => s,
+        None => return,
+    };
+
+    if !force {
+        eprint!("Remove secret '{name}'? [y/N] ");
+        let _ = io::stderr().flush();
+        let mut answer = String::new();
+        if io::stdin().lock().read_line(&mut answer).is_err() {
+            eprintln!("aborted");
+            return;
+        }
+        if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+            eprintln!("aborted");
+            return;
+        }
+    }
+
+    match store.remove_secret(name) {
+        Ok(true) => println!("✅ Removed '{name}'"),
+        Ok(false) => {
+            eprintln!("warn: '{name}' did not exist");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Opens GrobStore at the default path. Prints + exits on failure.
+fn open_store() -> Option<GrobStore> {
+    match GrobStore::open(&GrobStore::default_path()) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            eprintln!("error: failed to open storage: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Redacts a secret for display (first 4 + last 4 chars).
+fn redact(value: &str) -> String {
+    if value.len() <= 12 {
+        "***".to_string()
+    } else {
+        format!("{}...{}", &value[..4], &value[value.len() - 4..])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_short_string() {
+        assert_eq!(redact("short"), "***");
+        assert_eq!(redact("twelvechars1"), "***");
+    }
+
+    #[test]
+    fn redact_long_string() {
+        assert_eq!(redact("sk-abcdefghijklmnopqr"), "sk-a...opqr");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::EnvFilter;
 
 use grob::cli;
 use grob::cli::args::{
-    detect_bare_trailing_cmd, Cli, Commands, KeyAction, LogsAction, PresetAction,
+    detect_bare_trailing_cmd, Cli, Commands, KeyAction, LogsAction, PresetAction, SecretsAction,
 };
 use grob::commands;
 
@@ -233,6 +233,14 @@ async fn main() -> anyhow::Result<()> {
             KeyAction::Revoke { id_or_prefix } => {
                 commands::key::cmd_key_revoke(&config, &id_or_prefix).await
             }
+        },
+        Commands::Secrets { action } => match action {
+            SecretsAction::Add { name } => commands::secrets::cmd_secrets_add(&name),
+            SecretsAction::List { json } => commands::secrets::cmd_secrets_list(json),
+            SecretsAction::Show { name, unsafe_show } => {
+                commands::secrets::cmd_secrets_show(&name, unsafe_show)
+            }
+            SecretsAction::Rm { name, force } => commands::secrets::cmd_secrets_rm(&name, force),
         },
         Commands::Rollback => {
             commands::config_rollback::cmd_config_rollback(&config, &config_source).await?;

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -1,4 +1,5 @@
 use crate::auth::TokenStore;
+use crate::cli::ProviderConfig;
 use crate::features::dlp::session::DlpSessionManager;
 use crate::features::token_pricing::spend::SpendTracker;
 use crate::features::token_pricing::SharedPricingTable;
@@ -47,9 +48,11 @@ pub(crate) async fn init_core_services(
     #[cfg(not(feature = "oauth"))]
     let token_store = TokenStore::new_empty();
 
+    let resolved_providers = resolve_provider_secrets(&config.providers, &grob_store);
+
     let provider_registry = Arc::new(
         ProviderRegistry::from_configs_with_models(
-            &config.providers,
+            &resolved_providers,
             Some(token_store.clone()),
             &config.models,
             &config.server.timeouts,
@@ -90,6 +93,71 @@ pub(crate) async fn init_core_services(
     }
 
     Ok((grob_store, token_store, provider_registry))
+}
+
+/// Resolves `api_key` placeholders in provider configs.
+///
+/// Three modes are recognised on the raw string value:
+/// - `secret:<name>` → looked up in [`GrobStore::get_secret`] (encrypted store)
+/// - `$ENV_VAR`     → resolved from process env via `std::env::var`
+/// - other          → used as-is
+///
+/// Returns a cloned vector with `api_key` replaced. Unresolved placeholders
+/// are kept as-is so the existing fallback / warning paths still trigger.
+fn resolve_provider_secrets(
+    providers: &[ProviderConfig],
+    store: &crate::storage::GrobStore,
+) -> Vec<ProviderConfig> {
+    use secrecy::{ExposeSecret, SecretString};
+
+    providers
+        .iter()
+        .cloned()
+        .map(|mut p| {
+            let raw = p.api_key.as_ref().map(|s| s.expose_secret().to_string());
+            if let Some(raw) = raw {
+                if let Some(name) = raw.strip_prefix("secret:") {
+                    match store.get_secret(name) {
+                        Some(resolved) => {
+                            p.api_key = Some(resolved);
+                            tracing::info!(
+                                "🔐 Resolved api_key for provider '{}' from grob secret '{}'",
+                                p.name,
+                                name
+                            );
+                        }
+                        None => {
+                            tracing::warn!(
+                                "Provider '{}' references unknown secret '{}' (use `grob secrets add {}`)",
+                                p.name,
+                                name,
+                                name
+                            );
+                        }
+                    }
+                } else if let Some(var) = raw.strip_prefix('$') {
+                    match std::env::var(var) {
+                        Ok(v) => {
+                            p.api_key = Some(SecretString::new(v));
+                            tracing::info!(
+                                "🔓 Resolved api_key for provider '{}' from env var ${}",
+                                p.name,
+                                var
+                            );
+                        }
+                        Err(_) => {
+                            tracing::warn!(
+                                "Provider '{}' references env var ${} but it is not set",
+                                p.name,
+                                var
+                            );
+                        }
+                    }
+                }
+            }
+            p
+        })
+        .collect()
 }
 
 /// Initializes tracing, spend tracker, pricing table, and Prometheus.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -229,6 +229,75 @@ impl GrobStore {
         Self::list_enc_files(&tokens_dir)
     }
 
+    // ── Generic secrets storage (for upstream provider api_keys) ────────
+
+    fn secret_path(&self, name: &str) -> PathBuf {
+        self.base_dir
+            .join("secrets")
+            .join(format!("{}.enc", sanitize_filename(name)))
+    }
+
+    fn ensure_secrets_dir(&self) -> Result<()> {
+        let dir = self.base_dir.join("secrets");
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("failed to create secrets dir: {}", dir.display()))
+    }
+
+    /// Stores a named secret encrypted with AES-256-GCM.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encryption or the atomic file write fails.
+    pub fn set_secret(&self, name: &str, value: &str) -> Result<()> {
+        self.ensure_secrets_dir()?;
+        let encrypted = self.cipher.encrypt(value.as_bytes())?;
+        atomic::write_atomic(&self.secret_path(name), &encrypted)?;
+        Ok(())
+    }
+
+    /// Reads a named secret. Returns `None` if absent.
+    pub fn get_secret(&self, name: &str) -> Option<secrecy::SecretString> {
+        let path = self.secret_path(name);
+        let encrypted = std::fs::read(&path).ok()?;
+        let decrypted = self.cipher.decrypt_or_plaintext(&encrypted);
+        let s = String::from_utf8(decrypted).ok()?;
+        Some(secrecy::SecretString::new(s))
+    }
+
+    /// Lists secret names (no values).
+    pub fn list_secrets(&self) -> Vec<String> {
+        let dir = self.base_dir.join("secrets");
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => return vec![],
+        };
+        let mut names = vec![];
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let s = name.to_string_lossy();
+            if let Some(stripped) = s.strip_suffix(".enc") {
+                names.push(stripped.to_string());
+            }
+        }
+        names.sort();
+        names
+    }
+
+    /// Removes a named secret. Returns `Ok(false)` if it did not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file exists but cannot be removed.
+    pub fn remove_secret(&self, name: &str) -> Result<bool> {
+        let path = self.secret_path(name);
+        if !path.exists() {
+            return Ok(false);
+        }
+        std::fs::remove_file(&path)
+            .with_context(|| format!("failed to remove secret: {}", path.display()))?;
+        Ok(true)
+    }
+
     /// Gets all OAuth tokens (decrypts each from AES-256-GCM).
     pub fn all_oauth_tokens(&self) -> std::collections::HashMap<String, OAuthToken> {
         let mut map = std::collections::HashMap::new();
@@ -395,7 +464,7 @@ fn sanitize_filename(s: &str) -> String {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use secrecy::SecretString;
+    use secrecy::{ExposeSecret, SecretString};
 
     #[test]
     fn test_open_and_spend_cycle() {
@@ -613,5 +682,58 @@ mod tests {
         assert_eq!(sanitize_filename("claude-max"), "claude-max");
         assert_eq!(sanitize_filename("tenant/evil"), "tenant_evil");
         assert_eq!(sanitize_filename("a:b"), "a_b");
+    }
+
+    #[test]
+    fn test_secret_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GrobStore::open(&dir.path().join("grob.db")).unwrap();
+
+        store.set_secret("minimax", "sk-minimax-test-123").unwrap();
+
+        let got = store.get_secret("minimax").unwrap();
+        assert_eq!(got.expose_secret(), "sk-minimax-test-123");
+    }
+
+    #[test]
+    fn test_secret_list_does_not_leak_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GrobStore::open(&dir.path().join("grob.db")).unwrap();
+
+        store.set_secret("minimax", "sk-secret-value").unwrap();
+        store.set_secret("groq", "gsk-other-secret").unwrap();
+
+        let names = store.list_secrets();
+        assert_eq!(names, vec!["groq", "minimax"]);
+        for n in &names {
+            assert!(!n.contains("sk-"), "list must not leak values");
+        }
+    }
+
+    #[test]
+    fn test_secret_remove() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GrobStore::open(&dir.path().join("grob.db")).unwrap();
+
+        store.set_secret("ephemeral", "x").unwrap();
+        assert!(store.get_secret("ephemeral").is_some());
+
+        let removed = store.remove_secret("ephemeral").unwrap();
+        assert!(removed);
+        assert!(store.get_secret("ephemeral").is_none());
+
+        let again = store.remove_secret("ephemeral").unwrap();
+        assert!(!again, "remove on absent must return Ok(false)");
+    }
+
+    #[test]
+    fn test_secret_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GrobStore::open(&dir.path().join("grob.db")).unwrap();
+
+        store.set_secret("rotating", "v1").unwrap();
+        store.set_secret("rotating", "v2").unwrap();
+
+        assert_eq!(store.get_secret("rotating").unwrap().expose_secret(), "v2");
     }
 }


### PR DESCRIPTION
## Summary
Adds an encrypted-at-rest store for upstream provider API keys, reusing the existing `StorageCipher` (AES-256-GCM) used for OAuth tokens. The cleartext key never touches `config.toml`, shell history, or dotfiles.

## Three modes for `[[providers]] api_key` (resolved at startup)

| Mode | Where the value lives | Status |
|---|---|---|
| `secret:<name>` | `~/.grob/secrets/<name>.enc` (AES-GCM) | ✅ recommended |
| `$ENV_VAR` | process env | now actually resolved (was silent before) |
| `<plain string>` | cleartext in TOML | ⚠️ accepted for dev only |

A startup log line confirms each resolution:
```
🔐 Resolved api_key for provider 'minimax' from grob secret 'minimax'
🔓 Resolved api_key for provider 'groq' from env var $GROQ_API_KEY
```

## Public surface

```sh
grob secrets add minimax           # prompts for value (or pipe via stdin)
grob secrets list [--json]         # names only — never values
grob secrets show minimax          # redacted (sk-a...XJ7Q)
grob secrets show minimax --unsafe-show
grob secrets rm minimax [--force]
```

`add` reads the value from stdin and rejects empty input. `list` never displays values (verified by unit test). `show` is redacted by default; `--unsafe-show` reveals.

## Files changed
- `src/storage/mod.rs` — `set_secret/get_secret/list_secrets/remove_secret` + 4 unit tests
- `src/commands/secrets.rs` — new module (4 actions + 2 redaction unit tests)
- `src/commands/mod.rs` — module declaration
- `src/cli/args.rs` — `Commands::Secrets` + `enum SecretsAction`
- `src/main.rs` — dispatch
- `src/server/init.rs` — `resolve_provider_secrets()` clones the providers list and substitutes resolved keys (backward compat: `ProviderConfig` struct unchanged)
- NEW `docs/how-to/manage-secrets.md` — migration steps from env vars, trade-offs vs Vault/KMS

## Test plan
- [x] `cargo test --lib storage::tests::test_secret` — 4 passed
- [x] `cargo test --lib commands::secrets::` — 2 passed
- [x] E2E verified: `printf 'sk-x' | grob secrets add foo`, `grob secrets list` (no value leak), `grob secrets show foo` (redacted), `grob secrets show foo --unsafe-show` (revealed), `grob secrets rm foo --force`
- [x] `cargo clippy --lib --tests --bin grob -- -D warnings` clean
- [x] All prek pre-commit + pre-push hooks green
- [ ] CI green (auto-merge enabled below)

## Out of scope (follow-up)
- `grob secrets export-key --to <file> --password <prompt>` and `import-key` for portable backup of the master AES key (PBKDF2 password wrap)
- `SecretBackend` trait + `File` / `Vault` / `KMS` backends — see P-276 (`feat/secret-backend-trait`, drafted)

## Migration
Drop-in compatible with existing `$VAR` providers (now actually resolved). For new secrets:

```sh
printf '%s' "$MINIMAX_API_KEY" | grob secrets add minimax
# Then in your TOML:
api_key = "secret:minimax"
# Then unset the env var.
```
