### PR TITLE
chore: silent-failure killers (5 audit quick wins)

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -54,25 +54,10 @@ args = ["-c", "lychee --offline --no-progress --include-fragments docs/**/*.md R
 types = ["markdown"]
 pass_filenames = false
 
-# Tests — expensive, runs only on pre-push
-[[repos.hooks]]
-id = "cargo-test"
-name = "cargo test"
-language = "system"
-entry = "cargo nextest run --profile ci"
-types = ["rust"]
-pass_filenames = false
-stages = ["pre-push"]
-
-# Doc tests — not covered by nextest
-[[repos.hooks]]
-id = "cargo-doctest"
-name = "cargo doc tests"
-language = "system"
-entry = "cargo test --doc"
-types = ["rust"]
-pass_filenames = false
-stages = ["pre-push"]
+# NOTE: cargo-test and cargo-doctest were removed from pre-push to keep
+# the gate fast-fail. CI re-runs the full suite on every PR (see
+# `.github/workflows/ci.yml` `tests` job), so duplicating ~20 min of work
+# locally only delays the developer feedback loop without adding signal.
 
 # Cargo deny — license & advisory & dependency checks
 # Only runs when Cargo.toml/lock or Rust files change.

--- a/src/cli/config/budget.rs
+++ b/src/cli/config/budget.rs
@@ -6,6 +6,7 @@ use crate::cli::BudgetUsd;
 
 /// Budget configuration
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct BudgetConfig {
     /// Global monthly hard cap in USD (0 = unlimited)
     #[serde(default)]

--- a/src/cli/config/cache.rs
+++ b/src/cli/config/cache.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// LLM response cache configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CacheConfig {
     /// Enable response caching (only for temperature=0 requests)
     #[serde(default)]

--- a/src/cli/config/providers.rs
+++ b/src/cli/config/providers.rs
@@ -28,6 +28,7 @@ pub enum AuthType {
 
 /// Provider configuration from TOML.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProviderConfig {
     /// Unique provider name used in routing and logging.
     pub name: String,

--- a/src/cli/config/providers.rs
+++ b/src/cli/config/providers.rs
@@ -119,7 +119,16 @@ pub struct ProviderConfig {
 }
 
 impl ProviderConfig {
-    /// Returns `true` if the provider is enabled (defaults to `true`).
+    /// Returns `true` if the provider is enabled.
+    ///
+    /// Semantics:
+    /// - `enabled = true`  → enabled.
+    /// - `enabled = false` → disabled.
+    /// - `enabled` absent  → enabled (sensible default for newly added blocks).
+    ///
+    /// Typo safety: `#[serde(deny_unknown_fields)]` on [`ProviderConfig`]
+    /// rejects misspelled keys (e.g. `enbaled`) at parse time, so an absent
+    /// `enabled` field genuinely means "not specified" rather than "typo'd".
     pub fn is_enabled(&self) -> bool {
         self.enabled.unwrap_or(true)
     }

--- a/src/cli/config/routing.rs
+++ b/src/cli/config/routing.rs
@@ -9,6 +9,7 @@ use super::user::PresetConfig;
 
 /// Router configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RouterConfig {
     /// Default model for unclassified requests
     pub default: String,
@@ -102,6 +103,7 @@ pub struct FanOutConfig {
 
 /// Model configuration with 1:N provider mappings
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelConfig {
     /// External model name (used in API requests)
     pub name: String,
@@ -203,6 +205,7 @@ pub struct TierMatchCondition {
 /// When the scoring heuristic classifies a request, the dispatch pipeline
 /// resolves providers from the matching tier instead of the default model mappings.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TierConfig {
     /// Tier name — must match a `ComplexityTier` variant (case-insensitive).
     pub name: String,

--- a/src/cli/config/security.rs
+++ b/src/cli/config/security.rs
@@ -8,6 +8,7 @@ use super::default_true;
 
 /// Security configuration (wired into middleware stack)
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SecurityConfig {
     /// Master switch for security middleware
     #[serde(default = "default_true")]

--- a/src/features/dlp/config.rs
+++ b/src/features/dlp/config.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Top-level DLP configuration, mapped from `[dlp]` in TOML.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct DlpConfig {
     /// Enables the DLP pipeline globally.
     #[serde(default)]

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -25,6 +25,7 @@ use crate::features::tap::TapConfig;
 
 /// Application configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AppConfig {
     /// Config schema version (for forward compatibility)
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/routing/classify/classify.rs
+++ b/src/routing/classify/classify.rs
@@ -84,6 +84,7 @@ impl Default for ScoringThresholds {
 
 /// Scoring configuration combining weights and thresholds.
 #[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ScoringConfig {
     /// Per-signal weights.
     pub weights: ScoringWeights,

--- a/src/server/config_guard.rs
+++ b/src/server/config_guard.rs
@@ -12,29 +12,76 @@ use std::sync::Arc;
 use tracing::info;
 
 /// Top-level TOML sections that are never writable via any config API.
-const DENIED_SECTIONS: &[&str] = &["providers", "dlp"];
+///
+/// Each entry is denied because hot-reloading it cannot be done safely
+/// at runtime — either the data is sensitive (and must travel through a
+/// dedicated secret API), or the code path that consumes it is set up
+/// once at process start and not re-initialised on `/api/config/reload`:
+///
+/// | Section     | Reason                                                                                  |
+/// |-------------|-----------------------------------------------------------------------------------------|
+/// | `providers` | Contains API keys; mutate via `grob connect` / secret backend, not the config API.      |
+/// | `dlp`       | Security policy must not be weakened by an authenticated control-plane caller.          |
+/// | `tee`       | TEE attestation runs at startup; flipping the mode mid-flight bypasses the gate.        |
+/// | `fips`      | FIPS mode is checked once on init; toggling at runtime gives a false sense of compliance. |
+///
+/// To change any of these the operator must edit `~/.grob/config.toml`
+/// and restart the daemon.
+const DENIED_SECTIONS: &[&str] = &["providers", "dlp", "tee", "fips"];
 
 /// Per-section keys that are never writable via any config API.
+///
+/// These are individual fields whose host section is otherwise editable,
+/// but the field itself is either credential material or wired into a
+/// non-reloadable subsystem:
+///
+/// | Section.Key        | Reason                                                                          |
+/// |--------------------|---------------------------------------------------------------------------------|
+/// | `router.api_key`   | Credential material — never round-trip through the config API.                  |
+/// | `budget.api_key`   | Same.                                                                           |
+/// | `cache.api_key`    | Same.                                                                           |
+/// | `server.tls`       | TLS listener is bound at startup; rebuilding it requires a daemon restart.      |
+/// | `secrets.backend`  | The secret backend is constructed once and shared via `Arc`; swapping it at     |
+/// |                    | runtime would orphan in-flight readers and change credential resolution semantics. |
 const DENIED_KEYS: &[(&str, &str)] = &[
     ("router", "api_key"),
     ("budget", "api_key"),
     ("cache", "api_key"),
+    ("server", "tls"),
+    ("secrets", "backend"),
 ];
 
 /// Checks whether a (section, key) pair is blocked by the deny-list.
 ///
-/// Returns `true` when the write must be rejected:
-/// - The entire `providers` section (contains API keys).
-/// - The entire `dlp` section (security must not be weakened).
-/// - Any `api_key` field in any section.
+/// Returns `true` when the write must be rejected. See [`DENIED_SECTIONS`]
+/// and [`DENIED_KEYS`] for the rationale behind every entry. A denied
+/// attempt is logged at INFO so the operator sees actionable guidance
+/// (restart instead of expecting a silent reload to take effect).
 pub fn is_section_or_key_denied(section: &str, key: &str) -> bool {
     if DENIED_SECTIONS.contains(&section) {
+        info!(
+            section = %section,
+            "config hot-reload: section is on the deny-list; restart the daemon to apply changes"
+        );
         return true;
     }
     if key == "api_key" {
+        info!(
+            section = %section,
+            key = %key,
+            "config hot-reload: api_key fields cannot be set via the config API; use `grob connect` or the secret backend"
+        );
         return true;
     }
-    DENIED_KEYS.iter().any(|(s, k)| *s == section && *k == key)
+    if DENIED_KEYS.iter().any(|(s, k)| *s == section && *k == key) {
+        info!(
+            section = %section,
+            key = %key,
+            "config hot-reload: key is on the deny-list; restart the daemon to apply changes"
+        );
+        return true;
+    }
+    false
 }
 
 /// Validates a key update against the deny-list using [`ConfigSection`].
@@ -175,6 +222,27 @@ mod tests {
         assert!(!is_section_or_key_denied("budget", "monthly_limit_usd"));
         assert!(!is_section_or_key_denied("cache", "enabled"));
         assert!(!is_section_or_key_denied("cache", "ttl_secs"));
+    }
+
+    #[test]
+    fn deny_static_init_sections() {
+        // tee and fips are checked once at startup; toggling them at runtime
+        // would bypass the gate without the operator realising.
+        assert!(is_section_or_key_denied("tee", "mode"));
+        assert!(is_section_or_key_denied("tee", "sealed_keys"));
+        assert!(is_section_or_key_denied("fips", "mode"));
+        assert!(is_section_or_key_denied("fips", "anything"));
+    }
+
+    #[test]
+    fn deny_static_init_keys() {
+        // The TLS listener and secret backend are constructed once on
+        // process start; both require a daemon restart to swap.
+        assert!(is_section_or_key_denied("server", "tls"));
+        assert!(is_section_or_key_denied("secrets", "backend"));
+        // Sibling keys in the same sections must remain editable.
+        assert!(!is_section_or_key_denied("server", "host"));
+        assert!(!is_section_or_key_denied("server", "port"));
     }
 
     #[cfg(feature = "mcp")]


### PR DESCRIPTION
## Summary

Five quick-win fixes from the architecture audit, all sharing the
"silent failure killer" theme — bugs that compile, parse, and run
green but mask user intent.

| # | Fix | Audit finding closed | Commit |
|---|-----|----------------------|--------|
| 1 | Drop redundant `cargo-test` and `cargo-doctest` from `prek.toml` pre-push hooks. CI re-runs them on every PR, so the local copy adds ~20 min per push without catching anything new. | Silent productivity tax (pre-push duplication). | `chore(prek): drop redundant cargo-test and cargo-doctest from pre-push` |
| 2 | Document `ProviderConfig::is_enabled()` semantics with explicit three-state docs (true / false / absent) and pin its typo-safety contract on fix #3. Behaviour is unchanged. | Silent typo killer on provider config. | `docs(config): clarify is_enabled semantics and typo-safety contract` |
| 3 | Add `#[serde(deny_unknown_fields)]` to `AppConfig` plus the major sub-structs (`ProviderConfig`, `ModelConfig`, `TierConfig`, `RouterConfig`, `ScoringConfig`, `CacheConfig`, `BudgetConfig`, `DlpConfig`, `SecurityConfig`). A typo like `enbaled = false` now fails parsing instead of silently becoming a misconfigured provider. Full nextest suite (1268 tests) and all doctests pass — no fixture, preset, or example carries a stale field. | Silent typo killer on TOML config. | `fix(config): reject unknown TOML fields in core config structs` |
| 5 | Document the rationale behind every entry of `DENIED_SECTIONS` / `DENIED_KEYS` in `src/server/config_guard.rs`, extend the deny-list to cover the static-init sections (`tee`, `fips`) and keys (`server.tls`, `secrets.backend`), and emit an INFO log on every denied attempt so operators see actionable guidance ("restart instead of expecting silent reload"). | Hot-reload UX (silent ignore of denied edits). | `docs(config-guard): document deny-list rationale and log denied reloads` |

## Aborted

| # | Fix | Reason |
|---|-----|--------|
| 4 | Delete `src/server/rpc/auth.rs` as orphaned dead code. | **Aborted per instructions** — `grep -rn "rpc::auth" src/ tests/` returned three real references (`src/server/mod.rs:601`, `src/server/mcp_handlers/control_bridge.rs:10`, `tests/unit/rpc_test.rs:1`). The module is not orphaned and removing it would break the build. |

## Test plan

- [x] `cargo check --all-targets` passes locally.
- [x] `cargo clippy --all-targets -- -D warnings` passes locally.
- [x] `cargo fmt --all -- --check` passes locally.
- [x] `cargo nextest run --no-fail-fast` — 1270 tests, all green (1268 before fix #5 added two new unit tests).
- [x] `cargo test --doc` — all doctests pass.
- [ ] CI green on the PR (auto-merge will gate on this).

## Base note

Original task suggested basing this PR on `fix/preset-mod-include-str` because main was thought to be broken by stale `include_str!` references. That branch (PR #304) has since merged into main, so this PR is correctly based on the up-to-date `main`.