### PR TITLE
fix(reload): apply secret resolution on every reload path

### DIFF
--- a/src/server/config_api.rs
+++ b/src/server/config_api.rs
@@ -223,9 +223,18 @@ pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Respons
     // 2. Build new router (compiles regexes)
     let new_router = Router::new(new_config.clone());
 
-    // 3. Build new provider registry (reuse existing token_store)
-    let new_registry = match ProviderRegistry::from_configs_with_models(
+    // 3. Build new provider registry. Resolve `secret:<name>` and
+    //    `$ENV_VAR` placeholders before passing the providers in, so a
+    //    hot reload behaves the same as `grob start` and CLI `validate`.
+    //    Same code path as `server::init` and `preset::build_registry`.
+    let secret_backend =
+        crate::storage::secrets::build_backend(&new_config.secrets, state.grob_store.clone());
+    let resolved_providers = crate::storage::secrets::resolve_provider_secrets(
         &new_config.providers,
+        secret_backend.as_ref(),
+    );
+    let new_registry = match ProviderRegistry::from_configs_with_models(
+        &resolved_providers,
         Some(state.token_store.clone()),
         &new_config.models,
         &new_config.server.timeouts,

--- a/src/server/config_guard.rs
+++ b/src/server/config_guard.rs
@@ -98,6 +98,13 @@ pub async fn persist_and_reload(
 }
 
 /// Rebuilds [`ReloadableState`] from a validated config and atomically swaps it.
+///
+/// Resolves `secret:<name>` and `$ENV_VAR` placeholders in `[[providers]]
+/// api_key` before constructing the new registry. Without this step, a hot
+/// reload that touches a provider declared with `api_key = "secret:foo"`
+/// would push the literal placeholder back into the registry and every
+/// upstream call would fail with 401 until the daemon is fully restarted.
+/// Same code path as `server::init` and `preset::build_registry`.
 fn reload_state(
     state: &Arc<super::AppState>,
     config: crate::models::config::AppConfig,
@@ -105,8 +112,15 @@ fn reload_state(
 ) -> Result<(), super::AppError> {
     let new_router = crate::routing::classify::Router::new(config.clone());
 
-    let new_registry = crate::providers::ProviderRegistry::from_configs_with_models(
+    let secret_backend =
+        crate::storage::secrets::build_backend(&config.secrets, state.grob_store.clone());
+    let resolved_providers = crate::storage::secrets::resolve_provider_secrets(
         &config.providers,
+        secret_backend.as_ref(),
+    );
+
+    let new_registry = crate::providers::ProviderRegistry::from_configs_with_models(
+        &resolved_providers,
         Some(state.token_store.clone()),
         &config.models,
         &config.server.timeouts,

--- a/src/server/rpc/server_ns.rs
+++ b/src/server/rpc/server_ns.rs
@@ -60,8 +60,18 @@ pub async fn reload_config(
 
     let new_router = Router::new(new_config.clone());
 
-    let new_registry = ProviderRegistry::from_configs_with_models(
+    // Resolve `secret:<name>` and `$ENV_VAR` placeholders so the JSON-RPC
+    // reload path sees the same authenticated registry as `grob start`,
+    // `validate`, and the HTTP `/api/config/reload` endpoint.
+    let secret_backend =
+        crate::storage::secrets::build_backend(&new_config.secrets, state.grob_store.clone());
+    let resolved_providers = crate::storage::secrets::resolve_provider_secrets(
         &new_config.providers,
+        secret_backend.as_ref(),
+    );
+
+    let new_registry = ProviderRegistry::from_configs_with_models(
+        &resolved_providers,
         Some(state.token_store.clone()),
         &new_config.models,
         &new_config.server.timeouts,


### PR DESCRIPTION
## Summary

PR #280 fixed `grob validate` to resolve `secret:<name>` and `$ENV_VAR` placeholders before building `ProviderRegistry`. **Three other paths in the same codebase had the same bug** and continued to rebuild the registry from raw `config.providers`, silently sending the literal placeholder as the upstream bearer token.

## Buggy callsites (now fixed)

| File | Path | Trigger |
|------|------|---------|
| `server::config_guard::reload_state` | PUT `/api/config` (persist + reload) | Web UI save, MCP `grob_configure` |
| `server::config_api::reload_config` | POST `/api/config/reload` | manual `curl`, dashboard |
| `server::rpc::server_ns::reload_config` | JSON-RPC `server/reload_config` | MCP RPC client |

## Symptom

Hot reload returned `{"status":"success"}` and atomically swapped the registry. Every subsequent upstream call then failed with `401 "Missing Authentication header"` — the daemon had to be fully stopped and restarted to pick up secrets. Hot-reload was effectively broken for any user with `api_key = "secret:..."`.

## Fix

Each callsite now mirrors `server::init`:

```rust
let secret_backend = storage::secrets::build_backend(&new_config.secrets, state.grob_store.clone());
let resolved = storage::secrets::resolve_provider_secrets(&new_config.providers, secret_backend.as_ref());
ProviderRegistry::from_configs_with_models(&resolved, ...)
```

Five reload-touching sites (init, validate, config_guard, config_api, server_ns) now share the same pre-resolution pipeline.

## Why didn't tests catch this?

- `resolve_provider_secrets` unit tests cover the helper in isolation.
- Reload-swap tests cover the atomic-swap mechanism in isolation.
- **No integration test wires "config with `secret:foo` → reload → upstream call sees resolved key" through the public API.**

Follow-up work should pick one of:

- **(a)** add the missing integration test (touches `AppState` test setup, ~150 LoC)
- **(b)** refactor `ProviderRegistry::from_configs_with_models` to accept `&dyn SecretBackend` so resolution is impossible to forget at the type level (~50 LoC, every existing caller updated, every future caller opts out explicitly)

I'd vote **(b)** — the bug pattern repeated three times in three months tells us the API shape is wrong.

## Test plan

- [x] `cargo check --all-features` clean
- [x] `cargo nextest run -E 'test(resolve_)'` — 14/14 passing (helper + access policy + control engine)
- [x] Manual: confirmed locally that `curl POST /api/config/reload` after this fix re-resolves secrets and subsequent upstream calls succeed without restart
- [ ] CI: full nextest + clippy + fmt + audit + deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)
