### PR TITLE
docs(providers): document Z.ai/GLM dual-endpoint model, no glm.rs needed

### DIFF
--- a/docs/how-to/providers.md
+++ b/docs/how-to/providers.md
@@ -21,7 +21,8 @@ Grob supports three categories of providers:
 | Together | `openai` | API key | `https://api.together.xyz/v1` |
 | Fireworks | `openai` | API key | `https://api.fireworks.ai/inference/v1` |
 | Ollama | `openai` | none | `http://localhost:11434/v1` |
-| z.ai | `z.ai` | API key | Anthropic-compatible |
+| z.ai (Coding Plan) | `z.ai` | API key | `https://api.z.ai/api/anthropic` (Anthropic) |
+| z.ai (PAYG / free tier) | `openai` | API key | `https://api.z.ai/api/paas/v4` (OpenAI) |
 | MiniMax | `minimax` | API key | Anthropic-compatible |
 | Kimi Coding | `kimi-coding` | API key | Anthropic-compatible |
 | Zenmux | `zenmux` | API key | Anthropic-compatible |
@@ -191,6 +192,58 @@ provider_type = "gemini"
 auth_type = "oauth"
 oauth_provider = "gemini-pro"
 ```
+
+---
+
+## Z.ai / GLM
+
+Z.ai exposes GLM models on **two parallel endpoints** — pick the one that matches your use case.
+
+### When to use which path
+
+| Use case | Path | `provider_type` | `base_url` |
+|----------|------|-----------------|------------|
+| Drop-in for Claude Code (paid Coding Plan or `glm-5.1` as opus replacement) | Anthropic-compatible | `z.ai` | `https://api.z.ai/api/anthropic` (default) |
+| Free-tier `glm-4.7-flash` / `glm-4.5-flash` / `glm-4.5-air` (PAYG, ongoing free) | OpenAI-compatible | `openai` | `https://api.z.ai/api/paas/v4` |
+
+The two endpoints are **separate products** at Z.ai. The Anthropic path serves the GLM Coding Plan subscription; the OpenAI path serves the standard PAYG / free-tier access. Use whichever the API key on your account is provisioned for.
+
+### Anthropic-compatible (drop-in for Claude Code)
+
+```toml
+[[providers]]
+name = "zai-coding"
+provider_type = "z.ai"
+api_key = "$ZAI_API_KEY"
+```
+
+This routes to `AnthropicCompatibleProvider`, which means: native Anthropic Messages format, full thinking-block support, beta-feature header forwarding, and tool-use-id sanitization. The `base_url` defaults to `https://api.z.ai/api/anthropic` and never needs to be set explicitly.
+
+### OpenAI-compatible (free tier, PAYG)
+
+```toml
+[[providers]]
+name = "zai"
+provider_type = "openai"
+api_key = "$ZAI_API_KEY"
+base_url = "https://api.z.ai/api/paas/v4"
+models = ["glm-4.7-flash", "glm-4.5-flash", "glm-4.5-air"]
+```
+
+Z.ai's `/api/paas/v4/chat/completions` is OpenAI Chat Completions API-compatible. Grob's standard `OpenAIProvider` translation layer handles the request/response shape. This is the path the `ultra-cheap` preset uses.
+
+#### Quirks ignored by grob
+
+The OpenAI-compat endpoint accepts a few GLM-specific request fields that grob does **not** surface today:
+
+- `thinking: { type: "enabled" | "disabled", clear_thinking: bool }` — chain-of-thought toggle (use `provider_type = "z.ai"` + Anthropic thinking blocks instead).
+- `do_sample: bool` — disables temperature/top_p sampling.
+- `request_id: string` — user-provided trace ID.
+- `tool_stream: bool` — streaming for function calls (GLM-4.6+).
+
+Grob requests pass through without these fields, which is harmless: the server applies its defaults. Error response shape (`{ code, message }` instead of OpenAI's `{ error: { message, type, code } }`) and finish reasons (`sensitive`, `model_context_window_exceeded`, `network_error`) are normalized into grob's standard error envelope at the dispatch layer.
+
+If you need GLM thinking control end-to-end, use the Anthropic-compatible path — `provider_type = "z.ai"` + Anthropic `thinking` blocks map cleanly to GLM's reasoning mode at the upstream.
 
 ---
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -158,6 +158,7 @@ Central registry mapping provider names to `Arc<dyn LlmProvider>` instances and 
 | `openrouter` | `OpenAIProvider` | `https://openrouter.ai/api/v1` |
 | `anthropic` | `AnthropicCompatibleProvider` | `https://api.anthropic.com` |
 | `z.ai` | `AnthropicCompatibleProvider` | `https://api.z.ai/api/anthropic` |
+| `openai` (with `base_url = api.z.ai/api/paas/v4`) | `OpenAIProvider` | (config-supplied) |
 | `minimax` | `AnthropicCompatibleProvider` | `https://api.minimax.io/anthropic` |
 | `zenmux` | `AnthropicCompatibleProvider` | `https://zenmux.ai/api/anthropic` |
 | `kimi-coding` | `AnthropicCompatibleProvider` | `https://api.kimi.com/coding` |

--- a/tests/unit/provider_test.rs
+++ b/tests/unit/provider_test.rs
@@ -66,4 +66,70 @@ mod tests {
 
         assert!(!config.is_enabled());
     }
+
+    /// Regression: Z.ai PAYG / free-tier endpoint must be reachable through
+    /// the standard `openai` provider type.
+    ///
+    /// Z.ai exposes two parallel endpoints:
+    ///
+    /// - `https://api.z.ai/api/anthropic` — Anthropic-compatible (Coding Plan), reached via `provider_type = "z.ai"`.
+    /// - `https://api.z.ai/api/paas/v4`   — OpenAI-compatible (free tier / PAYG), reached via `provider_type = "openai"` + explicit `base_url`.
+    ///
+    /// The `ultra-cheap` preset uses the second path. This test parses the
+    /// shipped TOML, asserts the `zai` provider entry survives parsing, and
+    /// verifies the OpenAI-compat fingerprint (provider_type, base_url, GLM
+    /// model list). It guards against accidental removal of the fields that
+    /// route the request to `OpenAIProvider` — if someone refactored the
+    /// registry to require a dedicated `glm`/`zai` provider type, this test
+    /// would still expect the openai-compat path to keep working since the
+    /// roadmap verdict (B-01) was: don't add a GLM-specific impl.
+    #[test]
+    fn ultra_cheap_preset_zai_uses_openai_compat() {
+        // The preset ships in the source tree at `presets/ultra-cheap.toml`.
+        // `CARGO_MANIFEST_DIR` is set to the package root by Cargo at build
+        // time and is stable across `cargo test` / `cargo nextest run` /
+        // workspace invocations.
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let preset_path = std::path::Path::new(manifest_dir).join("presets/ultra-cheap.toml");
+        let toml_str = std::fs::read_to_string(&preset_path).unwrap_or_else(|e| {
+            panic!(
+                "presets/ultra-cheap.toml is shipped with the source tree (read {:?}): {}",
+                preset_path, e
+            )
+        });
+
+        let value: toml::Value = toml::from_str(&toml_str).expect("ultra-cheap.toml is valid TOML");
+
+        let providers = value
+            .get("providers")
+            .and_then(|p| p.as_array())
+            .expect("preset has [[providers]] entries");
+
+        let zai = providers
+            .iter()
+            .find(|p| p.get("name").and_then(|n| n.as_str()) == Some("zai"))
+            .expect("ultra-cheap preset declares a `zai` provider");
+
+        assert_eq!(
+            zai.get("provider_type").and_then(|t| t.as_str()),
+            Some("openai"),
+            "Z.ai free-tier path must use openai_compat — not a dedicated `z.ai` provider type"
+        );
+        assert_eq!(
+            zai.get("base_url").and_then(|u| u.as_str()),
+            Some("https://api.z.ai/api/paas/v4"),
+            "Z.ai OpenAI-compat endpoint base URL is the canonical paas/v4 path"
+        );
+
+        let models: Vec<&str> = zai
+            .get("models")
+            .and_then(|m| m.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        assert!(
+            models.iter().any(|m| m.starts_with("glm-")),
+            "zai provider must list at least one GLM model (got: {:?})",
+            models
+        );
+    }
 }


### PR DESCRIPTION
## Verdict on roadmap B-01: keep `openai_compat`, do not add a dedicated GLM provider impl.

## Summary

Z.ai exposes GLM models on **two parallel endpoints**, both already covered by grob without any new code:

| Path | `provider_type` | `base_url` | Purpose |
|------|-----------------|------------|---------|
| Anthropic Messages API | `z.ai` (existing) | `https://api.z.ai/api/anthropic` | Drop-in for Claude Code (Coding Plan) |
| OpenAI Chat Completions API | `openai` | `https://api.z.ai/api/paas/v4` | Free tier / PAYG (`ultra-cheap` preset) |

The first path was wired in `src/providers/registry.rs:233-247` (routes to `AnthropicCompatibleProvider`). The second path is what `presets/ultra-cheap.toml` uses today and works as-is through the standard `OpenAIProvider` translation layer.

## Why no `glm.rs`

Investigated the OpenAI-compat endpoint quirks (`docs.z.ai/api-reference/llm/chat-completion`):

| Quirk | Impact on grob |
|-------|----------------|
| `thinking: { type, clear_thinking }` | Request-side, optional. Use `provider_type = "z.ai"` + Anthropic thinking blocks if needed end-to-end. |
| `do_sample: bool` | Request-side, optional. Not emitted by Claude Code / Codex CLI. |
| `request_id: string` | Request-side, optional trace ID. Not emitted by inbound clients. |
| `tool_stream: bool` (GLM-4.6+) | Request-side, optional. Not emitted by inbound clients. |
| Error shape `{ code, message }` | Cosmetic — normalized at dispatch layer. |
| Finish reasons `sensitive` / `model_context_window_exceeded` / `network_error` | Cosmetic in passthrough. |

None of these are emitted by Claude Code or Codex CLI (the only inbound surfaces grob proxies). A dedicated `glm.rs` would duplicate `OpenAIProvider` verbatim and ship as dead code.

## Changes

- `docs/how-to/providers.md`: new "Z.ai / GLM" section documenting both paths, when to pick each, and the OpenAI-compat quirks grob deliberately ignores. Overview table now lists both rows.
- `docs/reference/providers.md`: provider creation dispatch table now documents `provider_type = "openai" + base_url = api.z.ai/api/paas/v4` next to the existing `z.ai` row.
- `tests/unit/provider_test.rs`: regression test `ultra_cheap_preset_zai_uses_openai_compat` that parses the shipped `presets/ultra-cheap.toml` and asserts the `zai` provider entry uses `provider_type = "openai"` + canonical paas/v4 URL. Guards against silent breakage of the free-tier path.

## Build dependency

Cherry-picks `5a34bac` from PR #304 (`fix/preset-mod-include-str`) because main is currently broken — `src/preset/mod.rs` has stale `include_str!` references to deleted preset files (`medium`/`local`/`cheap`/`fast.toml`). Once #304 lands, that commit becomes a no-op merge.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --tests --all-targets` passes (no warnings)
- [x] `cargo nextest run --test lib` passes (217/217 tests)
- [x] `ultra_cheap_preset_zai_uses_openai_compat` passes
- [x] `enterprise::preset_snapshot_test::snapshot_preset_ultra_cheap` passes

## Rollback

If a future user reports they need a dedicated GLM provider for one of the quirks above, revisit by adding the field to `RequestExtensions` rather than forking a new provider type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)