### PR TITLE
docs: fix Docs Lint (markdownlint MD004 + broken DCI link)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,4 +38,4 @@ Grob exposes Prometheus metrics at `/metrics`. A Grafana dashboard is provided i
 
 ## Documentation Completeness
 
-See [DCI-REPORT.md](reference/dci-report.md) for the Documentation Completeness Index with scores, gaps, and improvement recommendations.
+See the Documentation Completeness Index reports for scores, gaps, and improvement recommendations: [DLP DCI report](reference/dci-report-dlp.md) and [Responses-compat DCI report](reference/dci-report-responses-compat.md).

--- a/docs/decisions/0024-preset-as-compliance-template.md
+++ b/docs/decisions/0024-preset-as-compliance-template.md
@@ -197,8 +197,8 @@ emits a structured event to the Sokolsky log backend (ADR-0017):
 }
 ```
 
-The digest gives a stable identifier for the **applied** posture (base
-+ overlay) without leaking the full TOML to the audit log. Auditors
+The digest gives a stable identifier for the **applied** posture (base +
+overlay) without leaking the full TOML to the audit log. Auditors
 querying Sokolsky can correlate the digest with a preset version known
 at the time of application.
 


### PR DESCRIPTION
Fixes the two pre-existing `Docs Lint` failures that were red on `main` (unrelated to feature work, but they keep the pipeline red).

- **markdownlint MD004** — `docs/decisions/0024-preset-as-compliance-template.md:201` had wrapped prose placing a `+` joining operator at column 1, which MD004 misreads as a plus-style bullet. Reflowed so `+` ends the previous line; the rendered text is unchanged.
- **Broken internal link** — `docs/README.md` linked to `reference/dci-report.md`, which no longer exists (the DCI report was split). Now links to the two existing reports: `dci-report-dlp.md` and `dci-report-responses-compat.md`. This is the high-confidence cause of the lychee failure (lychee resolves relative links to local files).

A repo-wide scan found no other genuine list-marker violations (other `+ ` hits are arithmetic inside fenced code blocks, which markdownlint skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)