### PR TITLE
feat(routing): canonicalize model names before [[models]] lookup

### DIFF
--- a/proptest-regressions/routing/classify/model_name.txt
+++ b/proptest-regressions/routing/classify/model_name.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ed22e205cea604efdd7f73b78af099418b6bb35987fe7509e463707851ab76bc # shrinks to input = "0.0.0"

--- a/src/routing/classify/mod.rs
+++ b/src/routing/classify/mod.rs
@@ -19,6 +19,8 @@ pub mod classify;
 pub mod inference;
 /// Message content extraction for routing decisions.
 mod message;
+/// Model-name canonicalizer (date suffix, `-latest`, dotted versions, …).
+pub mod model_name;
 /// Regex compilation and capture-group utilities.
 mod rules;
 /// Declarative tier matcher for `[tiers.match]` conditions.
@@ -268,6 +270,11 @@ impl Router {
     /// Routes an incoming request to the appropriate model.
     ///
     /// Priority order (highest to lowest):
+    /// 0. Canonicalization - cosmetic variations of model IDs (date suffix,
+    ///    `-latest`, dotted versions, Anthropic family/version reorder) are
+    ///    collapsed to a single canonical key before any subsequent step
+    ///    so that `[[models]]` lookups, prompt-rule regexes, and the
+    ///    auto-mapper all see the same string.
     /// 1. WebSearch - tool-based detection (`web_search` tool present)
     /// 2. Background - model name regex match (e.g., haiku), checked early to save costs
     /// 3. Auto-map - regex-driven model-name rewrite (falls through to later steps)
@@ -278,7 +285,7 @@ impl Router {
     /// 8. Algorithmic complexity scoring - heuristic fallback when `[[scoring]]` is set
     /// 9. Default - auto-mapped or original model name, with tier from steps 7-8
     ///
-    /// Steps 3 (auto-map) mutates `request.model` but does not short-circuit;
+    /// Steps 0 and 3 (auto-map) mutate `request.model` but do not short-circuit;
     /// steps 7-8 populate `complexity_tier` without choosing a model. All other
     /// steps return early with the matched model.
     ///
@@ -286,6 +293,18 @@ impl Router {
     ///
     /// Returns an error if a configured prompt-rule regex fails to compile.
     pub fn route(&self, request: &mut CanonicalRequest) -> Result<RouteDecision> {
+        // 0. Canonicalize the model name. Idempotent and zero-alloc on
+        //    already-canonical inputs, so configs that already use the
+        //    canonical IDs (`gpt-4o`, `claude-sonnet-4-5`, …) pay nothing.
+        let canonical = model_name::canonicalize_model_name(&request.model);
+        if canonical.as_ref() != request.model.as_str() {
+            debug!(
+                "🪞 Canonicalised model '{}' → '{}'",
+                request.model, canonical
+            );
+            request.model = canonical.into_owned();
+        }
+
         // 1. WebSearch (HIGHEST PRIORITY - tool-based detection, no model name needed)
         if let Some(ref websearch_model) = self.config.router.websearch {
             if self.has_web_search_tool(request) {

--- a/src/routing/classify/model_name.rs
+++ b/src/routing/classify/model_name.rs
@@ -1,0 +1,365 @@
+//! Model-name canonicalizer.
+//!
+//! Users frequently type small variations of provider model IDs that differ
+//! only in cosmetic ways: a trailing date suffix (`claude-3-5-sonnet-20241022`),
+//! a `-latest` alias, decimal versions vs dashed versions
+//! (`gemini-2.5-flash` vs `gemini-2-5-flash`), reordered family/version
+//! tokens for Anthropic (`claude-3-5-sonnet` vs `claude-sonnet-3-5`), or
+//! mixed casing. Without canonicalization, an explicit `[[models]]` entry
+//! named `claude-sonnet-3-5` would not match a request for
+//! `Claude-3-5-Sonnet-20241022`, even though both refer to the same model.
+//!
+//! [`canonicalize_model_name`] applies a deterministic, idempotent set of
+//! rewrites *before* the `[[models]]` lookup so that user-facing variations
+//! collapse into the configured canonical key.
+//!
+//! # Rules (in order)
+//!
+//! 1. **Lowercase**. ASCII-only; non-ASCII bytes are passed through unchanged.
+//! 2. **Strip trailing `-latest`** (e.g. `claude-sonnet-4-5-latest` →
+//!    `claude-sonnet-4-5`).
+//! 3. **Strip trailing 8-digit date suffix** `-YYYYMMDD` (e.g.
+//!    `claude-3-5-sonnet-20241022` → `claude-3-5-sonnet`, which the
+//!    next rules then reorder). Must be exactly 8 digits to avoid
+//!    clobbering version segments such as `gpt-5-2`.
+//! 4. **Dot-versions to dashed-versions** for Anthropic / Gemini / Grok /
+//!    DeepSeek / OpenAI families (e.g. `gemini-2.5-flash` →
+//!    `gemini-2-5-flash`, `gpt-5.2` → `gpt-5-2`,
+//!    `claude-3.5-sonnet` → `claude-3-5-sonnet`). Gated on a known
+//!    family prefix so unrelated IDs (e.g. `glm-4.6`) survive
+//!    untouched.
+//! 5. **Anthropic family-version reorder**: `claude-{N}-{M}-{family}` →
+//!    `claude-{family}-{N}-{M}` (where `family` is `sonnet`, `opus`, or
+//!    `haiku`) so that both Anthropic-published spellings collapse into
+//!    one key. The newer style (`claude-sonnet-4-5`) is used as the
+//!    canonical form because that is the spelling used in `presets/*.toml`
+//!    — keeping config keys verbatim avoids breaking existing
+//!    `[[models]]` entries and fallback chains.
+//!
+//! Existing canonical names (`gpt-4o`, `deepseek-chat`, `gemini-3-pro`,
+//! `claude-sonnet-4-5`) are fixed points: each rule short-circuits when its
+//! pattern is absent, so `canonicalize_model_name(canonical) == canonical`.
+//!
+//! # Idempotence
+//!
+//! Each rule either strips a fixed suffix or rewrites a token in place,
+//! and none of the rewrites introduce a substring that another rule would
+//! match. Therefore
+//! `canonicalize_model_name(canonicalize_model_name(x)) ==
+//! canonicalize_model_name(x)` for every input — covered by a proptest
+//! over arbitrary alphanumeric strings.
+//!
+//! # Examples
+//!
+//! ```
+//! use grob::routing::classify::model_name::canonicalize_model_name;
+//! assert_eq!(
+//!     canonicalize_model_name("claude-3-5-sonnet-20241022"),
+//!     "claude-sonnet-3-5"
+//! );
+//! assert_eq!(
+//!     canonicalize_model_name("claude-3-5-sonnet"),
+//!     "claude-sonnet-3-5"
+//! );
+//! assert_eq!(canonicalize_model_name("claude-sonnet-4-5"), "claude-sonnet-4-5");
+//! assert_eq!(canonicalize_model_name("gpt-4o"), "gpt-4o");
+//! ```
+
+use std::borrow::Cow;
+
+/// Returns the canonical form of a user-supplied model name.
+///
+/// Borrows when no rewrite is needed (the common steady-state case for
+/// already-canonical names) and only allocates when at least one rule
+/// fires. The function is idempotent: applying it to its own output is a
+/// no-op.
+///
+/// See the [module docs](self) for the full rule list.
+///
+/// # Examples
+///
+/// ```
+/// use grob::routing::classify::model_name::canonicalize_model_name;
+/// // Date-suffixed Anthropic ID collapses to its dateless form, and the
+/// // older `claude-3-5-sonnet` ordering reorders to the modern
+/// // `claude-sonnet-3-5` spelling used in `presets/*.toml`.
+/// assert_eq!(
+///     canonicalize_model_name("claude-3-5-sonnet-20241022"),
+///     "claude-sonnet-3-5"
+/// );
+/// // Dotted Gemini version becomes dashed.
+/// assert_eq!(
+///     canonicalize_model_name("gemini-2.5-flash"),
+///     "gemini-2-5-flash"
+/// );
+/// // Already-canonical names borrow without allocating.
+/// assert_eq!(canonicalize_model_name("gpt-4o"), "gpt-4o");
+/// assert_eq!(canonicalize_model_name("claude-sonnet-4-5"), "claude-sonnet-4-5");
+/// ```
+#[must_use]
+pub fn canonicalize_model_name(input: &str) -> Cow<'_, str> {
+    // Rule 1: lowercase. Borrow when already lowercase.
+    let mut current: Cow<'_, str> = if input.bytes().any(|b| b.is_ascii_uppercase()) {
+        Cow::Owned(input.to_ascii_lowercase())
+    } else {
+        Cow::Borrowed(input)
+    };
+
+    // Rule 2: strip trailing `-latest`.
+    if let Some(stripped) = current.strip_suffix("-latest") {
+        current = Cow::Owned(stripped.to_string());
+    }
+
+    // Rule 3: strip trailing `-YYYYMMDD` (exactly 8 digits).
+    if let Some(stripped) = strip_trailing_date(&current) {
+        current = Cow::Owned(stripped.to_string());
+    }
+
+    // Rule 4: dot-versions to dashed-versions for known families. Gated on a
+    // known prefix to avoid touching unrelated provider IDs (e.g. `glm-4.6`,
+    // which the user explicitly does not want rewritten).
+    if has_known_family_prefix(&current) && has_dotted_version(&current) {
+        current = Cow::Owned(replace_dot_versions(&current));
+    }
+
+    // Rule 5: Anthropic family-version reorder.
+    if let Some(reordered) = reorder_anthropic_family(&current) {
+        current = Cow::Owned(reordered);
+    }
+
+    current
+}
+
+/// Returns the input minus a trailing `-YYYYMMDD` suffix when present.
+fn strip_trailing_date(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    if bytes.len() < 9 {
+        return None;
+    }
+    let split = bytes.len() - 9;
+    if bytes[split] != b'-' {
+        return None;
+    }
+    if bytes[split + 1..].iter().all(u8::is_ascii_digit) {
+        Some(&s[..split])
+    } else {
+        None
+    }
+}
+
+/// Returns true when the string contains a `<digit>.<digit>` sequence —
+/// the cheap pre-check before allocating a rewritten string.
+fn has_dotted_version(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes
+        .windows(3)
+        .any(|w| w[0].is_ascii_digit() && w[1] == b'.' && w[2].is_ascii_digit())
+}
+
+/// Known model-family prefixes for which the dot-version rule fires.
+///
+/// Listing them explicitly keeps the rewrite confined to families whose
+/// version syntax we actually understand and avoids rewriting unrelated
+/// IDs like `glm-4.6` (the GLM family) or `mistral-3.1.0`.
+const DOTTED_VERSION_FAMILIES: &[&str] = &["claude-", "gpt-", "gemini-", "grok-", "deepseek-"];
+
+/// Returns true when the input starts with one of [`DOTTED_VERSION_FAMILIES`].
+fn has_known_family_prefix(s: &str) -> bool {
+    DOTTED_VERSION_FAMILIES.iter().any(|p| s.starts_with(p))
+}
+
+/// Replaces every `<digit>.<digit>` with `<digit>-<digit>`.
+///
+/// Walks one byte at a time so chained dotted versions like `1.2.3`
+/// rewrite to `1-2-3` in a single pass — that one-pass property is what
+/// makes the canonicalizer idempotent.
+fn replace_dot_versions(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    for i in 0..bytes.len() {
+        if bytes[i] == b'.'
+            && i > 0
+            && i + 1 < bytes.len()
+            && bytes[i - 1].is_ascii_digit()
+            && bytes[i + 1].is_ascii_digit()
+        {
+            out.push('-');
+        } else {
+            out.push(bytes[i] as char);
+        }
+    }
+    out
+}
+
+/// Anthropic family slugs that may appear before or after the version
+/// number depending on which Anthropic-published spelling the caller used.
+const ANTHROPIC_FAMILIES: &[&str] = &["sonnet", "opus", "haiku"];
+
+/// Reorders `claude-<N>-<M>-<family>...` → `claude-<family>-<N>-<M>...`
+/// when the input matches that pattern; returns `None` otherwise.
+///
+/// The newer Anthropic spelling (`claude-sonnet-4-5`) is the canonical
+/// form because that is what `presets/*.toml` uses. Older
+/// `claude-3-5-sonnet` style names rewrite to `claude-sonnet-3-5` so
+/// both collapse into one key for `[[models]]` lookup.
+fn reorder_anthropic_family(s: &str) -> Option<String> {
+    let rest = s.strip_prefix("claude-")?;
+    let mut parts = rest.splitn(4, '-');
+    let major = parts.next()?;
+    let minor = parts.next()?;
+    let family = parts.next()?;
+    if !ANTHROPIC_FAMILIES.contains(&family) {
+        return None;
+    }
+    if !major.bytes().all(|b| b.is_ascii_digit()) || !minor.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let tail = parts.next();
+    let mut out = String::with_capacity(s.len());
+    out.push_str("claude-");
+    out.push_str(family);
+    out.push('-');
+    out.push_str(major);
+    out.push('-');
+    out.push_str(minor);
+    if let Some(tail) = tail {
+        out.push('-');
+        out.push_str(tail);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Coverage matrix across all listed provider families.
+    ///
+    /// Each row is `(input, expected_canonical)`. The matrix exists as a
+    /// single table so adding a new family is one line, and a regression
+    /// from any rule lights up exactly one row.
+    #[test]
+    fn canonicalize_known_inputs() {
+        let cases: &[(&str, &str)] = &[
+            // Anthropic — date suffix stripped + family-version reorder
+            ("claude-3-5-sonnet-20241022", "claude-sonnet-3-5"),
+            ("claude-3-5-haiku-20241022", "claude-haiku-3-5"),
+            // Anthropic — `-latest` stripped (already-canonical 4.x form)
+            ("claude-sonnet-4-5-latest", "claude-sonnet-4-5"),
+            ("claude-opus-4-5-latest", "claude-opus-4-5"),
+            // Anthropic — older 3.x ordering reorders to 4.x style
+            ("claude-3-5-sonnet", "claude-sonnet-3-5"),
+            ("claude-3-5-haiku", "claude-haiku-3-5"),
+            // Anthropic — already canonical (fixed point, modern style)
+            ("claude-sonnet-4-5", "claude-sonnet-4-5"),
+            ("claude-haiku-4-5", "claude-haiku-4-5"),
+            ("claude-opus-4-7", "claude-opus-4-7"),
+            // Anthropic — dotted version becomes dashed
+            ("claude-3.5-sonnet", "claude-sonnet-3-5"),
+            // Anthropic — uppercase normalization
+            ("Claude-3-5-Sonnet-20241022", "claude-sonnet-3-5"),
+            // OpenAI
+            ("gpt-4o", "gpt-4o"),
+            ("gpt-5", "gpt-5"),
+            ("gpt-5-2", "gpt-5-2"),
+            ("gpt-5.2", "gpt-5-2"),
+            ("gpt-4o-latest", "gpt-4o"),
+            // DeepSeek
+            ("deepseek-chat", "deepseek-chat"),
+            ("deepseek-v3", "deepseek-v3"),
+            ("deepseek-v4-flash", "deepseek-v4-flash"),
+            // Gemini
+            ("gemini-2.5-flash", "gemini-2-5-flash"),
+            ("gemini-3-flash", "gemini-3-flash"),
+            ("gemini-3-pro-latest", "gemini-3-pro"),
+            // Grok
+            ("grok-4", "grok-4"),
+            ("grok-4-1-fast", "grok-4-1-fast"),
+            ("grok-4.1-fast", "grok-4-1-fast"),
+        ];
+        for (input, expected) in cases {
+            let got = canonicalize_model_name(input);
+            assert_eq!(
+                got.as_ref(),
+                *expected,
+                "canonicalize_model_name({input:?}) → {got:?}, expected {expected:?}"
+            );
+        }
+        // 25 cases — exceeds the ≥ 20-case requirement.
+        assert!(cases.len() >= 20, "coverage matrix must have ≥ 20 cases");
+    }
+
+    /// Idempotence: applying the canonicalizer twice equals once.
+    #[test]
+    fn canonicalize_is_idempotent_on_matrix() {
+        let cases: &[&str] = &[
+            "claude-3-5-sonnet-20241022",
+            "claude-sonnet-3-5",
+            "claude-opus-4-5-latest",
+            "claude-sonnet-4-5",
+            "gpt-5.2",
+            "gemini-2.5-flash",
+            "grok-4.1-fast",
+            "Claude-3-5-Sonnet-20241022",
+        ];
+        for input in cases {
+            let once = canonicalize_model_name(input).into_owned();
+            let twice = canonicalize_model_name(&once).into_owned();
+            assert_eq!(once, twice, "not idempotent for {input:?}");
+        }
+    }
+
+    /// Already-canonical lowercase inputs must not allocate.
+    #[test]
+    fn canonical_inputs_borrow() {
+        let inputs = ["gpt-4o", "deepseek-chat", "gemini-3-pro", "grok-4"];
+        for input in inputs {
+            let got = canonicalize_model_name(input);
+            assert!(
+                matches!(got, Cow::Borrowed(_)),
+                "expected borrowed Cow for canonical input {input:?}, got owned"
+            );
+        }
+    }
+
+    // Property: `canonicalize(canonicalize(x)) == canonicalize(x)`.
+    proptest! {
+        #[test]
+        fn prop_canonicalize_is_idempotent(input in "[A-Za-z0-9.\\-]{1,32}") {
+            let once = canonicalize_model_name(&input).into_owned();
+            let twice = canonicalize_model_name(&once).into_owned();
+            prop_assert_eq!(once, twice);
+        }
+    }
+
+    /// Date stripping requires exactly 8 digits — guards against eating
+    /// version segments like `-2` from `gpt-5-2`.
+    #[test]
+    fn date_stripper_only_strips_8_digits() {
+        assert_eq!(canonicalize_model_name("gpt-5-2"), "gpt-5-2");
+        assert_eq!(canonicalize_model_name("gpt-5-12345"), "gpt-5-12345");
+        assert_eq!(canonicalize_model_name("gpt-5-12345678"), "gpt-5");
+    }
+
+    /// Anthropic reorder must fire only when the family slug is the
+    /// third token and the first two are numeric.
+    #[test]
+    fn anthropic_reorder_requires_known_family_and_numeric_version() {
+        // No reorder: trailing token is unknown family slug.
+        assert_eq!(
+            canonicalize_model_name("claude-3-5-instant"),
+            "claude-3-5-instant"
+        );
+        // No reorder: first two tokens are not all digits.
+        assert_eq!(
+            canonicalize_model_name("claude-x-y-sonnet"),
+            "claude-x-y-sonnet"
+        );
+        // No reorder: already in canonical {family}-{N}-{M} form.
+        assert_eq!(
+            canonicalize_model_name("claude-sonnet-x-y"),
+            "claude-sonnet-x-y"
+        );
+    }
+}

--- a/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_eu_ai_act.snap
+++ b/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_eu_ai_act.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 [
     "default_simple: model=eu-default type=default matched=none",
-    "default_non_claude: model=gpt-5.2 type=default matched=none",
+    "default_non_claude: model=gpt-5-2 type=default matched=none",
     "thinking_enabled: model=eu-think type=think matched=none",
     "websearch_tool: model=eu-default type=default matched=none",
     "background_haiku: model=eu-background type=background matched=none",

--- a/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_eu_eco.snap
+++ b/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_eu_eco.snap
@@ -5,7 +5,7 @@ expression: snapshot
 ---
 [
     "default_simple: model=default-model type=default matched=none",
-    "default_non_claude: model=gpt-5.2 type=default matched=none",
+    "default_non_claude: model=gpt-5-2 type=default matched=none",
     "thinking_enabled: model=think-model type=prompt-rule matched=Architect",
     "websearch_tool: model=search-model type=web-search matched=none",
     "background_haiku: model=background-model type=background matched=none",

--- a/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_eu_max.snap
+++ b/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_eu_max.snap
@@ -5,7 +5,7 @@ expression: snapshot
 ---
 [
     "default_simple: model=default-model type=default matched=none",
-    "default_non_claude: model=gpt-5.2 type=default matched=none",
+    "default_non_claude: model=gpt-5-2 type=default matched=none",
     "thinking_enabled: model=think-model type=prompt-rule matched=Architect",
     "websearch_tool: model=search-model type=web-search matched=none",
     "background_haiku: model=background-model type=background matched=none",

--- a/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_eu_pro.snap
+++ b/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_eu_pro.snap
@@ -5,7 +5,7 @@ expression: snapshot
 ---
 [
     "default_simple: model=default-model type=default matched=none",
-    "default_non_claude: model=gpt-5.2 type=default matched=none",
+    "default_non_claude: model=gpt-5-2 type=default matched=none",
     "thinking_enabled: model=think-model type=prompt-rule matched=Architect",
     "websearch_tool: model=search-model type=web-search matched=none",
     "background_haiku: model=background-model type=background matched=none",

--- a/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_gdpr.snap
+++ b/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_gdpr.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 [
     "default_simple: model=eu-default type=default matched=none",
-    "default_non_claude: model=gpt-5.2 type=default matched=none",
+    "default_non_claude: model=gpt-5-2 type=default matched=none",
     "thinking_enabled: model=eu-think type=think matched=none",
     "websearch_tool: model=eu-default type=default matched=none",
     "background_haiku: model=eu-background type=background matched=none",

--- a/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_perf.snap
+++ b/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_perf.snap
@@ -5,7 +5,7 @@ expression: snapshot
 ---
 [
     "default_simple: model=claude-sonnet-4-6 type=default matched=none",
-    "default_non_claude: model=gpt-5.2 type=default matched=none",
+    "default_non_claude: model=gpt-5-2 type=default matched=none",
     "thinking_enabled: model=claude-opus-4-7 type=think matched=none",
     "websearch_tool: model=claude-sonnet-4-6 type=web-search matched=none",
     "background_haiku: model=claude-haiku-4-5 type=background matched=none",

--- a/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_ultra_cheap.snap
+++ b/tests/enterprise/snapshots/lib__enterprise__preset_snapshot_test__snapshot_preset_ultra_cheap.snap
@@ -5,7 +5,7 @@ expression: snapshot
 ---
 [
     "default_simple: model=default-model type=default matched=none",
-    "default_non_claude: model=gpt-5.2 type=default matched=none",
+    "default_non_claude: model=gpt-5-2 type=default matched=none",
     "thinking_enabled: model=think-model type=think matched=none",
     "websearch_tool: model=search-model type=web-search matched=none",
     "background_haiku: model=background-model type=background matched=none",


### PR DESCRIPTION
## Summary

- Add `routing::classify::model_name::canonicalize_model_name` and call it as step 0 of `Router::route`, so cosmetic variations of provider model IDs collapse to a single canonical key before any subsequent step (background regex, auto-map, prompt rules, `[[models]]` lookup).
- Idempotent and zero-allocation on already-canonical inputs (`Cow::Borrowed`), so configs that use the canonical IDs (`gpt-4o`, `claude-sonnet-4-5`, …) pay nothing.
- Bump the 7 enterprise preset snapshots whose `default_non_claude` row now carries the canonicalized `gpt-5-2` instead of `gpt-5.2`.

## Rules (in order)

1. Lowercase ASCII.
2. Strip trailing `-latest`.
3. Strip trailing `-YYYYMMDD` (exactly 8 digits — guards `gpt-5-2`).
4. `<digit>.<digit>` to `<digit>-<digit>`, gated on a known family prefix (`claude-`, `gpt-`, `gemini-`, `grok-`, `deepseek-`) so unrelated IDs like `glm-4.6` survive untouched.
5. Anthropic family-version reorder: `claude-{N}-{M}-{family}` → `claude-{family}-{N}-{M}` so older `claude-3-5-sonnet` and modern `claude-sonnet-4-5` spellings collapse into one key (matching the spelling used in `presets/*.toml`).

## Why this base branch

Based on `fix/preset-mod-include-str` (PR #304) because `main` does not currently build (referenced `presets/{medium,local,cheap,fast}.toml` files were deleted but `include_str!` calls remain). Will rebase to `main` automatically once #304 lands.

## Test plan

- [x] 25-row coverage matrix in `model_name.rs` exercises Anthropic 3.x/4.x, OpenAI (`gpt-4o`, `gpt-5`, `gpt-5-2`, `gpt-5.2`), DeepSeek, Gemini, Grok families.
- [x] Proptest verifies idempotence over arbitrary alphanumeric inputs (regression seed for `0.0.0` checked in).
- [x] All 130 existing routing tests pass (including the regression guards `test_auto_map_skips_explicit_virtual_model` and `test_no_auto_map_non_matching` — `glm-4.6` is unaffected by rule 4 thanks to the family-prefix gate).
- [x] All 1263 lib + integration tests pass.
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` all green locally.