### PR TITLE
feat(pricing): local token estimate fallback for estimate mode

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -66,7 +66,7 @@ token_counting = "api"         # "api" (default) or "estimate"
 **Token counting.**
 
 - `api` (default) — trust the provider-reported usage and record spend synchronously, so the next budget check sees it immediately.
-- `estimate` — move the spend mutex and journal write off the response hot path into a detached task, so request latency is never gated on disk I/O. Provider-reported usage stays the source of truth; counters consolidate a fraction of a second later, so a concurrent budget check may lag by at most one in-flight request.
+- `estimate` — move the spend mutex and journal write off the response hot path into a detached task, so request latency is never gated on disk I/O. Provider-reported usage stays the source of truth; counters consolidate a fraction of a second later, so a concurrent budget check may lag by at most one in-flight request. When a provider omits usage entirely, input and output tokens are estimated locally (~4 chars/token) so genuinely-consumed tokens aren't billed as `$0` (non-streaming responses).
 
 ## Providers
 

--- a/src/server/budget.rs
+++ b/src/server/budget.rs
@@ -1,6 +1,8 @@
 use crate::features::token_pricing::TokenCounter;
-use crate::models::RouteType;
-use crate::providers::AuthType;
+use crate::models::{
+    CanonicalRequest, ContentBlock, KnownContentBlock, MessageContent, RouteType, SystemPrompt,
+};
+use crate::providers::{AuthType, ProviderResponse};
 use std::sync::Arc;
 use tracing::warn;
 
@@ -198,6 +200,89 @@ async fn commit_spend(
     }
 }
 
+/// Returns `true` when token counting runs in off-hot-path estimate mode.
+pub(crate) fn is_estimate_mode(state: &Arc<AppState>) -> bool {
+    matches!(
+        state.snapshot().config.pricing.token_counting,
+        crate::cli::TokenCountingMode::Estimate
+    )
+}
+
+/// Resolves the token counts to bill, falling back to a local estimate.
+///
+/// Provider-reported usage is authoritative. Only when a provider omits usage
+/// entirely (both counts zero) **and** token counting is in
+/// [`Estimate`](crate::cli::TokenCountingMode::Estimate) mode does this estimate
+/// from the request and response text, so genuinely-consumed tokens are not
+/// silently billed as `$0`. In `api` mode (or with reported usage) the provider
+/// numbers are returned unchanged.
+pub(crate) fn effective_token_counts(
+    state: &Arc<AppState>,
+    request: &CanonicalRequest,
+    response: &ProviderResponse,
+) -> (u32, u32) {
+    let usage = &response.usage;
+    let usage_absent = usage.input_tokens == 0 && usage.output_tokens == 0;
+    if usage_absent && is_estimate_mode(state) {
+        let input = estimate_input_tokens(request);
+        let output = estimate_output_tokens(response);
+        tracing::debug!(
+            estimated_input_tokens = input,
+            estimated_output_tokens = output,
+            "provider omitted usage; billing from local token estimate"
+        );
+        (input, output)
+    } else {
+        (usage.input_tokens, usage.output_tokens)
+    }
+}
+
+/// Converts a character count to an approximate token count (~4 chars/token).
+///
+/// A deliberately cheap, tokenizer-free heuristic that only feeds the
+/// estimate-mode fallback; saturates rather than overflowing on huge inputs.
+fn tokens_from_chars(chars: usize) -> u32 {
+    u32::try_from(chars.div_ceil(4)).unwrap_or(u32::MAX)
+}
+
+/// Estimates input tokens from a request's system prompt and message text.
+///
+/// Non-text blocks (images, tool I/O) are ignored — this is a coarse fallback.
+pub(crate) fn estimate_input_tokens(req: &CanonicalRequest) -> u32 {
+    let mut chars = 0usize;
+    if let Some(system) = &req.system {
+        match system {
+            SystemPrompt::Text(t) => chars += t.chars().count(),
+            SystemPrompt::Blocks(blocks) => {
+                chars += blocks.iter().map(|b| b.text.chars().count()).sum::<usize>();
+            }
+        }
+    }
+    for msg in &req.messages {
+        match &msg.content {
+            MessageContent::Text(t) => chars += t.chars().count(),
+            MessageContent::Blocks(blocks) => chars += content_blocks_chars(blocks),
+        }
+    }
+    tokens_from_chars(chars)
+}
+
+/// Estimates output tokens from a response's text content blocks.
+pub(crate) fn estimate_output_tokens(resp: &ProviderResponse) -> u32 {
+    tokens_from_chars(content_blocks_chars(&resp.content))
+}
+
+/// Sums the character count of text content blocks, ignoring non-text blocks.
+fn content_blocks_chars(blocks: &[ContentBlock]) -> usize {
+    blocks
+        .iter()
+        .map(|b| match b {
+            ContentBlock::Known(KnownContentBlock::Text { text, .. }) => text.chars().count(),
+            _ => 0,
+        })
+        .sum()
+}
+
 /// Check if a provider uses OAuth (subscription = $0 cost)
 pub(crate) fn is_provider_subscription(inner: &Arc<ReloadableState>, provider_name: &str) -> bool {
     inner
@@ -392,5 +477,56 @@ mod tests {
             output_tokens: 25,
             cost_usd: 0.001,
         });
