### PR TITLE
fix(ci): docs-lint regex matches IP addresses; dedupe Iterate heading

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -68,11 +68,14 @@ jobs:
           set -euo pipefail
           # Allow specific historical references (CHANGELOG, ADRs that
           # legitimately quote a version, dci-report archive). Reject
-          # anything else under docs/ that matches the v0.X.Y pattern.
-          if grep -REn 'v?0\.[0-9]+\.[0-9]+' docs/ \
+          # anything else under docs/ that matches the vX.Y.Z pattern.
+          # The literal `v` prefix is required so IP addresses like
+          # `0.0.0.0` and `127.0.0.1` (legitimate in network docs) are
+          # not flagged as version drift.
+          if grep -REn '\bv[0-9]+\.[0-9]+\.[0-9]+\b' docs/ \
               --include='*.md' \
               --exclude-dir=archive \
-            | grep -vE '(CHANGELOG|examples/|reference/dci-report|decisions/0007|decisions/0011|decisions/0014|decisions/0017|decisions/0018|decisions/0006|decisions/0010|decisions/0009)'; then
+            | grep -vE '(CHANGELOG|examples/|reference/dci-report|reference/benchmarks|decisions/0007|decisions/0011|decisions/0014|decisions/0017|decisions/0018|decisions/0006|decisions/0010|decisions/0009|decisions/0012|decisions/0015|decisions/0016)'; then
             echo
             echo "::error::Hardcoded version string detected in docs/."
             echo "Single source of truth is Cargo.toml. Reference Cargo.toml or the CHANGELOG instead."

--- a/docs/how-to/auto-tune-routing.md
+++ b/docs/how-to/auto-tune-routing.md
@@ -164,8 +164,6 @@ tool). The hint is consumed for one request only.
 
 ## Iterate
 
-## Iterate
-
 1. Collect traces for a representative period (a few hours to a day).
 2. Run the `jq` analysis to find misrouted or slow requests.
 3. Adjust one parameter at a time via `grob_configure`.


### PR DESCRIPTION
## Summary

Two pre-existing false positives in the docs-lint workflow that surface on every release-plz auto-PR (#291 currently blocked by both):

### 1. `no-hardcoded-version` regex matches IP addresses

The regex `v?0\.[0-9]+\.[0-9]+` was too greedy: with `?` on `v` plus the `0\.` anchor, it matched the first three octets of legitimate IP addresses like `0.0.0.0` and `127.0.0.1` in network-deployment docs (`oauth-setup.md`, `troubleshooting.md`, `deploy.md`, `security.md`).

Tightened to `\bv[0-9]+\.[0-9]+\.[0-9]+\b`: the literal `v` prefix is mandatory, word boundaries prevent partial matches inside other identifiers.

Also extended the exclusion list to cover ADR-0012/0015/0016 and `reference/benchmarks.md` which legitimately quote historical version numbers when documenting when a feature landed.

### 2. Duplicate `## Iterate` heading in auto-tune-routing.md

Removed the duplicate empty heading that triggered `MD024 no-duplicate-heading`.

## Why now

Both were pre-existing on `main`. They surface specifically on release-plz PRs because:
- The workflow's `paths: ["**.md"]` trigger picks up `CHANGELOG.md` edits.
- Each release cut runs the full doc-lint suite on the existing tree.

The version-bump PR #291 (v0.36.39) is currently blocked. Merging this fix unblocks every future release.

## Test plan

- [x] Local repro: `grep -REn '\bv[0-9]+\.[0-9]+\.[0-9]+\b' docs/ --include='*.md' --exclude-dir=archive | grep -vE '<exclusion>'` → empty (guard passes).
- [x] `docs/how-to/auto-tune-routing.md` no longer has duplicate H2.
- [ ] CI: docs-lint job goes green; #291 release-plz PR can auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)