### PR TITLE
fix(routing): auto-map respects explicit [[models]] entries

### DIFF
--- a/src/routing/classify/mod.rs
+++ b/src/routing/classify/mod.rs
@@ -312,14 +312,32 @@ impl Router {
             }
         }
 
-        // 3. Auto-mapping (model name transformation, after background check)
+        // 3. Auto-mapping (model name transformation, after background check).
+        //
+        // If the user has an explicit `[[models]]` entry whose name matches
+        // the incoming request model, that entry takes precedence — auto-map
+        // is a "catch-all rewrite for unconfigured models", not a forced
+        // override. Without this guard, a request for `claude-sonnet-4-6`
+        // would be rewritten to `router.default` even when the user defined
+        // a virtual `claude-sonnet-4-6` model with its own fallback chain;
+        // the chain would never run and pass-through would leak the virtual
+        // name "default-model" to the upstream provider.
         if let Some(ref mapper) = self.auto_mapper {
             if mapper.is_match(&request.model) {
-                info!(
-                    "Auto-mapped model '{}' → '{}'",
-                    request.model, self.config.router.default
-                );
-                request.model.clone_from(&self.config.router.default);
+                let has_explicit_virtual =
+                    self.config.models.iter().any(|m| m.name == request.model);
+                if has_explicit_virtual {
+                    info!(
+                        "Auto-map skipped for '{}' — explicit [[models]] entry takes precedence",
+                        request.model
+                    );
+                } else {
+                    info!(
+                        "Auto-mapped model '{}' → '{}'",
+                        request.model, self.config.router.default
+                    );
+                    request.model.clone_from(&self.config.router.default);
+                }
             }
         }
 

--- a/src/routing/classify/tests.rs
+++ b/src/routing/classify/tests.rs
@@ -201,6 +201,50 @@ fn test_auto_map_custom_regex() {
 }
 
 #[test]
+fn test_auto_map_skips_explicit_virtual_model() {
+    // Regression: a request that matches the auto_map regex must NOT be
+    // rewritten to `router.default` when the user has an explicit
+    // `[[models]]` entry with the same name. Without this guard the
+    // virtual entry's fallback chain would be bypassed entirely and the
+    // virtual name would leak to a pass-through provider downstream.
+    use crate::cli::ModelConfig;
+
+    let mut config = create_test_config();
+    // Add a virtual model entry with the same name as the incoming model.
+    config.models.push(ModelConfig {
+        name: "claude-sonnet-4-6".to_string(),
+        mappings: vec![],
+        budget_usd: None,
+        strategy: Default::default(),
+        fan_out: None,
+        deprecated: None,
+    });
+    let router = Router::new(config);
+
+    let mut request = create_simple_request("Hello");
+    request.model = "claude-sonnet-4-6".to_string();
+
+    let decision = router.route(&mut request).unwrap();
+    assert_eq!(decision.route_type, RouteType::Default);
+    // Must use the explicit virtual name, NOT the auto-mapped default.
+    assert_eq!(decision.model_name, "claude-sonnet-4-6");
+}
+
+#[test]
+fn test_auto_map_still_rewrites_unmapped_claude() {
+    // Counter-test: when the user has no `[[models]]` entry for the
+    // incoming claude-* name, auto-map continues to rewrite as before.
+    let config = create_test_config();
+    let router = Router::new(config);
+
+    let mut request = create_simple_request("Hello");
+    request.model = "claude-some-unmapped-variant".to_string();
+
+    let decision = router.route(&mut request).unwrap();
+    assert_eq!(decision.model_name, "default.model");
+}
+
+#[test]
 fn test_no_auto_map_non_matching() {
     let config = create_test_config();
     let router = Router::new(config);


### PR DESCRIPTION
## Summary

`Router::route` step 3 (auto-mapping) was rewriting `request.model` to `router.default` for any name matching `auto_map_regex` — **even when the user had an explicit `[[models]]` virtual entry with that name**. The virtual entry's fallback chain was therefore bypassed entirely.

The bug surfaces in production with errors like:

```
Provider API error: 400 - {"error":{"message":"default-model is not a valid model ID","code":400},"user_id":"user_..."}
```

## Repro

1. Client sends `claude-sonnet-4-6`.
2. Auto-map regex `^claude-` matches → `request.model` rewritten to `default-model`.
3. The user's explicit `[[models]] name = "claude-sonnet-4-6"` with fallbacks (anthropic native → OR `anthropic/claude-sonnet-4.6` → `deepseek-v4-flash`) is **never consulted**.
4. `default-model` chain runs; on exhaustion `try_direct_provider_lookup` forwards `model = "default-model"` to a pass-through provider (OpenRouter), which 400s.

This is the failure mode I hit while debugging Anthropic 429 fallback chains: when the primary `anthropic/claude-sonnet-4-6` mapping returned 429, the fallback to `openrouter/anthropic/claude-sonnet-4.6` should have succeeded (and does succeed when called directly), but auto-map prevented it from ever being tried.

## Fix

```rust
let has_explicit_virtual = self.config.models.iter().any(|m| m.name == request.model);
if !has_explicit_virtual {
    request.model.clone_from(&self.config.router.default);
}
```

The check is regex-agnostic: it covers every `auto_map_regex` configuration (claude, gpt, gemini, mixed, custom) — no provider-specific code path needed.

Auto-map continues to rewrite the model when no explicit virtual exists, preserving the original "catch-all rewrite for unconfigured models" intent.

## Other routing steps audited

| Step | Mutation pattern | Same bug? |
|------|-----------------|-----------|
| 1 WebSearch | `decision.model_name = ...` direct | No |
| 2 Background | `decision.model_name = ...` direct | No |
| **3 Auto-map** | `request.model = ...` then falls through | **Yes — fixed here** |
| 4 Subagent | `decision.model_name = ...` direct | No |
| 5 PromptRule | `decision.model_name = ...` direct | No |
| 6 Think | `decision.model_name = ...` direct | No |

Auto-map is the only step that mutates `request.model` and falls through; the other steps either return early or set `decision.model_name` without touching `request.model`. No other leak path exists.

## Tests

Adds two regression tests:

- `test_auto_map_skips_explicit_virtual_model` — confirms the new behaviour.
- `test_auto_map_still_rewrites_unmapped_claude` — counter-test confirming the original catch-all path is intact.

Existing tests still pass: `test_auto_map_claude_models`, `test_auto_map_custom_regex`, `test_no_auto_map_non_matching`, `test_auto_map_routes_to_default`.

## Test plan

- [x] `cargo nextest run -E 'test(auto_map)'` — 9/9 passing
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [ ] CI: full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)