### PR TITLE
style: satisfy clippy::for_kv_map (fix red nightly toolchain canary)

### DIFF
--- a/src/features/dlp/names.rs
+++ b/src/features/dlp/names.rs
@@ -248,7 +248,7 @@ impl NameAnonymizer {
         // Phase 2: Dynamic cache reverse lookup
         if self.mode == NamesMode::AutoDetect {
             let cache = self.dynamic_cache.lock().unwrap_or_else(|e| e.into_inner());
-            for (_, (real_name, pseudo)) in cache.iter() {
+            for (real_name, pseudo) in cache.values() {
                 if current.contains(pseudo.as_str()) {
                     current = current.replace(pseudo.as_str(), real_name);
                     modified = true;
@@ -324,7 +324,7 @@ impl NameAnonymizer {
         let mut all_rules = self.rules.clone();
         let mut all_pseudonyms = self.pseudonyms.clone();
 
-        for (_, (real_name, pseudo)) in cache.iter() {
+        for (real_name, pseudo) in cache.values() {
             all_rules.push(NameRule {
                 term: real_name.clone(),
                 action: NameAction::Pseudonym,

--- a/src/providers/gemini/transform.rs
+++ b/src/providers/gemini/transform.rs
@@ -18,7 +18,7 @@ pub(super) fn clean_json_schema(value: &mut serde_json::Value) {
             map.remove("$defs");
 
             // Recursively clean nested objects
-            for (_, v) in map.iter_mut() {
+            for v in map.values_mut() {
                 clean_json_schema(v);
             }
         }

--- a/src/server/config_api.rs
+++ b/src/server/config_api.rs
@@ -28,7 +28,7 @@ fn remove_null_values(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
             map.retain(|_, v| !v.is_null());
-            for (_, v) in map.iter_mut() {
+            for v in map.values_mut() {
                 remove_null_values(v);
             }
         }


### PR DESCRIPTION
## Why

The scheduled **Nightly Toolchain Check** (beta/nightly Rust) went red while the stable gating CI stayed green. Proof it's a toolchain change, not our code: the **same commit `5c6cac9` passed on 2026-05-26 and failed on 2026-05-27** with no code change. A newer clippy now enforces `clippy::for_kv_map` (run with `--all-features -- -D warnings`) on four map iterations that ignore the key.

## Fix
- `src/providers/gemini/transform.rs` — `for (_, v) in map.iter_mut()` → `for v in map.values_mut()`
- `src/features/dlp/names.rs` (×2) — `for (_, (a, b)) in cache.iter()` → `for (a, b) in cache.values()`
- `src/server/config_api.rs` — `for (_, v) in map.iter_mut()` → `for v in map.values_mut()`

Behaviour is identical — idiomatic cleanup that keeps the bleeding-edge canary green.

## Tests
`cargo fmt`, `cargo clippy --all-targets --all-features` and the gating no-default-features set (`-D warnings`), `cargo test --lib` (1147) + `--test lib` (266) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)