### PR TITLE
fix(budget): enforce budget caps on the fan-out path

### DIFF
--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -22,8 +22,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    calculate_cost, effective_token_counts, is_provider_subscription, log_audit,
-    record_request_metrics, record_spend, resolve_provider_mappings,
+    calculate_cost, check_budget_for_tenant, effective_token_counts, is_provider_subscription,
+    log_audit, record_request_metrics, record_spend, resolve_provider_mappings,
     sanitize_provider_response_reported, AppState, AuditCompliance, AuditParams, ReloadableState,
     RequestError, RequestMetrics,
 };
@@ -496,6 +496,23 @@ async fn dispatch_fan_out(
     fan_out_config: &crate::cli::FanOutConfig,
     decision: &crate::models::RouteDecision,
 ) -> Result<DispatchResult, RequestError> {
+    // Budget enforcement: fan-out returns from `dispatch()` *before* the
+    // provider loop, which is where the per-attempt budget gate lives. Without
+    // this check, fan-out — the most expensive dispatch (N providers in
+    // parallel) — would bypass budget caps entirely. Each participating mapping
+    // is checked; if any provider/model/global cap is already reached the whole
+    // fan-out is rejected before any upstream call is made.
+    for mapping in sorted_mappings {
+        check_budget_for_tenant(
+            ctx.state,
+            ctx.inner,
+            &mapping.provider,
+            &decision.model_name,
+            ctx.tenant_id.as_deref(),
+        )
+        .await?;
+    }
+
     let mut fan_request = request.clone();
     ctx.sanitize_input(&mut fan_request);
 


### PR DESCRIPTION
## Audit finding (same class as the streaming-spend gap)

While auditing for other "accounting/enforcement done on one path but not all", I found that **fan-out bypasses budget enforcement entirely**.

`dispatch_fan_out` is `return`ed from `dispatch()` (tier `fanout=true` or model `strategy=FanOut`) **before** `provider_loop::dispatch_provider_loop` — which is the *only* place `check_budget_for_tenant` runs. `fan_out.rs` has no budget check either. So fan-out — the **most expensive** dispatch (N providers in parallel) — could run unbounded: a tenant already over its monthly / per-provider / per-model cap kept firing fan-out requests.

(Accounting for fan-out was already correct — `record_fan_out_costs` records via `record_spend`. This is the missing *enforcement* half.)

## Fix
Add the budget gate at the top of `dispatch_fan_out`, before any upstream call: check every participating mapping; if any global/provider/model cap is reached, reject the whole fan-out with the standard `budget_exceeded` error — mirroring the single-provider path.

## Tests
`cargo fmt`, both clippy configs (`-D warnings`), `cargo test --lib` (1133) and `--test lib` (266) all green.

## Related gaps (noted, not in this PR)
- Streaming spend accounting — fixed separately in #345.
- Streaming responses get a coarse audit entry from the outer middleware (no token counts) rather than the detailed `Response` entry the non-streaming path writes — minor compliance nicety, follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)