### PR TITLE
docs: ADR-0013/0015 status corrections + ADR-0023/0024/0025/0026 drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ADR-0008 promoted from `proposed` to `accepted` (2026-04-28). Unblocks chantiers A-1 (ControlEngine) and A-2 (CLI thin).
 
+### Documentation
+
+- **ADR hygiene** — corrected zombie statuses on previously-`done` ADRs whose
+  implementations are deferred. ADR-0013 (storage refactor on atomic files +
+  JSONL) and ADR-0015 (indirect prompt injection coverage) revert from `done`
+  to `accepted`; both designs remain final and binding, but no production
+  code matches them yet (redb persistence still active in v0.36.x; A-6 output
+  scan deferred). Status notes inline in each ADR record the correction.
+- **ADR-0023 (proposed)** — Preset Naming and Composition Strategy. Formalises
+  the existing five-preset catalogue with a `[meta] tier` taxonomy
+  (`base`, `audience-specific`, `experimental`), the kebab-case naming
+  convention, and the rule that presets do not nest (compliance overlays are
+  a separate `kind = "overlay"` concept). No code changes yet — proposal only.
+- **ADR-0024 (proposed)** — Preset-as-Compliance-Template. Treats compliance
+  presets as packaged decisions bundling routing topology, policy choices,
+  ADR-0022 `[endpoints.compliance]` metadata, and `[meta] compliance_reviewed`
+  attestation. Documents customer-extension overlays (tighten only, never
+  loosen) and the certification-renewal lifecycle. No code changes yet —
+  proposal only.
+- **ADR-0025 (proposed)** — RPC Mutation Transactionality and In-Flight
+  Visibility. Pins down semantics for `config/set`, `pledge/set`, `tools/*`,
+  `policy/*` RPC mutations: in-flight requests see pre-mutation snapshots,
+  persistence is atomic with the in-memory swap, per-namespace mutex permits
+  parallel writes across namespaces, every mutation emits an
+  `AuditEvent::RpcMutation` with `before_hash` / `after_hash`. No code
+  changes yet — proposal only; resolves the open question on issue #228.
+- **ADR-0026 (proposed)** — Model Name Canonicalization Policy. Records the
+  fixed rule set landed in PR #307 (lowercase, strip `-latest`, strip 8-digit
+  date suffix, dot-to-dash version on a known prefix gate, Anthropic
+  family-version reorder), the idempotence guarantee, the operator escape
+  hatches (per-endpoint `actual_model` mapping or table patch), and the
+  2-minor-release deprecation window for renamed models. No code changes
+  yet — formalises the existing implementation.
+
 ## [0.36.41](https://github.com/azerozero/grob/compare/v0.36.40...v0.36.41) - 2026-04-28
 
 ### Added

--- a/docs/decisions/0013-storage-files-no-redb.md
+++ b/docs/decisions/0013-storage-files-no-redb.md
@@ -1,10 +1,17 @@
 ---
-status: done
+status: accepted
 date: 2026-04-09
 deciders: [azerozero, architect]
 consulted: []
 informed: []
 ---
+
+> **Status note (2026-04-28)**: status reverted from `done` to `accepted`.
+> redb persistence remains the active storage substrate in v0.36.x — `GrobStore`
+> in `src/storage/mod.rs` is still the live code path and `~/.grob/spend/*.jsonl`
+> has not yet been written. The A-7 storage refactor is deferred to v0.37+.
+> The decision recorded here remains binding; only the implementation flag has
+> been corrected to reflect that no production code matches the design yet.
 
 # ADR-0013: Storage on Atomic Files + Append-Only Journal — No redb
 

--- a/docs/decisions/0015-indirect-prompt-injection-coverage.md
+++ b/docs/decisions/0015-indirect-prompt-injection-coverage.md
@@ -1,10 +1,17 @@
 ---
-status: done
+status: accepted
 date: 2026-04-09
 deciders: [azerozero, architect]
 consulted: []
 informed: []
 ---
+
+> **Status note (2026-04-28)**: status reverted from `done` to `accepted`.
+> A-6 (indirect prompt injection coverage) implementation is deferred — no
+> production code merges yet. The framework design described here is final and
+> binding for the next implementation pass; only the implementation flag has
+> been corrected to reflect that the symmetric output-side scan is not yet wired
+> into the dispatch pipeline.
 
 # ADR-0015: Indirect Prompt Injection Coverage — Scan Responses and `tool_result` Blocks
 

