### PR TITLE
chore: release v0.36.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.38](https://github.com/azerozero/grob/compare/v0.36.37...v0.36.38) - 2026-04-26
+
+### Added
+
+- *(rpc)* impl tools/enable + tools/disable with in-memory mutation ([#228](https://github.com/azerozero/grob/pull/228))
+
 ## [0.36.37](https://github.com/azerozero/grob/compare/v0.36.36...v0.36.37) - 2026-04-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.37"
+version = "0.36.38"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.37"
+version = "0.36.38"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.37 -> 0.36.38

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.38](https://github.com/azerozero/grob/compare/v0.36.37...v0.36.38) - 2026-04-26

### Added

- *(rpc)* impl tools/enable + tools/disable with in-memory mutation ([#228](https://github.com/azerozero/grob/pull/228))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).