### PR TITLE
chore: release v0.36.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.34](https://github.com/azerozero/grob/compare/v0.36.33...v0.36.34) - 2026-04-25
+
+### Added
+
+- *(secrets)* AES-GCM encrypted upstream api_keys + grob secrets CLI
+
+### Fixed
+
+- *(profiles)* rename silently-ignored fields + wire Phase P in full-opti-v5
+
 ## [0.36.33](https://github.com/azerozero/grob/compare/v0.36.32...v0.36.33) - 2026-04-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.33"
+version = "0.36.34"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.33"
+version = "0.36.34"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.33 -> 0.36.34

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.34](https://github.com/azerozero/grob/compare/v0.36.33...v0.36.34) - 2026-04-25

### Added

- *(secrets)* AES-GCM encrypted upstream api_keys + grob secrets CLI

### Fixed

- *(profiles)* rename silently-ignored fields + wire Phase P in full-opti-v5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).