### PR TITLE
chore: release v0.36.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.35](https://github.com/azerozero/grob/compare/v0.36.34...v0.36.35) - 2026-04-26
+
+### Other
+
+- *(infra,ci)* pin container images and guard against version drift
+- SDK examples, freshness fixes, and orphan-page links
+- *(slices)* per-slice README charters and slice manifest
+- *(mcp)* split mcp_handlers.rs into per-domain modules
+
 ## [0.36.34](https://github.com/azerozero/grob/compare/v0.36.33...v0.36.34) - 2026-04-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.34"
+version = "0.36.35"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.34"
+version = "0.36.35"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.34 -> 0.36.35

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.35](https://github.com/azerozero/grob/compare/v0.36.34...v0.36.35) - 2026-04-26

### Other

- *(infra,ci)* pin container images and guard against version drift
- SDK examples, freshness fixes, and orphan-page links
- *(slices)* per-slice README charters and slice manifest
- *(mcp)* split mcp_handlers.rs into per-domain modules
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).