+    }
+
+    fn request_with_text(system: Option<&str>, user: &str) -> CanonicalRequest {
+        let mut body = serde_json::json!({
+            "model": "m",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": user}],
+        });
+        if let Some(s) = system {
+            body["system"] = serde_json::json!(s);
+        }
+        serde_json::from_value(body).expect("valid request")
+    }
+
+    fn response_with_text(text: &str) -> ProviderResponse {
+        serde_json::from_value(serde_json::json!({
+            "id": "r",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+            "model": "m",
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        }))
+        .expect("valid response")
+    }
+
+    #[test]
+    fn tokens_from_chars_rounds_up() {
+        assert_eq!(tokens_from_chars(0), 0);
+        assert_eq!(tokens_from_chars(1), 1);
+        assert_eq!(tokens_from_chars(4), 1);
+        assert_eq!(tokens_from_chars(5), 2);
+    }
+
+    #[test]
+    fn estimate_input_counts_system_and_messages() {
+        // "you are concise" (15) + "hello there friend" (18) = 33 chars.
+        let req = request_with_text(Some("you are concise"), "hello there friend");
+        assert_eq!(estimate_input_tokens(&req), tokens_from_chars(15 + 18));
+    }
+
+    #[test]
+    fn estimate_input_ignores_absent_system() {
+        let req = request_with_text(None, "abcd"); // 4 chars → 1 token
+        assert_eq!(estimate_input_tokens(&req), 1);
+    }
+
+    #[test]
+    fn estimate_output_counts_text_blocks() {
+        // "abcd efgh" = 9 chars → ceil(9/4) = 3 tokens.
+        assert_eq!(estimate_output_tokens(&response_with_text("abcd efgh")), 3);
     }
 }

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -22,9 +22,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    calculate_cost, is_provider_subscription, log_audit, record_request_metrics, record_spend,
-    resolve_provider_mappings, sanitize_provider_response_reported, AppState, AuditCompliance,
-    AuditParams, ReloadableState, RequestError, RequestMetrics,
+    calculate_cost, effective_token_counts, is_provider_subscription, log_audit,
+    record_request_metrics, record_spend, resolve_provider_mappings,
+    sanitize_provider_response_reported, AppState, AuditCompliance, AuditParams, ReloadableState,
+    RequestError, RequestMetrics,
 };
 use crate::features::watch::events::{DlpDirection, WatchEvent};
 
