### PR TITLE
fix(connect): trigger OAuth browser flow directly from grob connect

### DIFF
--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -1,9 +1,16 @@
+use crate::providers::AuthType;
 use crate::{cli, preset};
 
 /// Launches interactive credential setup for one or all providers.
 ///
 /// When `force_reauth` is set, any existing OAuth tokens for the targeted
 /// provider(s) are deleted and a fresh PKCE flow is initiated.
+///
+/// The provider argument matches against either `[[providers]] name` or
+/// `[[providers]] oauth_provider`, so `grob connect anthropic-max` and
+/// `grob connect anthropic` both reach the Anthropic OAuth flow when the
+/// config wires them together (a frequent source of confusion in support
+/// threads).
 pub async fn cmd_connect(
     config: &cli::AppConfig,
     config_source: &cli::ConfigSource,
@@ -18,12 +25,28 @@ pub async fn cmd_connect(
         }
     };
 
-    if let Some(ref provider_name) = provider {
-        let found = config.providers.iter().any(|p| p.name == *provider_name);
-        if !found {
-            eprintln!("❌ Provider '{}' not found in config", provider_name);
+    // Resolve the user-supplied identifier (which may be either the
+    // provider name or the oauth_provider id) to the canonical provider
+    // name used everywhere else in the codebase.
+    let resolved_provider: Option<String> = if let Some(ref id) = provider {
+        if let Some(p) = config
+            .providers
+            .iter()
+            .find(|p| p.name == *id || p.oauth_provider.as_deref() == Some(id.as_str()))
+        {
+            if p.name != *id {
+                println!(
+                    "ℹ  '{}' resolves to provider '{}' (oauth_provider={}). Using canonical name.",
+                    id,
+                    p.name,
+                    p.oauth_provider.as_deref().unwrap_or("?")
+                );
+            }
+            Some(p.name.clone())
+        } else {
+            eprintln!("❌ Provider '{}' not found in config", id);
             eprintln!(
-                "   Available: {}",
+                "   Available names:           {}",
                 config
                     .providers
                     .iter()
@@ -31,15 +54,42 @@ pub async fn cmd_connect(
                     .collect::<Vec<_>>()
                     .join(", ")
             );
+            let oauth_ids: Vec<&str> = config
+                .providers
+                .iter()
+                .filter_map(|p| p.oauth_provider.as_deref())
+                .collect();
+            if !oauth_ids.is_empty() {
+                eprintln!("   Available oauth_provider:  {}", oauth_ids.join(", "));
+            }
             return Ok(());
+        }
+    } else {
+        None
+    };
+
+    if force_reauth {
+        return force_reauth_flow(config, resolved_provider.as_deref()).await;
+    }
+
+    // OAuth fast path: when the targeted provider uses OAuth and has no
+    // stored token, drive the browser flow directly here. This avoids the
+    // legacy "OAuth will be set up on first `grob start`" message which
+    // misled users into chaining `grob connect` then `grob start` then
+    // hitting the "already running" error.
+    if let Some(ref provider_name) = resolved_provider {
+        let target = config
+            .providers
+            .iter()
+            .find(|p| p.name == *provider_name)
+            .expect("resolved provider exists by construction");
+
+        if target.auth_type == AuthType::OAuth {
+            return run_oauth_flow_for_provider(config, provider_name).await;
         }
     }
 
-    if force_reauth {
-        return force_reauth_flow(config, provider.as_deref()).await;
-    }
-
-    if let Some(ref provider_name) = provider {
+    if let Some(ref provider_name) = resolved_provider {
         println!("🔑 Setting up credentials for '{}'...", provider_name);
         if let Err(e) =
             preset::setup_credentials_interactive_filtered(&file_path, Some(provider_name))
@@ -52,6 +102,59 @@ pub async fn cmd_connect(
             eprintln!("❌ Credential setup failed: {}", e);
         }
     }
+    Ok(())
+}
+
+/// Runs the PKCE browser flow for a single OAuth provider (no token
+/// deletion, unlike `force_reauth_flow`). If a valid token already exists,
+/// reports that and exits without prompting again.
+async fn run_oauth_flow_for_provider(
+    config: &cli::AppConfig,
+    provider_name: &str,
+) -> anyhow::Result<()> {
+    use crate::auth::auto_flow::{detect_credentials, run_interactive_flow, CredentialStatus};
+    use crate::auth::TokenStore;
+    use crate::storage::GrobStore;
+    use std::sync::Arc;
+
+    let grob_store = Arc::new(
+        GrobStore::open(&GrobStore::default_path())
+            .map_err(|e| anyhow::anyhow!("Failed to initialize credential storage: {}", e))?,
+    );
+
+    #[cfg(feature = "oauth")]
+    let token_store = TokenStore::with_store(grob_store.clone())
+        .map_err(|e| anyhow::anyhow!("Failed to initialize token store: {}", e))?;
+    #[cfg(not(feature = "oauth"))]
+    let token_store = {
+        let _ = &grob_store;
+        TokenStore::new_empty()
+    };
+
+    let statuses = detect_credentials(&config.providers, &token_store);
+    let needs_oauth: Vec<CredentialStatus> = statuses
+        .into_iter()
+        .filter(|s| {
+            matches!(s, CredentialStatus::MissingOAuth { provider_name: name, .. } if name == provider_name)
+        })
+        .collect();
+
+    if needs_oauth.is_empty() {
+        println!(
+            "✅ Provider '{}' already has a valid OAuth token.",
+            provider_name
+        );
+        println!(
+            "   Use `grob connect {} --force-reauth` to redo.",
+            provider_name
+        );
+        return Ok(());
+    }
+
+    println!("🔑 Launching OAuth flow for '{}'...", provider_name);
+    println!("   A browser window will open. Sign in to grant access.");
+    run_interactive_flow(needs_oauth, &token_store).await?;
+    println!("✅ OAuth setup complete. You can now run `grob start` or `grob exec -- <cmd>`.");
     Ok(())
 }
 

--- a/src/preset/credentials.rs
+++ b/src/preset/credentials.rs
@@ -217,11 +217,19 @@ pub fn setup_credentials_interactive(config_path: &Path) -> Result<()> {
 }
 
 /// Prompt the user for a single missing credential. Returns true if config was modified.
+///
+/// OAuth providers cannot be handled here — the PKCE flow is async and
+/// needs a tokio runtime + browser callback server. The caller
+/// (`cmd_connect`) detects OAuth statuses up-front and routes them through
+/// `auth::auto_flow::run_interactive_flow` instead. This function only
+/// gets a status whose detail does NOT contain "OAuth".
 fn prompt_for_credential(status: &CredentialStatus, config: &mut toml::Value) -> Result<bool> {
     if status.detail.contains("OAuth") {
+        // Defensive: should be filtered out by cmd_connect; preserve a clear
+        // pointer to the right entry point if it ever slips through.
         println!(
-            "  {} — OAuth will be set up on first `grob start`",
-            status.provider_name
+            "  {} — OAuth detected; run `grob connect {}` (without --force-reauth) to launch the browser flow.",
+            status.provider_name, status.provider_name
         );
         return Ok(false);
     }


### PR DESCRIPTION
## Summary

`grob connect <provider>` is supposed to be the one-stop credential setup, but the current OAuth flow is broken in two ways that turn it into a multi-step support thread.

### Bug 1 — `grob connect anthropic-max` rejects a name the docs tell users to type

Every onboarding doc, preset comment, and prior support thread refers to the Anthropic Max OAuth via `anthropic-max` (the `oauth_provider` id). But `cmd_connect` only matches against `[[providers]] name`, so the command fails with:

```
❌ Provider 'anthropic-max' not found in config
   Available: anthropic, openrouter, deepseek, mercury, groq, gemini
```

Users have to know that the actual `name` in the config happens to be `anthropic`. This is a frequent first-run footgun.

### Bug 2 — `grob connect anthropic` doesn't actually run OAuth

Once you find the right name, the command prints:

```
  anthropic — OAuth will be set up on first `grob start`
```

…and exits without doing anything. Users then run `grob start`, which either:
- starts the daemon and runs the browser flow against a callback that never reaches them, or
- fails with `Service is already running (PID: …)` if a previous `grob start -d` is up,

forcing a `grob stop` → `grob start` → Ctrl+C → `grob start -d` cycle to actually log in.

## Fix

Three changes in `src/commands/connect.rs` and one safety net in `src/preset/credentials.rs`:

1. **Resolve identifier through both `name` and `oauth_provider`.** When the user supplies `anthropic-max`, the lookup finds the provider whose `oauth_provider == "anthropic-max"`, prints `ℹ 'anthropic-max' resolves to provider 'anthropic'`, and continues with the canonical name. Both forms now reach the right flow.

2. **OAuth fast path.** When `target.auth_type == AuthType::OAuth`, `cmd_connect` now calls a new `run_oauth_flow_for_provider` which opens a `GrobStore` + `TokenStore`, calls `detect_credentials`, filters down to the provider's `MissingOAuth` status, and runs the existing `auth::auto_flow::run_interactive_flow` directly. The browser opens in the same invocation; no `grob start` chaining required. If a token already exists, the command reports it and tells the user to add `--force-reauth` if they want to redo.

3. **Defensive fallback in the legacy wizard.** `prompt_for_credential` used to print "OAuth will be set up on first `grob start`" — now it points at `grob connect <name>` (without `--force-reauth`) so any code path that leaks into the wizard with an OAuth status still surfaces the right next command.

API key providers (and the all-providers form `grob connect`) keep their existing wizard path untouched. `force_reauth_flow` is unchanged and still handles the explicit re-auth case.

## Verified locally

- `cargo check --all-features` clean
- `cargo nextest run -E 'test(connect) or test(force_reauth) or test(prompt_for_credential)'` — 4/4 (existing tests still pass)
- The OAuth flow itself is browser-driven; it cannot be exercised in CI but the call into `run_interactive_flow` is the same primitive that `--force-reauth` already uses successfully.

## Test plan

- [x] `cargo check --all-features`
- [x] `cargo nextest run -E 'test(connect)'`
- [ ] CI: full nextest + clippy + fmt + audit + deny
- [ ] Manual: `grob connect anthropic-max` opens a browser and stores the token without `grob start`
- [ ] Manual: `grob connect anthropic` (canonical name) does the same
- [ ] Manual: `grob connect openrouter` (api_key provider) still goes through the TOML wizard
- [ ] Manual: `grob connect anthropic-max --force-reauth` deletes + re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
