### PR TITLE
chore: release v0.36.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.41](https://github.com/azerozero/grob/compare/v0.36.40...v0.36.41) - 2026-04-28
+
+### Added
+
+- *(secrets)* add `grob secrets test` subcommand
+- *(presets)* add 'eu' preset (strict EU sovereign routing)
+- *(presets)* add 'optimal' preset (multi-provider speed-first routing)
+
+### Fixed
+
+- *(preset)* auto-discover builtins via include_dir, fix broken main
+- *(presets)* drop signup-bonus providers from ultra-cheap
+- *(presets)* drop MiniMax from ultra-cheap (avoid trial deadline)
+
+### Other
+
+- *(preset)* fix test_apply_preset_to_temp_config to use ultra-cheap
+- *(presets)* add Z.ai GLM, MiniMax, Mercury, DeepSeek direct
+- *(presets)* max ultra-cheap free tiers + correct rate limits
+- *(presets)* optimize ultra-cheap with Grok + R1 + V4 Flash
+- *(presets)* consolidate to 5 presets with clear positioning
+- *(presets)* split eu into eu-eco/pro/max, drop xAI Grok
+
 ### Routing roadmap (no code yet — design only)
 
 - **ADR-0018 promoted to `accepted`** (was `proposed` since 2026-04-17). Triggered by re-evaluation against two concrete user audiences: time-sensitive trading bots and security-prevails customers (defense, banks, OIV).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.40"
+version = "0.36.41"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.40"
+version = "0.36.41"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.40 -> 0.36.41

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.41](https://github.com/azerozero/grob/compare/v0.36.40...v0.36.41) - 2026-04-28

### Added

- *(secrets)* add `grob secrets test` subcommand
- *(presets)* add 'eu' preset (strict EU sovereign routing)
- *(presets)* add 'optimal' preset (multi-provider speed-first routing)

### Fixed

- *(preset)* auto-discover builtins via include_dir, fix broken main
- *(presets)* drop signup-bonus providers from ultra-cheap
- *(presets)* drop MiniMax from ultra-cheap (avoid trial deadline)

### Other

- *(preset)* fix test_apply_preset_to_temp_config to use ultra-cheap
- *(presets)* add Z.ai GLM, MiniMax, Mercury, DeepSeek direct
- *(presets)* max ultra-cheap free tiers + correct rate limits
- *(presets)* optimize ultra-cheap with Grok + R1 + V4 Flash
- *(presets)* consolidate to 5 presets with clear positioning
- *(presets)* split eu into eu-eco/pro/max, drop xAI Grok

### Routing roadmap (no code yet — design only)

- **ADR-0018 promoted to `accepted`** (was `proposed` since 2026-04-17). Triggered by re-evaluation against two concrete user audiences: time-sensitive trading bots and security-prevails customers (defense, banks, OIV).
- ADR-0019 — EMA stigmergy: opt-in adaptive endpoint health scoring; transparent to clients, fully observable. **All defaults configurable** in `[router.ema]`; default flip from `static` to `ema` is itself a config-schema default change, never silent.
- ADR-0020 — Hedged requests: opt-in tail-latency reduction via speculative duplication; per-slot config. Adds `compliance_isolation` flag for security audiences (hedging restricted to endpoints sharing trust zone, jurisdiction, and meeting data-classification floor — fail-closed if either endpoint omits the compliance block). **Cancellation cost behavior is operator-declared** in `[hedge.providers.<name>]` after empirical verification; binary ships no speculative knowledge.
- ADR-0022 — `[[endpoints]]` + `[[policies]]` schema rebuild. **10-version auto-migration window** (~12-18 calendar months) with deprecation warnings starting at the announcement release; legacy parser removed at the 10th minor release after announcement. New optional `[endpoints.compliance]` block with 6 structured fields (`trust_zone`, `jurisdiction`, `data_classification`, `certifications`, `provider_risk_score`, `sub_processors`). **Everything is operator-tunable** via config: `data_classification` levels, `required_fields` for strict-mode lint, policy precedence (`priority = N` opt-in), `trust_zone` taxonomy. Industry-naming guidance documented (AWS regions, SecNumCloud, FedRAMP, EU AI Act tiers) but not enforced.

ADR-0021 (Thompson sampling) was rejected before drafting: probabilistic
exploration is incompatible with both trading audit trails and security-prevails
predictability requirements.

ADRs 0019, 0020, 0022 land here as `status: proposed`. None ship code in this
release. A separate `status: accepted` promotion PR gates each implementation.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).