--- a/docs/decisions/0023-preset-naming-and-composition.md
+++ b/docs/decisions/0023-preset-naming-and-composition.md
@@ -1,0 +1,269 @@
+---
+status: proposed
+date: 2026-04-28
+deciders: [azerozero]
+consulted: []
+informed: []
+supersedes: []
+related: [ADR-0008, ADR-0022, ADR-0024]
+---
+
+# ADR-0023: Preset Naming and Composition Strategy
+
+## Context and Problem Statement
+
+Grob ships five built-in presets today (`perf`, `ultra-cheap`, `eu-eco`,
+`eu-pro`, `eu-max`) plus two compliance overlays (`gdpr`, `eu-ai-act`) under
+`presets/*.toml`. The set has been growing organically: each new audience has
+been served by adding a preset, sometimes by splitting an existing one
+(`eu` → `eu-eco`/`eu-pro`/`eu-max` in a recent release; see CHANGELOG),
+sometimes by adding an overlay alongside (`gdpr.toml`, `eu-ai-act.toml`).
+
+Two structural questions have never been settled:
+
+1. **What makes a preset shippable as a built-in?** The current heuristic is
+   "the maintainer thinks a meaningful audience exists". This produces
+   inconsistencies — for example, `optimal` shipped briefly in a recent
+   release then was retired before users adopted it (see CHANGELOG).
+   There is no checklist a candidate must pass.
+2. **How do presets compose?** `gdpr.toml` and `eu-ai-act.toml` look like
+   presets but are actually meant to be applied **on top of** another preset.
+   Nothing in the file format distinguishes the two roles. A user reading
+   `presets/index.toml` cannot tell that `gdpr` is an overlay and `eu-pro`
+   is a base.
+
+These ambiguities surface in three operational pain points:
+
+- **Discovery.** `grob preset list` flattens overlays and bases into one
+  list, so first-time users get confused about which one to pick.
+- **Configuration drift.** When a base preset (e.g. `eu-pro`) is updated
+  with a new provider, the overlay (`gdpr`) does not automatically reflect
+  the change because the relationship is implicit, not declared.
+- **Naming sprawl.** Without a convention, future presets risk landing
+  with inconsistent names — `eu-strict-2026`, `cheap-no-anthropic`,
+  `experimental-bandit-routing` — making the catalogue hard to navigate.
+
+ADR-0022 introduces structured `[endpoints.compliance]` blocks. This makes
+the overlay-vs-base distinction tractable in code: an overlay is a config
+fragment that targets `[endpoints.compliance]` keys, a base is a full
+routing configuration. The schema is now expressive enough to formalise
+the strategy that has been operating informally.
+
+## Decision Drivers
+
+- **Single source of truth for "is this preset shippable?"** A candidate
+  must pass an explicit gate, not rely on maintainer intuition.
+- **Predictable user experience.** Users should be able to read the preset
+  catalogue and immediately know which entries are starting points, which
+  are tunings, and which are experimental.
+- **Compatible with the ADR-0022 schema rebuild.** The strategy chosen here
+  must survive the `[[endpoints]]` / `[[policies]]` migration without
+  needing a second redesign.
+- **Backward compatible.** Existing preset names (`perf`, `ultra-cheap`,
+  `eu-eco`, `eu-pro`, `eu-max`, `gdpr`, `eu-ai-act`) must keep working;
+  no rename forces user config rewrites.
+- **Auditability for security-prevails customers.** Compliance overlays
+  are a documented surface; they must not silently merge into base
+  presets in a way that hides which compliance decisions apply.
+
+## Considered Options
+
+1. **Status quo — informal convention.** Keep adding presets as needed; let
+   the maintainer eyeball "is this generally useful". Reject: produces the
+   sprawl described above and offers no answer to the overlay-vs-base
+   question.
+2. **Folder-based separation.** Put base presets in `presets/base/`,
+   overlays in `presets/overlay/`, experimental in `presets/experimental/`.
+   Simple but invisible to anyone who does not run `tree`.
+3. **Frontmatter `tier` field.** Add a typed `[meta] tier = "base"` to
+   every preset's `[meta]` block; gate `grob preset list` formatting on
+   it; reject loading a preset whose tier value is not in a fixed set.
+   Composition rules become explicit in the data model, not just in
+   maintainer custom.
+4. **Dedicated TOML namespaces.** Rename overlays to `overlay-gdpr.toml`,
+   experimental to `experimental-bandit.toml`. Encodes the role in the
+   filename, but breaks any user who has scripted `grob preset apply
+   gdpr` and similar.
+
+## Decision Outcome
+
+**Chosen: option 3 — frontmatter `tier` field.** Each preset declares its
+role inside its own `[meta]` block. `grob preset info <name>` reads the
+field, `grob preset list` groups by it, and the loader rejects unknown
+values. Filenames stay unchanged; the existing names keep working.
+
+### Tier taxonomy
+
+Three tiers, fixed by this ADR:
+
+| Tier | Purpose | Examples (today) |
+|---|---|---|
+| `base` | Standalone routing config — pick one. Never overlaid on another base. | `perf`, `ultra-cheap` |
+| `audience-specific` | Standalone routing config tuned to a specific audience constraint (sovereignty, jurisdiction, vertical). | `eu-eco`, `eu-pro`, `eu-max` |
+| `experimental` | Opt-in beta. Not shipped as a built-in unless the user enables a feature flag. | (none today; reserved for new primitives) |
+
+A separate concept, **overlay**, is *not* a preset tier. Overlays are
+documented in ADR-0024 and identified by a different frontmatter field
+(`[meta] kind = "overlay"`).
+
+### Naming convention
+
+`{audience-or-cost}-{tier-or-grade}` lower-case kebab-case.
+
+Concrete patterns:
+
+- Cost-driven: `ultra-cheap`, `cheap-eu`, `mid-tier`.
+- Audience-driven (sovereignty / jurisdiction / vertical):
+  `eu-{eco|pro|max}`, `us-{eco|pro|max}`, `apac-{eco|pro|max}`.
+- Performance-driven: `perf`, `perf-anthropic`, `perf-multi`.
+- Experimental: `experimental-{primitive-name}` (`experimental-bandit`,
+  `experimental-hedged`).
+
+The convention is descriptive, not prescriptive: a preset with a clearly
+distinct audience (e.g. a healthcare-vertical preset) can pick the most
+recognisable name without contortion.
+
+### Composition rules
+
+1. **Presets do not nest.** A base or audience-specific preset is a
+   complete routing configuration. It does not inherit from, extend, or
+   reference another preset. This matches the existing TOML structure:
+   each preset file is self-contained, and merging two of them is the
+   user's responsibility.
+2. **Compliance overlays are not presets.** `gdpr.toml` and
+   `eu-ai-act.toml` carry `[meta] kind = "overlay"` and only declare
+   `[endpoints.compliance]` blocks (per ADR-0022) plus optional
+   `[policies]` filters. They are applied on top of a base preset by
+   `grob preset apply <base> --with <overlay>`.
+3. **Experimental presets ship in-tree but not built-in.** Files live in
+   `presets/experimental/` and are gated behind `[features]
+   experimental_presets = true` at runtime. `grob preset list` shows
+   them only when the feature is enabled, with an `(experimental)` tag.
+4. **Composition is one-way.** A base preset does not reach into an
+   overlay; an overlay does not redefine endpoints declared in the base.
+   If a user needs a base modified, they fork the preset file rather
+   than overlay it. This keeps the merge order trivial: base first,
+   overlay second, no diamond conflicts.
+
+### Lifecycle gate — `grob preset info` as the shippability check
+
+Every preset must satisfy three conditions before shipping in-tree as
+built-in:
+
+1. `[meta] description = "..."` is non-empty and ≤ 80 characters
+   (matches the format used by `presets/index.toml`).
+2. `[meta] tier` is one of `base`, `audience-specific`, or
+   `experimental`. The loader rejects any other value.
+3. `grob preset info <name>` runs to completion and emits no warning.
+   This validates that providers referenced exist, that auto-map regexes
+   compile, and that compliance metadata (when present, see ADR-0024)
+   parses.
+
+These three checks are wired into CI as `cargo test
+preset_validation_built_in`. Adding a new preset to the in-tree set is a
+documentation event: the test fails until the preset passes the gate.
+
+### What this ADR does *not* cover
+
+- **Preset versioning** — when an existing preset bumps to a new
+  provider list, what is the user-visible signal? Deferred to ADR-0024,
+  which handles this for compliance presets specifically (cert
+  expiry, sub-processor change, etc.).
+- **User-authored presets in `~/.grob/presets/`** — the convention
+  documented here is for in-tree built-ins; user-authored presets are
+  free to ignore it. The loader will continue to accept any well-formed
+  TOML.
+- **Auto-translation of legacy preset names** — every name that ships at
+  the time this ADR is accepted keeps working. No rename pressure.
+
+## Consequences
+
+### Positive
+
+- **`grob preset list` becomes navigable.** Output groups bases first,
+  then audience-specific, with overlays in a separate section. Users
+  reading the output for the first time can identify a starting point in
+  one screen.
+- **CI gates new presets.** Adding a preset is a single documented
+  operation; the gate ensures every shipped preset has a description, a
+  tier, and validates cleanly.
+- **Composition is structural, not implicit.** ADR-0024's compliance
+  overlays plug into a documented hook rather than relying on naming
+  conventions.
+- **Experimental presets get a home.** Bench results from new primitives
+  (e.g. early Thompson-sampling experiments) can land in-tree without
+  promising end-user stability.
+
+### Negative
+
+- **One more required field per preset file.** Every existing preset
+  needs a `[meta] tier = "..."` line. Mechanical change, but a change.
+- **The taxonomy is finite.** If a future preset does not fit into
+  `base` / `audience-specific` / `experimental`, this ADR has to be
+  revisited. The taxonomy was sized for the current catalogue plus
+  expected growth (~12 presets), not for an unbounded set.
+- **`experimental_presets` feature flag is a new surface.** Adds one
+  more configuration knob and one more test path.
+
+### Confirmation
+
+- **Linter test** (`tests/preset_metadata.rs`) asserts every file in
+  `presets/*.toml` declares `[meta] tier = "..."` from the allowed set
+  and that `[meta] description` is non-empty.
+- **Validation test** (`tests/preset_validation_built_in.rs`) calls
+  `grob preset info <name>` against every shipped preset and asserts
+  zero warnings.
+- **Naming-convention test** (`tests/preset_naming.rs`) asserts every
+  shipped filename matches `[a-z0-9]+(-[a-z0-9]+)*` (lower-case
+  kebab-case).
+- **CI gate** runs all three on every PR; CHANGELOG `[Unreleased]`
+  block records the expected additions for the next release.
+
+## Pros and Cons of the Options
+
+### Option 1 — Informal convention (status quo)
+
+**Pros:** zero work; no schema change.
+**Cons:** the sprawl described in *Context*; new contributors have no
+guidance; overlays remain invisible in tooling.
+
+### Option 2 — Folder-based separation
+
+**Pros:** simple; no TOML schema change.
+**Cons:** invisible to most users (who use `grob preset list`, not
+`tree presets/`); breaks file-name-based scripts; cannot encode richer
+metadata (description length, validation status).
+
+### Option 3 — Frontmatter `tier` field (chosen)
+
+**Pros:** explicit, machine-readable, backward compatible (only adds a
+field), composes with ADR-0024's `kind = "overlay"`.
+**Cons:** adds one required field per preset; one more lint to
+maintain.
+
+### Option 4 — Dedicated TOML namespaces
+
+**Pros:** the role is visible in the filename.
+**Cons:** breaks every user who has typed `grob preset apply gdpr` —
+the rename cost is large for limited gain over option 3.
+
+## More Information
+
+### Related ADRs
+
+- [ADR-0008](0008-wizard-lifecycle.md) — wizard exposes preset selection
+  during first-run; `grob preset list` formatting changes here will
+  reflect there.
+- [ADR-0022](0022-declarative-endpoints-policies-schema.md) —
+  `[endpoints.compliance]` is the schema hook compliance overlays
+  declare against.
+- [ADR-0024](0024-preset-as-compliance-template.md) — formalises
+  compliance overlays as packaged decisions.
+
+### Migration plan
+
+1. Land this ADR (`status: proposed`).
+2. Add `[meta] tier = "..."` to every shipped preset file in a
+   follow-up PR (mechanical change, no behaviour delta).
+3. Implement `grob preset info` validation gate.
+4. Promote ADR to `accepted` when the gate is enforced in CI.