@@ -507,7 +508,7 @@ async fn dispatch_fan_out(
     .await
     {
         Ok((response, provider_info)) => {
-            handle_fan_out_success(ctx, response, &provider_info, decision).await
+            handle_fan_out_success(ctx, &fan_request, response, &provider_info, decision).await
         }
         Err(e) => Err(RequestError::ProviderUpstream {
             provider: "fan_out".to_string(),
@@ -520,6 +521,7 @@ async fn dispatch_fan_out(
 /// Process a successful fan-out response: DLP output scan, cost tracking, metrics, audit.
 async fn handle_fan_out_success(
     ctx: &DispatchContext<'_>,
+    request: &CanonicalRequest,
     mut response: ProviderResponse,
     provider_info: &[(String, String)],
     decision: &crate::models::RouteDecision,
@@ -527,7 +529,7 @@ async fn handle_fan_out_success(
     ctx.sanitize_output(&mut response);
 
     let latency_ms = ctx.start_time.elapsed().as_millis() as u64;
-    record_fan_out_costs(ctx, &response, provider_info).await;
+    record_fan_out_costs(ctx, request, &response, provider_info).await;
 
     record_request_metrics(&RequestMetrics {
         model: &ctx.model,
@@ -566,16 +568,20 @@ async fn handle_fan_out_success(
 /// Track cost for each provider in a fan-out response.
 async fn record_fan_out_costs(
     ctx: &DispatchContext<'_>,
+    request: &CanonicalRequest,
     response: &ProviderResponse,
     provider_info: &[(String, String)],
 ) {
+    // Bill provider-reported usage, or a local estimate when usage is absent in
+    // estimate mode (computed once for the shared fan-out response).
+    let (input_tokens, output_tokens) = effective_token_counts(ctx.state, request, response);
     for (provider_name, actual_model) in provider_info {
         let is_subscription = is_provider_subscription(ctx.inner, provider_name);
         let counter = calculate_cost(
             ctx.state,
             actual_model,
-            response.usage.input_tokens,
-            response.usage.output_tokens,
+            input_tokens,
+            output_tokens,
             is_subscription,
         )
         .await;

--- a/src/server/dispatch/retry.rs
+++ b/src/server/dispatch/retry.rs
@@ -208,6 +208,15 @@ pub(super) async fn dispatch_non_streaming(
     provider: &dyn crate::providers::LlmProvider,
     attempt: &ProviderAttempt<'_>,
 ) -> Result<DispatchResult, ProviderLoopAction> {
+    // Capture an input-token estimate before the request is consumed below. It
+    // is only ever read when the provider omits usage in estimate mode; skip
+    // the work entirely otherwise.
+    let estimated_input_tokens = if crate::server::is_estimate_mode(ctx.state) {
+        crate::server::estimate_input_tokens(&provider_request)
+    } else {
+        0
+    };
+
     // Wrap in Option so we can move (not clone) on the final attempt.
     let mut owned_request = Some(provider_request);
     for retry in 0..=MAX_RETRIES {
@@ -250,6 +259,7 @@ pub(super) async fn dispatch_non_streaming(
                     decision: attempt.decision,
                     response: &response,
                     latency_ms,
+                    estimated_input_tokens,
                 };
                 let cost_usd =
                     calculate_and_record_metrics(ctx, &outcome, attempt.is_subscription).await;

--- a/src/server/dispatch/telemetry.rs
+++ b/src/server/dispatch/telemetry.rs
@@ -2,7 +2,10 @@ use crate::providers::ProviderResponse;
 use tracing::info;
 
 use super::DispatchContext;
-use crate::server::{calculate_cost, record_request_metrics, record_spend, RequestMetrics};
+use crate::server::{
+    calculate_cost, estimate_output_tokens, is_estimate_mode, record_request_metrics, record_spend,
+    RequestMetrics,
+};
 
 /// Outcome of a successful provider dispatch, used for metrics and telemetry.
 pub(crate) struct DispatchOutcome<'a> {
@@ -10,6 +13,9 @@ pub(crate) struct DispatchOutcome<'a> {
     pub decision: &'a crate::models::RouteDecision,
     pub response: &'a ProviderResponse,
     pub latency_ms: u64,
+    /// Local input-token estimate, used only as an estimate-mode fallback when
+    /// the provider omits usage. Zero in `api` mode (never consulted there).
+    pub estimated_input_tokens: u32,
 }
 
 /// Calculate cost and emit performance metrics + Prometheus counters.
@@ -22,12 +28,31 @@ pub(crate) async fn calculate_and_record_metrics(
     let response = outcome.response;
     let decision = outcome.decision;
     let latency_ms = outcome.latency_ms;
-    let tok_s = (response.usage.output_tokens as f32 * 1000.0) / latency_ms as f32;
+
+    // Bill provider-reported usage when present; only fall back to the local
+    // estimate when a provider omits usage and we're in estimate mode.
+    let (input_tokens, output_tokens) = {
+        let usage = &response.usage;
+        let usage_absent = usage.input_tokens == 0 && usage.output_tokens == 0;
+        if usage_absent && is_estimate_mode(ctx.state) {
+            let estimated_output = estimate_output_tokens(response);
+            tracing::debug!(
+                estimated_input_tokens = outcome.estimated_input_tokens,
+                estimated_output_tokens = estimated_output,
+                "provider omitted usage; billing from local token estimate"
+            );
+            (outcome.estimated_input_tokens, estimated_output)
+        } else {
+            (usage.input_tokens, usage.output_tokens)
+        }
+    };
+
+    let tok_s = (output_tokens as f32 * 1000.0) / latency_ms as f32;
     let cost = calculate_cost(
         ctx.state,
         &mapping.actual_model,
-        response.usage.input_tokens,
-        response.usage.output_tokens,
+        input_tokens,
+        output_tokens,
         is_subscription,
     )
     .await;
@@ -37,7 +62,7 @@ pub(crate) async fn calculate_and_record_metrics(
         mapping.provider,
         latency_ms,
         tok_s,
-        response.usage.output_tokens,
+        output_tokens,
         cost.estimated_cost_usd,
         if is_subscription {
             " (subscription)"
@@ -52,8 +77,8 @@ pub(crate) async fn calculate_and_record_metrics(
         route_type: &decision.route_type,
         status: "ok",
         latency_ms,
-        input_tokens: response.usage.input_tokens,
-        output_tokens: response.usage.output_tokens,
+        input_tokens,
+        output_tokens,
         cost_usd: cost.estimated_cost_usd,
     });
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -34,7 +34,8 @@ mod watch_sse;
 pub use audit::AuditEntryBuilder;
 pub(crate) use audit::{log_audit, AuditCompliance, AuditParams};
 pub(crate) use budget::{
-    calculate_cost, check_budget_for_tenant, is_auth_revoked_error, is_provider_subscription,
+    calculate_cost, check_budget_for_tenant, effective_token_counts, estimate_input_tokens,
+    estimate_output_tokens, is_auth_revoked_error, is_estimate_mode, is_provider_subscription,
     is_retryable, record_request_metrics, record_spend, retry_delay, RequestMetrics, MAX_RETRIES,
 };
 pub use error::{ErrorVariantTag, RequestError};


### PR DESCRIPTION
Follow-up to #339. The `estimate` token-counting mode (added in #339) promised a local heuristic estimate when a provider omits usage — both in the chosen design and in the `TokenCountingMode::Estimate` doc-comment — but `record_spend` returns early on `cost <= 0.0`, so a usage-less response was silently billed as **$0**. This makes the promise hold.

## Changes
- `effective_token_counts` resolves the tokens to bill: **provider-reported usage when present** (authoritative). Only in `estimate` mode **and** only when usage is entirely absent does it fall back to a local **~4 chars/token** estimate over the request (system + messages) and response text.
- **Non-streaming path**: the input estimate is captured up-front in `dispatch_non_streaming` (before the request is consumed) and carried on `DispatchOutcome`; output is estimated from the response in `calculate_and_record_metrics`. `api` mode is completely untouched.
- **Fan-out path**: `record_fan_out_costs` now receives the request and uses the same combined helper.
- Estimators live in `budget.rs`; non-text blocks (images, tool I/O) are ignored.

## Scope
Streaming keeps its own usage accounting (estimating streamed output would require buffering chunks) — noted in the docs as non-streaming-only.

## Tests
- New unit tests: char→token rounding, request input extraction (system + messages), response output extraction.
- `cargo test` green (1133 lib + 266 integration); clippy `-D warnings` on both CI feature sets; fmt clean; 0 missing-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)