### PR TITLE
fix(auth): don't block the listener bind on the initial JWKS fetch

### DIFF
--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -200,6 +200,16 @@ pub(crate) fn init_policies(
 }
 
 /// Initializes JWT validation and spawns the JWKS refresh loop.
+///
+/// The initial JWKS fetch runs inside the spawned background task (first
+/// iteration, before any sleep) rather than being awaited here, so a slow or
+/// unreachable JWKS endpoint can never stall the listener bind. The function
+/// returns as soon as the validator is built.
+///
+/// As a consequence, JWT requests that rely on JWKS keys are rejected with an
+/// auth error (mapped to HTTP 401) until the first refresh completes — see
+/// [`crate::auth::JwtValidator::validate`], which returns `InvalidToken` when no
+/// loaded key can verify the token rather than panicking.
 pub(crate) async fn init_auth(
     config: &AppConfig,
 ) -> anyhow::Result<Option<Arc<crate::auth::JwtValidator>>> {
@@ -214,11 +224,13 @@ pub(crate) async fn init_auth(
 
     if validator.jwks_url().is_some() {
         let jwt_validator = validator.clone();
-        if let Err(e) = jwt_validator.refresh_jwks().await {
-            warn!("Initial JWKS fetch failed (will retry): {}", e);
-        }
         let base_interval = config.auth.jwt.jwks_refresh_interval;
         tokio::spawn(async move {
+            // Immediate first refresh, backgrounded so it can never block the
+            // bind. JWT requests are rejected until this succeeds.
+            if let Err(e) = jwt_validator.refresh_jwks().await {
+                warn!("Initial JWKS fetch failed (will retry): {}", e);
+            }
             let mut current_interval = base_interval;
             let max_interval = base_interval * 8;
             loop {


### PR DESCRIPTION
## Problem

When `auth.mode = "jwt"` with a `jwks_url` configured, `init_auth` (`src/server/init.rs`) **awaited** the first `refresh_jwks()` before returning. Since `start_server` awaits `init_auth` *before* `lifecycle::bind_and_serve`, a slow or unreachable JWKS endpoint stalled the listener bind.

This violates the project design principle: nothing may block the listener bind; startup network must run in the background (same failure class already handled for pricing and preset sync).

This path is opt-in (default `auth.mode = "none"`), so default startup was never affected — but JWT-auth deployments were exposed.

## Change

Move the initial JWKS fetch **inside** the spawned background task:

- The spawned task does an immediate first `refresh_jwks()` (warn on failure) **before** any sleep.
- It then enters the existing sleep + exponential-backoff refresh loop, unchanged.
- `init_auth` now returns as soon as the validator is built.

Warn-on-failure logging, the exponential backoff, and the `jwks_refresh_interval` / max-interval (× 8) behavior are all preserved. Smallest correct change: 15 insertions, 3 deletions, one file.

## Trade-off (verified)

JWT requests that rely on JWKS keys are rejected with an auth error (mapped to HTTP 401) until the first refresh completes. This is the expected and acceptable degraded window.

`JwtValidator::validate` -> `validate_signature` (`src/auth/jwt.rs`) iterates over the initially-empty RSA/EC `Vec`s (zero iterations) and returns `AuthError::InvalidToken("No valid key found for token")`. It **never panics or deadlocks** — every `RwLock` read recovers from poisoning via `unwrap_or_else(|e| e.into_inner())`. So the not-yet-loaded window fails gracefully.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --all-targets --no-default-features --features dlp,oauth,tap,compliance,mcp,watch,policies,socket-opts,dirs -- -D warnings` — clean
- `cargo test --lib` — 1133 passed
- `cargo test --test lib` — 266 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