--- a/docs/decisions/0024-preset-as-compliance-template.md
+++ b/docs/decisions/0024-preset-as-compliance-template.md
@@ -1,0 +1,322 @@
+---
+status: proposed
+date: 2026-04-28
+deciders: [azerozero]
+consulted: []
+informed: []
+supersedes: []
+related: [ADR-0006, ADR-0022, ADR-0023]
+---
+
+# ADR-0024: Preset-as-Compliance-Template — Packaged Compliance Decisions
+
+## Context and Problem Statement
+
+The `eu-pro` and `eu-max` presets ship today carrying compliance metadata
+**implicitly** in TOML comments and provider selection: "this preset uses
+Scaleway (FR datacenters) and Nebius (eu-north1, FI), excludes US
+providers, and is intended for GDPR-strict EU sovereign routing." The
+intent is documented in the preset header; the *machine-readable* form
+of that intent does not exist anywhere — neither the policy engine nor
+the audit log knows that `eu-pro` makes specific compliance claims.
+
+ADR-0022 introduces a structured `[endpoints.compliance]` block with six
+typed fields (`trust_zone`, `jurisdiction`, `data_classification`,
+`certifications`, `provider_risk_score`, `sub_processors`). With this
+schema, presets can encode compliance decisions in a typed form rather
+than in prose. But three structural questions remain:
+
+1. **Authority.** When an `eu-pro` preset declares
+   `jurisdiction = "EU"` for every endpoint, who guarantees that this
+   declaration is correct as of the release date? Today the answer is
+   "the preset maintainer reviewed the provider's docs"; tomorrow this
+   needs to be a documented commitment with a review cadence.
+2. **Evolution.** When a sub-processor changes (e.g. Scaleway adds a new
+   partner data centre outside FR) or a certification expires (e.g. the
+   provider drops SecNumCloud), what is the user-facing signal?
+   Currently a preset would silently still claim the old compliance
+   posture until the next release.
+3. **Customer extension.** A security-prevails customer may want to
+   *narrow* a shipped preset (add more requirements) without forking
+   the entire preset. How does grob support that without making the
+   merge order ambiguous?
+
+ADR-0023 establishes the tier taxonomy and recognises *overlay* as a
+distinct concept, but leaves the **content** of compliance overlays
+unspecified. This ADR fills that gap.
+
+The strategic question is: do we treat compliance presets as
+documentation (informal claims, soft guarantees, no machine
+verification), or as *packaged decisions* — a typed bundle of routing
+topology, policy choices, and compliance metadata, versioned and
+auditable?
+
+## Decision Drivers
+
+- **Security-prevails customers cannot adopt informal claims.** Defense,
+  banks, and OIV change-management processes require evidence that a
+  declared posture is current, traceable, and reviewable. A TOML comment
+  does not pass that bar.
+- **Compliance changes outside grob's release cycle.** Provider
+  certifications expire on the provider's calendar, not on grob's.
+  The signalling mechanism must surface drift even when grob itself
+  has not changed.
+- **Composition with the ADR-0023 overlay model.** Compliance overlays
+  must plug cleanly into the tier taxonomy without introducing a fourth
+  tier or breaking the "presets do not nest" rule.
+- **No silent merges.** When an overlay tightens a base preset, the user
+  must see the diff before applying — both the new value and the
+  rationale.
+- **Audit trail.** Each preset application emits an event readable by
+  ADR-0017's Sokolsky log backend, capturing which preset, which
+  overlay, and which compliance commitments were active at apply time.
+
+## Considered Options
+
+1. **Documentation-only compliance.** Keep the TOML-comment status quo;
+   add a `docs/compliance/` page describing each preset's claims. No
+   schema, no audit, no enforcement. Reject: does not solve the
+   security-prevails adoption blocker.
+2. **External compliance registry.** Maintain a separate JSON/YAML file
+   under `compliance/registry.json` that maps preset names to their
+   compliance metadata. Reject: introduces a second source of truth that
+   can drift from the preset itself.
+3. **Compliance metadata embedded in the preset (chosen).** Each preset
+   declares `[endpoints.compliance]` per ADR-0022 directly inline. A
+   preset is a packaged decision: topology + policy + compliance, all
+   versioned together.
+4. **Formal certification authority.** Grob ships compliance presets
+   only after an external auditor signs off. Reject: out of scope; the
+   maintainer can document review without claiming an external audit.
+
+## Decision Outcome
+
+**Chosen: option 3 — compliance metadata embedded inline as part of the
+preset.** A compliance preset is a *packaged decision*: it bundles
+topology (`[[endpoints]]`), policies (`[[policies]]`), and compliance
+declarations (`[endpoints.compliance]`) in a single TOML file, versioned
+in lockstep, reviewable as a unit.
+
+### What "packaged decision" means
+
+A compliance preset (e.g. `eu-pro`, `eu-max`) commits to four things,
+all visible in the preset file and inspectable via `grob preset info`:
+
+1. **Routing topology.** Which endpoints exist (`[[endpoints]]`).
+2. **Policy choices.** How requests select among them (`[[policies]]`).
+3. **Compliance posture.** What every endpoint declares
+   (`[endpoints.compliance]` per ADR-0022).
+4. **Review metadata.** When the preset was last reviewed against the
+   sub-processor lists and certifications it claims (`[meta]
+   compliance_reviewed = "YYYY-MM-DD"`).
+
+These four are inseparable. A preset that declares
+`jurisdiction = "EU"` but routes to a US endpoint is rejected by
+`grob preset info`. A preset whose `compliance_reviewed` date is more
+than 12 months old emits a warning at apply time.
+
+### Customer extension via overlays
+
+A security-prevails customer can extend a shipped preset with their
+own `[endpoints.compliance]` overrides through an overlay file (per
+ADR-0023's `[meta] kind = "overlay"`):
+
+```toml
+# /etc/grob/overlays/customer-extra.toml
+[meta]
+kind = "overlay"
+description = "Additional internal classification for customer X"
+applies_to = ["eu-pro", "eu-max"]
+
+[endpoints.compliance]
+data_classification = "restricted"
+certifications = ["customer-internal-baseline-2026-q2"]
+```
+
+Apply: `grob preset apply eu-pro --with /etc/grob/overlays/customer-extra.toml`.
+
+The overlay **adds** to the base's compliance metadata; it does not
+silently *relax* a base's declared posture. If a customer needs to
+weaken a base (e.g. allow `data_classification = "internal"` where the
+base demands `restricted`), the loader rejects the overlay with a
+clear error. Tightening is allowed; loosening requires forking.
+
+### Update lifecycle — versioning compliance presets
+
+Compliance presets are versioned with the rest of grob. When the
+preset's compliance posture changes:
+
+1. **Sub-processor added or removed.** Bump the preset's
+   `[meta] compliance_reviewed` date and emit a CHANGELOG entry under
+   the *Compliance* heading. The preset filename does not change.
+2. **Certification expires.** If a certification listed in
+   `[endpoints.compliance].certifications` is renewed in time, bump
+   `compliance_reviewed`. If it lapses, **bump the preset filename** to
+   `<preset>-v2.toml` and keep the v1 file shippable until the next
+   minor release for compatibility (mirrors ADR-0023's
+   audience-specific tier policy on backward compatibility).
+3. **Major posture change.** A change that removes a jurisdiction or
+   trust zone (e.g. dropping FR data centres) is a major bump:
+   `<preset>-v2.toml` ships, the v1 file gets a deprecation note in
+   `[meta]`, and the deprecation appears in the CHANGELOG and at every
+   `grob preset apply <name>` until the v1 file is removed.
+
+This mirrors the ADR-0022 deprecation cadence (10 minor releases) for
+the highest-impact case (major posture change). For the common case
+(routine review), nothing visibly changes for the user beyond an updated
+review date.
+
+### Schema additions to `[meta]`
+
+Compliance presets add three optional `[meta]` fields on top of the
+existing `[meta] description` from ADR-0023:
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `compliance_reviewed` | date `YYYY-MM-DD` | — | Last review against sub-processors and certifications. |
+| `compliance_summary` | string ≤ 200 chars | — | One-paragraph user-facing summary of the posture. |
+| `replaces` | string (preset name) | — | Older preset this one supersedes. Triggers deprecation banner on the named preset. |
+
+`grob preset info <name>` renders these alongside the routing summary.
+`grob preset list --compliance` filters to the subset of presets that
+declare `compliance_summary`.
+
+### Audit trail at apply time
+
+When a user runs `grob preset apply <preset> [--with <overlay>]`, grob
+emits a structured event to the Sokolsky log backend (ADR-0017):
+
+```json
+{
+  "kind": "preset.apply",
+  "preset": "eu-pro",
+  "preset_compliance_reviewed": "2026-04-28",
+  "overlay": "/etc/grob/overlays/customer-extra.toml",
+  "overlay_compliance_summary": "Additional internal classification for customer X",
+  "endpoints_compliance_digest": "<sha256 of merged compliance blocks>"
+}
+```
+
+The digest gives a stable identifier for the **applied** posture (base
++ overlay) without leaking the full TOML to the audit log. Auditors
+querying Sokolsky can correlate the digest with a preset version known
+at the time of application.
+
+### What this ADR does *not* cover
+
+- **Provider-side certification verification.** Grob does not query
+  provider APIs to confirm certifications are current. The
+  `compliance_reviewed` date is a maintainer attestation, not a live
+  check.
+- **Cryptographic signing of presets.** Presets are reviewed in git;
+  no PGP/Sigstore signature is required at this stage. Future work,
+  separate ADR.
+- **Auto-update of the review date.** A preset whose last review is
+  stale must be hand-bumped by the maintainer; no nightly job rewrites
+  it.
+
+## Consequences
+
+### Positive
+
+- **Compliance posture is machine-readable.** ADR-0022's typed schema
+  combined with the `[meta] compliance_*` fields gives every shipped
+  preset an inspectable, auditable shape.
+- **Customer extensibility without forking.** Overlays cover the common
+  case (tighten, do not relax). Forking remains the escape hatch for
+  the uncommon case.
+- **Deprecation is loud.** The `replaces` field and CHANGELOG entry
+  ensure users on a stale preset see a banner at every apply, not
+  silently inherit lapsed claims.
+- **Sokolsky digest** gives forensic auditors a stable handle for the
+  posture in effect at any given application time.
+
+### Negative
+
+- **More work for the preset maintainer.** Each compliance preset must
+  carry a review date and a summary; the maintainer must keep the
+  review fresh.
+- **Lifecycle rules add complexity.** Three categories (routine
+  review / certification renew / major posture change) each have a
+  different signalling cost. The rules must be documented in the
+  contributor guide.
+- **No external audit.** A preset still represents a maintainer
+  judgement, not a third-party attestation. Customers who need an
+  audited posture must run their own due diligence.
+
+### Confirmation
+
+- **Schema test** (`tests/preset_compliance_schema.rs`) asserts that
+  every preset declaring at least one `[endpoints.compliance]` block
+  also declares `[meta] compliance_reviewed` and
+  `[meta] compliance_summary`.
+- **Apply-time test** (`tests/preset_compliance_apply.rs`) verifies the
+  Sokolsky `preset.apply` event is emitted with the correct digest for
+  a fixture preset + overlay pair.
+- **Stale-review warning test** asserts that
+  `compliance_reviewed > 12 months ago` emits a warning to stderr at
+  apply time (not blocking, surfacing).
+- **Overlay tightening test** asserts that an overlay attempting to
+  loosen `data_classification` is rejected with a clear error.
+
+## Pros and Cons of the Options
+
+### Option 1 — Documentation-only compliance
+
+**Pros:** zero schema cost.
+**Cons:** does not pass security-prevails change-management; informal
+claims drift silently; no machine verification.
+
+### Option 2 — External compliance registry
+
+**Pros:** clean separation of concerns.
+**Cons:** two sources of truth; preset and registry can drift; review
+cadence is not enforceable.
+
+### Option 3 — Embedded compliance metadata (chosen)
+
+**Pros:** single source of truth (the preset file); reviewable in git;
+composes with ADR-0022 and ADR-0023.
+**Cons:** more work per preset; more rules in the lifecycle.
+
+### Option 4 — Formal certification authority
+
+**Pros:** strongest claim possible.
+**Cons:** out of scope for grob's resourcing; entangles release
+cadence with auditor schedule.
+
+## More Information
+
+### Related ADRs
+
+- [ADR-0006](0006-policy-engine-encrypted-audit-hit-gateway.md) —
+  policy engine and audit pipeline; preset-apply events flow through
+  the same path.
+- [ADR-0017](0017-sokolsky-log-backend.md) — production audit sink for
+  the `preset.apply` digest.
+- [ADR-0022](0022-declarative-endpoints-policies-schema.md) — defines
+  the `[endpoints.compliance]` schema this ADR commits to embedding in
+  presets.
+- [ADR-0023](0023-preset-naming-and-composition.md) — establishes the
+  overlay-vs-base separation that this ADR populates with content.
+
+### Worked example — `eu-pro` after this ADR
+
+```toml
+[meta]
+description = "Strict-EU sovereign, balanced — Hermes-4-405B + Qwen3.5-397B"
+tier = "audience-specific"
+compliance_reviewed = "2026-04-28"
+compliance_summary = "EU sovereign routing through Scaleway (FR) and Nebius (eu-north1, FI). All endpoints declare jurisdiction = EU and trust_zone = sovereign-eu. SecNumCloud and ISO 27001 listed where the provider has them."
+
+# topology + policy + compliance follow, per ADR-0022
+```
+
+### Migration plan
+
+1. Land this ADR (`status: proposed`).
+2. Backfill `[meta] compliance_reviewed` and `compliance_summary` on
+   shipped EU presets in a follow-up PR.
+3. Add tests listed under *Confirmation*.
+4. Promote ADR to `accepted` once tests are enforced and Sokolsky
+   wiring lands.

--- a/docs/decisions/0025-rpc-mutation-transactionality.md
+++ b/docs/decisions/0025-rpc-mutation-transactionality.md
@@ -1,0 +1,323 @@
+---
+status: proposed
+date: 2026-04-28
+deciders: [azerozero]
+consulted: []
+informed: []
+supersedes: []
+related: [ADR-0001, ADR-0006, ADR-0011, ADR-0017]
+---
+
+# ADR-0025: RPC Mutation Transactionality and In-Flight Visibility
+
+## Context and Problem Statement
+
+ADR-0001 established the static-config-with-atomic-reload model: the server
+loads TOML on startup, and the `/api/config/reload` endpoint atomically
+swaps reloadable state (router, provider registry, model index) without
+restart. In-flight requests continue on the old snapshot via a single
+`snapshot()` mechanism that captures the configuration version in scope at
+the start of dispatch.
+
+A new class of mutation has been growing under issue #228 — RPC calls that
+modify server state at runtime *without* going through `config/reload`.
+Examples include:
+
+- `config/set` — set a single config key (e.g. enable a feature flag).
+- `pledge/set` — narrow the active pledge.
+- `tools/enable`, `tools/disable` — toggle a tool in the matrix
+  ([ADR-0011](0011-control-engine-mcp-tools.md)).
+- `policy/upsert`, `policy/delete` — mutate an entry in the policy engine
+  ([ADR-0006](0006-policy-engine-encrypted-audit-hit-gateway.md)).
+
+These mutations work in-memory today; their persistence semantics, ordering
+guarantees, and audit footprint have never been recorded as a binding
+decision. Operators using them cannot answer the following questions
+without reading source code:
+
+1. **Visibility.** A mutation lands while a request is mid-dispatch. Does
+   the in-flight request see the pre-mutation state, the post-mutation
+   state, or some interleaving of both?
+2. **Persistence.** A mutation succeeds and the operator restarts the
+   server. Does the mutation survive the restart, or is the next startup
+   loaded from disk-only state? Today the answer is "depends on the
+   namespace", and is not documented.
+3. **Concurrency.** Two mutations land at the same time on different
+   namespaces (`config/set` and `pledge/set`). Do they serialize behind a
+   single global mutex (slow), or do they interleave (correctness risk)?
+4. **Audit.** Does every mutation appear in the Sokolsky audit log
+   ([ADR-0017](0017-sokolsky-log-backend.md))? Today some do, some do
+   not; the inventory is implicit.
+
+These ambiguities have not produced a known incident, but they will: an
+operator writing automation against the RPC surface assumes one set of
+semantics, and the next refactor changes them silently.
+
+## Decision Drivers
+
+- **Compatibility with ADR-0001's snapshot model.** Whatever this ADR
+  chooses must reuse the existing `snapshot()` machinery. Inventing a
+  second consistency primitive doubles the surface to reason about.
+- **No surprise to operators.** A mutation that succeeds via RPC must
+  either persist or fail loudly; "succeeded but lost on restart" is not
+  acceptable.
+- **Bounded contention.** A global mutex across all RPC mutations is the
+  simplest model but serializes unrelated namespaces unnecessarily.
+- **Audit completeness.** Every mutation that changes operator-observable
+  state must produce an entry in the audit log. Mutations that *do not*
+  change state (e.g. a no-op policy upsert) may emit a tagged event but
+  should not flood the log.
+- **Bounded blast radius.** A failed mutation must not leave the server
+  in a half-mutated state. Either the in-memory swap and the disk write
+  both succeed, or neither does.
+
+## Considered Options
+
+1. **Eventually-consistent — in-memory only, write to disk in the
+   background.** Cheap, but mutations can be lost on restart. Reject:
+   violates the "no surprise" driver.
+2. **Restart-required for every mutation.** Treat every RPC mutation as
+   "edit a config file and restart". Cleanest semantically but makes the
+   RPC surface useless for the live-tuning workflows it was built for.
+3. **Atomic in-memory swap + atomic disk persist + per-namespace mutex
+   (chosen).** Mutations apply via a critical section that updates the
+   in-memory snapshot and writes to disk in a single atomic operation;
+   different namespaces can mutate in parallel.
+4. **Two-phase commit across namespaces.** Mutations to multiple
+   namespaces in one RPC call become a transaction that fully succeeds
+   or fully fails. Reject: complexity is not justified by today's
+   workload (mutations are single-namespace in 100% of observed RPC
+   traffic).
+
+## Decision Outcome
+
+**Chosen: option 3 — atomic in-memory swap + atomic disk persist +
+per-namespace mutex.** Visibility reuses ADR-0001's `snapshot()`;
+persistence happens before the RPC returns success; per-namespace
+serialization permits parallel writes across namespaces while keeping a
+single namespace's writes ordered.
+
+### Visibility model
+
+In-flight requests captured a `snapshot()` at dispatch start (per
+ADR-0001). They keep that snapshot for the request's lifetime. New
+requests entering dispatch *after* the swap point pick up the new
+snapshot. Concretely:
+
+```text
+                    │
+   request A ──────►│   captures snapshot v1
+                    │
+   RPC mutation ────►│   atomic swap: v1 → v2
+                    │
+   request B ──────►│   captures snapshot v2
+                    │
+                    ▼
+                   time
+```
+
+Request A finishes on v1, even if v2 is the new "live" version. This
+matches the existing `/api/config/reload` semantics exactly — the RPC
+mutation path is just a smaller-grained variant.
+
+The implementation surface is `ApplicationState::snapshot()` already
+in `src/server/mod.rs`. RPC mutations call a private
+`apply_mutation(namespace, action)` helper that:
+
+1. Acquires the namespace mutex.
+2. Computes the proposed new state.
+3. Performs the atomic in-memory swap (pointer update on the
+   ApplicationState arc-swap).
+4. Writes the proposed state to disk.
+5. Releases the mutex.
+
+Failure between steps 3 and 4 (e.g. disk write fails) **rolls back the
+in-memory swap** before returning an error. The RPC client either sees
+success-with-persistence or failure-with-no-state-change.
+
+### Persistence semantics
+
+Per-namespace persistence destinations:
+
+| Namespace | Disk artifact | Format |
+|---|---|---|
+| `config/*` | `~/.grob/config.toml` (rewritten atomically via `write_temp + rename`) | TOML |
+| `pledge/*` | `~/.grob/pledge/active.toml` | TOML |
+| `tools/*` | `~/.grob/tools/matrix.toml` | TOML |
+| `policy/*` | `~/.grob/policies/<id>.toml` (one file per policy) | TOML |
+
+All writes use the atomic `write_temp + fsync + rename` pattern from
+ADR-0013 (or its successor implementation). The RPC returns success
+only when `rename(2)` completes; any earlier failure propagates as an
+error, and the in-memory snapshot is rolled back.
+
+A server restart loads from disk and arrives at the same state the
+client observed at the last successful mutation. There is no "in-memory
+only" state for RPC mutations — by design.
+
+### Concurrency model — per-namespace mutex
+
+A single global mutex would serialize a `config/set` behind a
+`pledge/set`, even though they touch unrelated state. This is a
+performance cost without a correctness benefit. Instead:
+
+- One `tokio::sync::Mutex` per namespace (`config`, `pledge`, `tools`,
+  `policy`).
+- A mutation acquires only its namespace's mutex.
+- Mutations in different namespaces run in parallel.
+- Mutations in the same namespace serialize in arrival order.
+
+Cross-namespace consistency is *not* guaranteed by this ADR. If a
+client wants to atomically update a config flag and a policy entry,
+the client either accepts an interleaved view or uses
+`/api/config/reload` (which already provides a single global swap).
+
+### Audit log entry
+
+Every successful mutation emits one Sokolsky audit event:
+
+```rust
+AuditEvent::RpcMutation {
+    namespace: String,    // "config", "pledge", "tools", "policy"
+    action: String,       // "set", "upsert", "delete", "enable", "disable"
+    target: String,       // resource id (key path, policy id, tool id)
+    before_hash: [u8; 32], // SHA-256 of pre-mutation namespace state
+    after_hash: [u8; 32],  // SHA-256 of post-mutation namespace state
+    actor: ActorId,        // who issued the RPC (token id, OAuth subject, etc.)
+    timestamp: SystemTime,
+}
+```
+
+A no-op mutation (e.g. `config/set` with the same value already in
+state) emits an event with `before_hash == after_hash`. Auditors can
+filter these out; the event log preserves the call attempt for forensic
+purposes.
+
+Failed mutations also emit an event (`RpcMutationFailed { namespace,
+action, error }`) so that an operator scripting against the RPC can
+correlate a 5xx with the audit log without grepping server logs.
+
+### Failure modes and rollback
+
+| Failure point | Behaviour |
+|---|---|
+| Mutex acquisition (deadlock impossible — single mutex per call) | N/A |
+| Validation of new state (e.g. malformed TOML produced by mutation) | Reject before swap; no in-memory or disk change. |
+| Atomic in-memory swap | Cannot fail (arc-swap is infallible). |
+| Disk write fails (`fsync`, `rename`) | Roll back in-memory swap to the pre-mutation pointer; return 500 to RPC client; emit `RpcMutationFailed` audit event. |
+| Audit emission fails | Mutation has succeeded on disk and in memory; audit-emit failure is logged but does not roll back. (Mirrors the existing reload path's audit semantics.) |
+
+The audit-emit failure case is a deliberate carve-out: if Sokolsky is
+unreachable, mutations should not be blocked. The local stderr/journal
+fallback receives the event and an alert is emitted by the audit
+subsystem.
+
+### What this ADR does *not* cover
+
+- **Cross-namespace transactions.** As noted, a multi-namespace mutation
+  is not supported; clients should use `/api/config/reload` for that
+  use case.
+- **Optimistic concurrency / CAS.** Conflicts within a namespace
+  serialize; clients are not handed a version token to detect
+  concurrent writers. If contention becomes a problem, a future ADR can
+  add it.
+- **Bulk import.** A client wishing to import a large policy set should
+  build a TOML file and call `/api/config/reload`, not script
+  thousands of `policy/upsert` RPCs.
+
+## Consequences
+
+### Positive
+
+- **Operator-visible state is consistent across restarts.** A mutation
+  that returns success is durable.
+- **Audit log is complete.** Every state-changing RPC and every failed
+  attempt produces an entry.
+- **Bounded contention.** Per-namespace mutexes prevent a slow `policy`
+  write from blocking a `config` flag flip.
+- **Compatibility with ADR-0001.** The RPC surface reuses the existing
+  snapshot model rather than inventing parallel machinery.
+
+### Negative
+
+- **One mutex per namespace** is a small surface to maintain. New
+  namespaces must be added to the mutex map at registration time.
+- **Disk write happens inside the RPC critical section.** This makes
+  RPC latency depend on disk fsync. Acceptable for the workloads RPC
+  was built for (live tuning, ~100/min); not acceptable for bulk
+  import (which uses `config/reload` instead).
+- **No cross-namespace atomicity.** Documented limitation; clients
+  needing it use `config/reload`.
+
+### Confirmation
+
+- **Snapshot test** (`tests/rpc_mutation_snapshot.rs`) asserts an
+  in-flight request started before a mutation observes the
+  pre-mutation namespace state for its full lifetime.
+- **Persistence test** (`tests/rpc_mutation_persistence.rs`) starts a
+  server, issues a mutation, restarts, and asserts the new state is
+  loaded.
+- **Concurrency test** (`tests/rpc_mutation_concurrency.rs`) issues
+  parallel mutations across namespaces and asserts they complete
+  concurrently; same-namespace mutations serialize in arrival order.
+- **Audit test** (`tests/rpc_mutation_audit.rs`) asserts every
+  successful mutation emits exactly one `RpcMutation` event with
+  matching `before_hash` / `after_hash`.
+- **Failure test** (`tests/rpc_mutation_disk_failure.rs`) injects a
+  disk-write failure, asserts the in-memory state is rolled back and
+  the RPC returns 500.
+
+## Pros and Cons of the Options
+
+### Option 1 — Eventually-consistent
+
+**Pros:** lowest RPC latency.
+**Cons:** mutations can be lost on restart; violates the "no surprise"
+driver.
+
+### Option 2 — Restart required
+
+**Pros:** zero new code; entirely covered by `config/reload`.
+**Cons:** RPC surface becomes useless for live tuning.
+
+### Option 3 — Atomic in-memory + disk + per-namespace mutex (chosen)
+
+**Pros:** explicit semantics; reuses ADR-0001 snapshot model; bounded
+contention; full audit.
+**Cons:** disk fsync inside critical section; one mutex per
+namespace.
+
+### Option 4 — Two-phase commit
+
+**Pros:** strong cross-namespace atomicity.
+**Cons:** complexity unjustified by current traffic; existing
+`config/reload` covers the use case.
+
+## More Information
+
+### Related ADRs
+
+- [ADR-0001](0001-static-config-no-hot-reload.md) — defines the
+  snapshot model that this ADR extends.
+- [ADR-0006](0006-policy-engine-encrypted-audit-hit-gateway.md) —
+  policy engine is one of the namespaces affected.
+- [ADR-0011](0011-control-engine-mcp-tools.md) — tool matrix is one of
+  the namespaces affected.
+- [ADR-0017](0017-sokolsky-log-backend.md) — destination for
+  `RpcMutation` audit events.
+
+### Reference issue
+
+- Issue #228 — "RPC mutations: persistence and concurrency". This ADR
+  is the formal answer.
+
+### Migration plan
+
+1. Land this ADR (`status: proposed`).
+2. Audit existing RPC handlers for namespace coverage; add
+   `apply_mutation` wrappers where missing.
+3. Add the four `tokio::sync::Mutex` instances to the
+   `ApplicationState`.
+4. Wire `RpcMutation` audit event into the Sokolsky pipeline.
+5. Land tests listed under *Confirmation*.
+6. Promote ADR to `accepted` when all tests pass in CI.

--- a/docs/decisions/0026-model-name-canonicalization-policy.md
+++ b/docs/decisions/0026-model-name-canonicalization-policy.md
@@ -1,0 +1,299 @@
+---
+status: proposed
+date: 2026-04-28
+deciders: [azerozero]
+consulted: []
+informed: []
+supersedes: []
+related: [ADR-0003, ADR-0018, ADR-0022]
+---
+
+# ADR-0026: Model Name Canonicalization Policy
+
+## Context and Problem Statement
+
+Pull request #307 (commit `b8b86b3`) introduced
+`canonicalize_model_name()` in `src/routing/classify/model_name.rs`. The
+function applies a small set of deterministic, idempotent rewrites so
+that user-typed model names map onto the canonical keys used in
+`[[models]]` config entries and `presets/*.toml`. The most common
+ambiguities it resolves:
+
+- Trailing date suffix: `claude-3-5-sonnet-20241022` →
+  `claude-3-5-sonnet`.
+- Trailing `-latest`: `claude-sonnet-4-5-latest` → `claude-sonnet-4-5`.
+- Dot-vs-dash version: `gemini-2.5-flash` → `gemini-2-5-flash`.
+- Anthropic family-version reorder: `claude-3-5-sonnet` →
+  `claude-sonnet-3-5`.
+- Mixed casing: lowercase ASCII.
+
+Without canonicalization, an explicit `[[models]]` entry named
+`claude-sonnet-3-5` would not match a request for
+`Claude-3-5-Sonnet-20241022`, even though both refer to the same model.
+The function unblocks a real user pain (the same model has multiple
+spellings in vendor docs and SDKs) but landed without a recorded
+decision. Three structural questions are unanswered in writing:
+
+1. **Are the rules canonical?** Today they are hardcoded in the source.
+   When a vendor publishes a sixth dot-versioned family, who decides
+   whether the new prefix gets added, and on what test? The current
+   code has tests for the rules that exist; the *policy* governing
+   addition of new rules is not documented.
+2. **Are operators allowed to override?** A power user routing to a
+   custom model whose name happens to match a canonicalization pattern
+   has no escape hatch documented anywhere.
+3. **What happens when a vendor renames a model?** Today an alias would
+   need a manual migration; the lifecycle is not documented.
+
+ADR-0018 introduced the topology-vs-policy split with `[[endpoints]]`,
+and ADR-0022 commits to the schema rebuild. Canonicalization must
+survive that schema migration without further ambiguity. The policy
+this ADR records governs the *rules* in
+`src/routing/classify/model_name.rs`, the *escape hatch* for operators,
+and the *deprecation cadence* for renamed models.
+
+## Decision Drivers
+
+- **Idempotence is non-negotiable.** Whatever rule set ships, applying
+  the canonicalizer twice must equal applying it once. This is a
+  property tested via proptest already; new rules must preserve it.
+- **Vendor-prefix gating prevents collisions.** A naive
+  dot-replacement rule would corrupt unrelated model names like
+  `glm-4.6`. Rules that rewrite version separators must be gated on a
+  known family prefix.
+- **Predictability beats expressiveness.** A small fixed rule set the
+  operator can read in 30 lines is preferable to a config-driven DSL
+  for 99% of users.
+- **Escape hatch for the 1%.** An operator running a custom proxy with
+  a model name colliding with the canonicalization rules must have a
+  documented way out.
+- **Stable upgrade story.** When a vendor renames a model (e.g.
+  `claude-3-7-opus` → `claude-opus-3-7-r1`), users must not silently
+  fall through into a "model not found" path on the next grob upgrade.
+
+## Considered Options
+
+1. **Config-driven canonicalization.** Operators declare rules in TOML.
+   Reject: 99% of users would have to write rules that match what we
+   ship anyway; the schema and validation cost is large.
+2. **Hardcoded rules with documented escape hatches (chosen).** Rules
+   live in source, gated by family prefix; operators with collisions
+   patch the table or use the per-endpoint `actual_model` mapping
+   already in `[[endpoints]]`.
+3. **Skip canonicalization, force users to write all spellings.**
+   Reject: this was the pre-PR-307 behaviour and it produced the bug
+   that the canonicalizer fixes. Reverting it would relitigate that
+   debate.
+4. **External alias service.** A network call resolves user input to
+   a canonical name. Reject: violates ADR-0014's single-binary
+   constraint and adds a new failure mode.
+
+## Decision Outcome
+
+**Chosen: option 2 — hardcoded rules with documented escape hatches.**
+The rules in `src/routing/classify/model_name.rs` are canonical; this
+ADR commits to their shape and lifecycle; operators with collisions
+have two documented escape paths (table patch or per-endpoint
+override).
+
+### Canonical form — fixed rule set
+
+The canonical form is produced by the following rules, applied in
+order. Each rule short-circuits when its pattern is absent, which
+guarantees idempotence.
+
+1. **Lowercase.** ASCII-only; non-ASCII bytes pass through unchanged.
+2. **Strip trailing `-latest`** (`claude-sonnet-4-5-latest` →
+   `claude-sonnet-4-5`).
+3. **Strip trailing 8-digit date suffix** `-YYYYMMDD`
+   (`claude-3-5-sonnet-20241022` → `claude-3-5-sonnet`). Must be
+   exactly 8 digits to avoid clobbering version segments such as
+   `gpt-5-2`.
+4. **Dot-versions to dashed-versions** for the family prefix set
+   (`gemini-2.5-flash` → `gemini-2-5-flash`). Gated on the family
+   prefix so unrelated IDs (e.g. `glm-4.6`) survive untouched.
+5. **Anthropic family-version reorder** (`claude-{N}-{M}-{family}` →
+   `claude-{family}-{N}-{M}` for `family ∈ {sonnet, opus, haiku}`).
+   Both Anthropic-published spellings collapse onto the modern
+   spelling used in `presets/*.toml`.
+
+### Family-prefix gate
+
+The dot-version replacement rule is gated on a known prefix set:
+
+```text
+claude-      gpt-      gemini-      grok-      deepseek-
+```
+
+A request whose model name starts with any other prefix bypasses rule
+4. This is the structural protection against collisions with custom
+model names. The gate is a constant in
+`src/routing/classify/model_name.rs`; adding a vendor prefix is a
+two-line change with a unit test.
+
+### Idempotence is a load-bearing property
+
+The proptest in `model_name.rs` asserts:
+
+```rust
+prop_assert_eq!(
+    canonicalize(canonicalize(x)),
+    canonicalize(x),
+);
+```
+
+over arbitrary alphanumeric strings. This is a release gate. Any new
+rule that breaks idempotence must be rejected at PR review.
+
+### Operator escape hatches
+
+Two paths, both documented:
+
+1. **Per-endpoint `actual_model` mapping.** ADR-0022's
+   `[[endpoints]]` schema already supports
+   `backend = { provider, model = "<exact string>" }`. The string is
+   passed to the provider verbatim, bypassing the canonicalizer for
+   the *outbound* leg. An operator hosting `my-claude-3.5-fork` on a
+   custom endpoint declares it once in the endpoint config and grob
+   never rewrites it.
+2. **Table patch.** An operator who needs the canonicalizer itself
+   to behave differently (e.g. a private fork of grob serving a
+   non-public vendor) patches the constant table and rebuilds. This
+   is explicitly *not* a config-driven path. It is the supported way
+   for operators outside the public vendor set to extend the
+   canonicalizer.
+
+These two cover the observed needs. A third path (config-driven
+rules) is rejected because the maintenance cost outweighs the value
+for the user count it would serve.
+
+### Deprecation lifecycle for renamed models
+
+When a vendor renames a model (or grob's canonical key changes for any
+other reason), the old name remains a recognised alias for **two
+minor releases** — the same cadence used for command-line argument
+deprecations elsewhere in grob.
+
+Concrete steps:
+
+1. **Release N (announcement).** Add the new canonical form. Add a
+   one-way alias from the old form to the new form (the canonicalizer
+   gains a new entry in rule 5 or an equivalent rule). Existing users
+   continue to resolve via the alias.
+2. **Releases N..N+1 (deprecation).** Each request resolved via an
+   alias logs a one-time WARN per session: "model name `<old>`
+   resolves to `<new>`; please update your config; alias removed in
+   v<N+2>".
+3. **Release N+2 (removal).** Alias removed; old name no longer
+   resolves; request returns the standard "model not found" error.
+
+The 2-minor-release window matches ADR-0022's deprecation cadence
+philosophy at a faster scale (the surface here is much smaller than
+the schema rebuild). For high-impact renames (e.g. an entire family
+rebrand), a future ADR may extend the window.
+
+### What this ADR does *not* cover
+
+- **Provider-side normalisation.** Some providers accept multiple
+  spellings; grob does not assume so. The canonicalizer fixes the
+  inbound side; the outbound model string is what the operator has
+  declared in `[[endpoints]]` or `[[models]]`.
+- **Capability tagging.** Mapping `claude-sonnet-4-5` to a
+  capability set (coding, vision, etc.) is governed by ADR-0018's
+  endpoint capability inference, not this ADR.
+- **Auto-completion in the wizard.** The wizard
+  ([ADR-0008](0008-wizard-lifecycle.md)) may suggest canonical names;
+  the suggestions come from the same table this ADR commits to.
+
+## Consequences
+
+### Positive
+
+- **Predictable behaviour.** Operators can read 30 lines of source
+  and know exactly what the canonicalizer does. No DSL to learn.
+- **Collision-safe.** The family-prefix gate prevents accidental
+  rewrites of unrelated model names.
+- **Escape hatch is honest.** Two documented paths cover the rare
+  cases without polluting the common case with config schema.
+- **Renames are loud.** The 2-release deprecation window with WARN
+  logging gives users time to update configs before silent failure.
+
+### Negative
+
+- **Hardcoded means new vendors require a release.** When a sixth
+  dot-versioned family appears, an operator cannot self-serve; they
+  open a PR or use the per-endpoint escape hatch.
+- **The rule set has an arbitrary stop point.** A future contributor
+  may want to add a sixth rule (e.g. underscore-vs-dash); this ADR
+  does not pre-approve such additions, but the property tests must
+  catch idempotence regressions.
+- **Aliases live in source.** Each rename adds a small amount of
+  permanent code surface (until removal at N+2).
+
+### Confirmation
+
+- **Idempotence proptest** (`model_name.rs::prop_canonicalize_is_idempotent`)
+  is a release gate.
+- **Family-prefix gate test** (`tests/canonicalize_unrelated.rs`)
+  asserts model names like `glm-4.6`, `mistral-large-2402`,
+  `qwen-3.5-72b` survive unchanged.
+- **Date-suffix length test** asserts strings ending in fewer than 8
+  digits do not get the date stripper.
+- **Alias deprecation test** is added per rename: WARN log emitted
+  exactly once per session, alias resolved correctly during the
+  deprecation window, error returned after removal.
+- **CI gate**: any change to the family-prefix set or the rule list
+  requires a corresponding test addition; reviewers reject PRs that
+  add a rule without a proptest update.
+
+## Pros and Cons of the Options
+
+### Option 1 — Config-driven canonicalization
+
+**Pros:** infinite flexibility.
+**Cons:** schema cost, validation cost, every operator writes rules
+that match what we ship anyway.
+
+### Option 2 — Hardcoded rules + escape hatches (chosen)
+
+**Pros:** simple, idempotent, fast; escape hatches cover the rare
+cases; family-prefix gate prevents collisions.
+**Cons:** new vendors require a release.
+
+### Option 3 — Skip canonicalization
+
+**Pros:** zero code.
+**Cons:** users hit the bug PR-307 fixed.
+
+### Option 4 — External alias service
+
+**Pros:** centralised aliases.
+**Cons:** violates the single-binary constraint; new failure mode.
+
+## More Information
+
+### Related ADRs
+
+- [ADR-0003](0003-regex-routing-engine.md) — the classification engine
+  that consumes the canonicalized name.
+- [ADR-0018](0018-nature-inspired-routing.md) — topology-vs-policy
+  split; the per-endpoint `actual_model` field is the operator escape
+  hatch this ADR points to.
+- [ADR-0022](0022-declarative-endpoints-policies-schema.md) —
+  `[[endpoints]]` schema where the per-endpoint override lives in
+  the new schema.
+
+### Reference
+
+- PR #307, commit `b8b86b3` — the implementation that landed the
+  rules this ADR formalises.
+- `src/routing/classify/model_name.rs` — module-level docs cover the
+  per-rule details; this ADR covers the *policy* governing the rules.
+
+### Migration plan
+
+1. Land this ADR (`status: proposed`).
+2. Cross-link the ADR from
+   `src/routing/classify/model_name.rs` module-level docs.
+3. Promote ADR to `accepted` when the family-prefix gate test is
+   in place and idempotence proptest is enforced as a release gate.


### PR DESCRIPTION
## Summary

Doc-only PR covering two ADR-status corrections and four new ADR drafts.

### Part 1 — Status corrections (zombie statuses)

Audit found two ADRs marked `done` whose implementations are deferred. Both
flip back to `accepted` with inline status notes; designs remain final and
binding, only the implementation flag has been corrected.

- **ADR-0013** (storage refactor on atomic files + JSONL) — redb persistence
  remains active in v0.36.x (`GrobStore` in `src/storage/mod.rs` still in
  use; no `~/.grob/spend/*.jsonl` files written). A-7 deferred to v0.37+.
- **ADR-0015** (indirect prompt injection coverage) — A-6 implementation
  deferred; framework design final but no production code merges yet.

### Part 2 — Four new ADRs (status: proposed)

- **ADR-0023 — Preset Naming and Composition Strategy.** Formalises the
  shipped catalogue: `[meta] tier` taxonomy (`base`,
  `audience-specific`, `experimental`), kebab-case naming convention,
  presets do not nest, and `grob preset info` validation gate before
  shipping built-in. Compliance overlays declared as separate
  `[meta] kind = "overlay"` concept.
- **ADR-0024 — Preset-as-Compliance-Template.** Compliance presets are
  packaged decisions bundling routing topology, policies, ADR-0022
  `[endpoints.compliance]` metadata, and `[meta] compliance_reviewed`
  attestation. Customer overlays may tighten but never loosen the base
  posture. Update lifecycle covers routine review, certification
  renewal, and major posture change.
- **ADR-0025 — RPC Mutation Transactionality and In-Flight Visibility.**
  Resolves the open question on issue #228. In-flight requests see
  pre-mutation snapshots (reusing ADR-0001's `snapshot()`); persistence
  is atomic with the in-memory swap (rollback on disk-write failure);
  per-namespace mutex permits parallel writes across namespaces; every
  mutation emits an `AuditEvent::RpcMutation { namespace, action,
  before_hash, after_hash }` to the Sokolsky pipeline.
- **ADR-0026 — Model Name Canonicalization Policy.** Records the fixed
  rule set landed in PR #307 (lowercase, strip `-latest`, strip 8-digit
  date suffix, dot-to-dash version on a known-prefix gate, Anthropic
  family-version reorder), idempotence guarantee, operator escape
  hatches (per-endpoint `actual_model` mapping or table patch), and
  2-minor-release deprecation window for renamed model aliases.

CHANGELOG `[Unreleased]` records the additions under a `Documentation`
heading. No code changes.

## Test plan

- [ ] `markdownlint` passes on all six modified/added files
- [ ] `lychee` resolves all internal cross-references (`[ADR-NNNN](NNNN-*.md)`)
- [ ] `no-hardcoded-version` CI guard passes (no `vX.Y.Z` literals in
      new ADRs; existing `v0.34.0` reference in ADR-0015 already
      whitelisted by the guard)
- [ ] All ADRs follow MADR 4.0 frontmatter + Context + Decision Drivers
      + Considered Options + Decision Outcome + Consequences structure
      matching ADR-0018's style