### PR TITLE
docs: promote ADR-0008 to accepted (unblocks ControlEngine work)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Lifecycle roadmap (no code yet — design only)
+
+- ADR-0008 promoted from `proposed` to `accepted` (2026-04-28). Unblocks chantiers A-1 (ControlEngine) and A-2 (CLI thin).
+
 ## [0.36.41](https://github.com/azerozero/grob/compare/v0.36.40...v0.36.41) - 2026-04-28
 
 ### Added

--- a/docs/decisions/0008-wizard-lifecycle.md
+++ b/docs/decisions/0008-wizard-lifecycle.md
@@ -1,7 +1,20 @@
+---
+status: accepted
+date: 2026-04-03
+accepted: 2026-04-28
+---
+
+> **Promotion note (2026-04-28)**: Status flipped from `proposed` to `accepted`.
+> Trigger: ADR-0011 (ControlEngine + MCP-tools-first) is already `accepted` and
+> formally depends on this ADR — keeping ADR-0008 `proposed` was a status inversion.
+> Implementation work (chantier A-1: ControlEngine, A-2: CLI thin wrapper) is
+> unblocked. No code changes ship in this PR — implementation tracked separately.
+
 # ADR-0008: Wizard Lifecycle Architecture
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-03
+**Accepted:** 2026-04-28
 **Context:** The current `grob setup` wizard is a one-shot interactive flow that doesn't re-examine existing config, doesn't validate after generation, and has broken OAuth auto-start promises.
 
 ## Decision

--- a/docs/decisions/0011-control-engine-mcp-tools.md
+++ b/docs/decisions/0011-control-engine-mcp-tools.md
@@ -101,7 +101,7 @@ Sequenced: A-1 blocks A-2 / A-3 / B-1 (structural refactor, conflict risk).
 
 ## Follow-ups and related ADRs
 
-- Extends [ADR-0008: Wizard Lifecycle Architecture](0008-wizard-lifecycle.md) — ADR-0008's state machine becomes a special case of the ControlEngine's action set.
+- Extends [ADR-0008: Wizard Lifecycle Architecture](0008-wizard-lifecycle.md) — ADR-0008's state machine becomes a special case of the ControlEngine's action set. ADR-0008 was promoted to `accepted` on 2026-04-28; this dependency is now satisfied and chantiers A-1/A-2 are unblocked.
 - [ADR-0009](0009-pledge-structural-tool-filtering.md), [ADR-0010](0010-universal-tool-layer.md) — modules that the engine orchestrates.
 - [ADR-0013](0013-storage-files-no-redb.md) — engine state persistence lands on the files backend.
 - Chantiers: A-1 (engine), A-2 (CLI thin), A-3 (MCP wizard extend) in the sprint menu.


### PR DESCRIPTION
## Summary

- Promote ADR-0008 (Wizard Lifecycle Architecture) from `proposed` to `accepted` per founder decision (2026-04-28)
- Resolve status inversion: ADR-0011 (ControlEngine + MCP-tools-first) is already `accepted` and formally depends on ADR-0008
- Unblock chantiers **A-1** (ControlEngine skeleton) and **A-2** (CLI thin wrapper)

Doc-only PR. No code changes — implementation tracked separately.

## Changes

- `docs/decisions/0008-wizard-lifecycle.md` — frontmatter `status: accepted` + `accepted: 2026-04-28`; promotion note added at top
- `docs/decisions/0011-control-engine-mcp-tools.md` — note that ADR-0008 dependency is now satisfied
- `CHANGELOG.md` — `[Unreleased]` entry under "Lifecycle roadmap (no code yet — design only)"

## Test plan

- [x] `prek` pre-commit hooks pass (no Rust files touched → cargo fmt/clippy/test skipped as expected)
- [x] CI quality gates green on PR (no-op for fmt/clippy/nextest since no `src/**` changes)
- [x] No release bump triggered (release-plz only watches `feat|fix|refactor|perf` prefixes; this is `docs:`)