### PR TITLE
fix(validate): resolve secret: and $ENV placeholders before testing providers

### DIFF
--- a/src/preset/validation.rs
+++ b/src/preset/validation.rs
@@ -7,6 +7,7 @@ use crate::auth::TokenStore;
 use crate::models::config::AppConfig;
 use crate::models::{CanonicalRequest, Message, MessageContent};
 use crate::providers::ProviderRegistry;
+use crate::storage::GrobStore;
 
 /// Result of validating a single provider/model mapping
 #[derive(Debug)]
@@ -51,17 +52,34 @@ impl ModelValidation {
 
 /// Builds a provider registry from config (for CLI validation path).
 ///
+/// Resolves `secret:<name>` and `$ENV_VAR` placeholders in `[[providers]]
+/// api_key` before constructing the registry, so `grob validate` exercises
+/// the same authentication path as the running server. Without this,
+/// `secret:` references would be sent verbatim as bearer tokens and every
+/// provider would fail with 401.
+///
 /// # Errors
 ///
-/// Returns an error if the token store cannot be initialized or the
-/// provider registry cannot be built from the config.
+/// Returns an error if the token store, encrypted store, or provider
+/// registry cannot be built from the config.
 pub fn build_registry(config: &AppConfig) -> Result<(Arc<ProviderRegistry>, TokenStore)> {
     let token_store = TokenStore::at_default_path()
         .map_err(|e| anyhow::anyhow!("Failed to init token store: {}", e))?;
 
+    let grob_store = Arc::new(
+        GrobStore::open(&GrobStore::default_path())
+            .map_err(|e| anyhow::anyhow!("Failed to open encrypted store: {}", e))?,
+    );
+    let secret_backend =
+        crate::storage::secrets::build_backend(&config.secrets, grob_store.clone());
+    let resolved_providers = crate::storage::secrets::resolve_provider_secrets(
+        &config.providers,
+        secret_backend.as_ref(),
+    );
+
     let registry = Arc::new(
         ProviderRegistry::from_configs_with_models(
-            &config.providers,
+            &resolved_providers,
             Some(token_store.clone()),
             &config.models,
             &config.server.timeouts,

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -1,5 +1,4 @@
 use crate::auth::TokenStore;
-use crate::cli::ProviderConfig;
 use crate::features::dlp::session::DlpSessionManager;
 use crate::features::token_pricing::spend::SpendTracker;
 use crate::features::token_pricing::SharedPricingTable;
@@ -51,7 +50,10 @@ pub(crate) async fn init_core_services(
     let secret_backend =
         crate::storage::secrets::build_backend(&config.secrets, grob_store.clone());
     info!("🔑 Secret backend: {}", secret_backend.label());
-    let resolved_providers = resolve_provider_secrets(&config.providers, secret_backend.as_ref());
+    let resolved_providers = crate::storage::secrets::resolve_provider_secrets(
+        &config.providers,
+        secret_backend.as_ref(),
+    );
 
     let provider_registry = Arc::new(
         ProviderRegistry::from_configs_with_models(
@@ -96,72 +98,6 @@ pub(crate) async fn init_core_services(
     }
 
     Ok((grob_store, token_store, provider_registry))
-}
-
-/// Resolves `api_key` placeholders in provider configs.
-///
-/// Three modes are recognised on the raw string value:
-/// - `secret:<name>` → looked up in [`GrobStore::get_secret`] (encrypted store)
-/// - `$ENV_VAR`     → resolved from process env via `std::env::var`
-/// - other          → used as-is
-///
-/// Returns a cloned vector with `api_key` replaced. Unresolved placeholders
-/// are kept as-is so the existing fallback / warning paths still trigger.
-fn resolve_provider_secrets(
-    providers: &[ProviderConfig],
-    backend: &dyn crate::storage::secrets::SecretBackend,
-) -> Vec<ProviderConfig> {
-    use secrecy::{ExposeSecret, SecretString};
-
-    providers
-        .iter()
-        .cloned()
-        .map(|mut p| {
-            let raw = p.api_key.as_ref().map(|s| s.expose_secret().to_string());
-            if let Some(raw) = raw {
-                if let Some(name) = raw.strip_prefix("secret:") {
-                    match backend.get(name) {
-                        Some(resolved) => {
-                            p.api_key = Some(resolved);
-                            tracing::info!(
-                                "🔐 Resolved api_key for provider '{}' from {} backend (name='{}')",
-                                p.name,
-                                backend.label(),
-                                name
-                            );
-                        }
-                        None => {
-                            tracing::warn!(
-                                "Provider '{}' references unknown secret '{}' on backend '{}'",
-                                p.name,
-                                name,
-                                backend.label()
-                            );
-                        }
-                    }
-                } else if let Some(var) = raw.strip_prefix('$') {
-                    match std::env::var(var) {
-                        Ok(v) => {
-                            p.api_key = Some(SecretString::new(v));
-                            tracing::info!(
-                                "🔓 Resolved api_key for provider '{}' from env var ${}",
-                                p.name,
-                                var
-                            );
-                        }
-                        Err(_) => {
-                            tracing::warn!(
-                                "Provider '{}' references env var ${} but it is not set",
-                                p.name,
-                                var
-                            );
-                        }
-                    }
-                }
-            }
-            p
-        })
-        .collect()
 }
 
 /// Initializes tracing, spend tracker, pricing table, and Prometheus.

--- a/src/storage/secrets.rs
+++ b/src/storage/secrets.rs
@@ -107,6 +107,77 @@ pub fn build_backend(cfg: &SecretsConfig, store: Arc<GrobStore>) -> Arc<dyn Secr
     }
 }
 
+/// Resolves `api_key` placeholders in provider configs.
+///
+/// Three modes are recognised on the raw string value:
+/// - `secret:<name>` → looked up in the supplied [`SecretBackend`]
+/// - `$ENV_VAR`     → resolved from process env via `std::env::var`
+/// - other          → used as-is
+///
+/// Returns a cloned vector with `api_key` replaced. Unresolved placeholders
+/// are kept as-is so the existing fallback / warning paths still trigger.
+///
+/// The single source of truth for this resolution: both the running server
+/// (`server::init`) and the `validate` CLI command go through this function
+/// so a `secret:` reference behaves identically in production and at the
+/// validation surface.
+pub fn resolve_provider_secrets(
+    providers: &[crate::cli::ProviderConfig],
+    backend: &dyn SecretBackend,
+) -> Vec<crate::cli::ProviderConfig> {
+    use secrecy::ExposeSecret;
+
+    providers
+        .iter()
+        .cloned()
+        .map(|mut p| {
+            let raw = p.api_key.as_ref().map(|s| s.expose_secret().to_string());
+            if let Some(raw) = raw {
+                if let Some(name) = raw.strip_prefix("secret:") {
+                    match backend.get(name) {
+                        Some(resolved) => {
+                            p.api_key = Some(resolved);
+                            tracing::info!(
+                                "🔐 Resolved api_key for provider '{}' from {} backend (name='{}')",
+                                p.name,
+                                backend.label(),
+                                name
+                            );
+                        }
+                        None => {
+                            tracing::warn!(
+                                "Provider '{}' references unknown secret '{}' on backend '{}'",
+                                p.name,
+                                name,
+                                backend.label()
+                            );
+                        }
+                    }
+                } else if let Some(var) = raw.strip_prefix('$') {
+                    match std::env::var(var) {
+                        Ok(v) => {
+                            p.api_key = Some(SecretString::new(v));
+                            tracing::info!(
+                                "🔓 Resolved api_key for provider '{}' from env var ${}",
+                                p.name,
+                                var
+                            );
+                        }
+                        Err(_) => {
+                            tracing::warn!(
+                                "Provider '{}' references unset env var ${}",
+                                p.name,
+                                var
+                            );
+                        }
+                    }
+                }
+            }
+            p
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,11 +185,110 @@ mod tests {
 
     // NOTE: env_backend with set_var would require `unsafe` (deny'd at lib level).
     // We only test the absent path here; the present path is exercised end-to-end
-    // by `init.rs::resolve_provider_secrets` through the existing $VAR pathway.
+    // by `resolve_provider_secrets` through the existing $VAR pathway.
     #[test]
     fn env_backend_returns_none_when_missing() {
         let b = EnvBackend;
         assert!(b.get("definitely-not-set-1234-grob").is_none());
+    }
+
+    /// Stub backend for testing `resolve_provider_secrets` without touching
+    /// disk or env. Returns the supplied value for the configured name only.
+    struct StubBackend {
+        name: &'static str,
+        value: &'static str,
+    }
+    impl SecretBackend for StubBackend {
+        fn get(&self, name: &str) -> Option<SecretString> {
+            if name == self.name {
+                Some(SecretString::new(self.value.into()))
+            } else {
+                None
+            }
+        }
+        fn label(&self) -> &'static str {
+            "stub"
+        }
+    }
+
+    fn make_provider(name: &str, api_key: Option<&str>) -> crate::cli::ProviderConfig {
+        crate::cli::ProviderConfig {
+            name: name.into(),
+            provider_type: "openai".into(),
+            auth_type: crate::cli::AuthType::ApiKey,
+            api_key: api_key.map(|s| SecretString::new(s.into())),
+            oauth_provider: None,
+            project_id: None,
+            location: None,
+            base_url: None,
+            headers: None,
+            models: vec![],
+            enabled: Some(true),
+            budget_usd: None,
+            region: None,
+            pass_through: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            pool: None,
+            circuit_breaker: None,
+            health_check: None,
+        }
+    }
+
+    #[test]
+    fn resolve_secret_prefix_replaces_api_key() {
+        let p = make_provider("openrouter", Some("secret:openrouter"));
+        let backend = StubBackend {
+            name: "openrouter",
+            value: "sk-or-v1-real-key",
+        };
+        let out = resolve_provider_secrets(&[p], &backend);
+        assert_eq!(
+            out[0].api_key.as_ref().unwrap().expose_secret(),
+            "sk-or-v1-real-key"
+        );
+    }
+
+    #[test]
+    fn resolve_secret_unknown_name_keeps_placeholder() {
+        // Unresolved placeholders survive — caller's fallback chain handles
+        // the resulting 401, the warning is emitted via tracing.
+        let p = make_provider("openrouter", Some("secret:nonexistent"));
+        let backend = StubBackend {
+            name: "other",
+            value: "irrelevant",
+        };
+        let out = resolve_provider_secrets(&[p], &backend);
+        assert_eq!(
+            out[0].api_key.as_ref().unwrap().expose_secret(),
+            "secret:nonexistent"
+        );
+    }
+
+    #[test]
+    fn resolve_plain_string_is_passthrough() {
+        let p = make_provider("openrouter", Some("sk-literal-key"));
+        let backend = StubBackend {
+            name: "openrouter",
+            value: "should-not-be-used",
+        };
+        let out = resolve_provider_secrets(&[p], &backend);
+        assert_eq!(
+            out[0].api_key.as_ref().unwrap().expose_secret(),
+            "sk-literal-key"
+        );
+    }
+
+    #[test]
+    fn resolve_missing_api_key_is_noop() {
+        let p = make_provider("anthropic", None);
+        let backend = StubBackend {
+            name: "x",
+            value: "y",
+        };
+        let out = resolve_provider_secrets(&[p], &backend);
+        assert!(out[0].api_key.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`grob validate` called `preset::build_registry` directly, which constructed a `ProviderRegistry` from raw `[[providers]] api_key` strings without going through the resolution pipeline used at server start. As a result, every provider configured with a `secret:<name>` reference returned **401 "Missing Authentication header"** during validation while working perfectly in production — a confusing, hard-to-debug split between the validate and runtime surfaces.

## Fix

Promote `resolve_provider_secrets` to a **single source of truth** living in `storage::secrets`:

```rust
pub fn resolve_provider_secrets(
    providers: &[ProviderConfig],
    backend: &dyn SecretBackend,
) -> Vec<ProviderConfig>
```

- `server::init` imports it (the inline copy is removed).
- `preset::validation::build_registry` opens a fresh `GrobStore`, builds the secret backend declared in `[secrets]`, resolves the provider configs, and only then constructs the registry.

Both `grob start` and `grob validate` now go through the same code path. A `secret:openrouter` placeholder behaves identically in both.

## Verified locally on the same config

| Mapping | Before | After |
|---------|--------|-------|
| `openrouter/deepseek/deepseek-v3.2` | ❌ 401 Missing Authentication header | ✅ OK (1505ms) |
| `openrouter/minimax/minimax-m2.7` | ❌ 401 | ✅ OK (483ms) |
| `openrouter/deepseek/deepseek-v4-pro` | ❌ 401 | ✅ OK (2058ms) |
| `groq/llama-3.1-8b-instant` | ❌ 401 Invalid API Key | ✅ OK (114ms) |

Errors still shown afterwards (OAuth not connected, deepseek/gemini direct API keys not stored) are **legitimate** misconfigurations the user can act on.

## Tests

Adds four unit tests covering `resolve_provider_secrets`:

- `resolve_secret_prefix_replaces_api_key` — `secret:<name>` resolves through the backend
- `resolve_secret_unknown_name_keeps_placeholder` — unknown name keeps the placeholder so callers see the warning + 401 (no silent eat)
- `resolve_plain_string_is_passthrough` — literal string passes through untouched
- `resolve_missing_api_key_is_noop` — absent `api_key` is a no-op (OAuth providers)

## Test plan

- [x] `cargo nextest run -E 'test(resolve_)'` — 14/14 passed (4 new + 10 unrelated)
- [x] `cargo check --all-features` — clean
- [x] `cargo run --release -- validate` — confirms the four mappings above flip from 401 to 200
- [ ] CI: full nextest + clippy + fmt + audit + deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)
