### PR TITLE
feat(oauth): retry adjacent ports when OAuth callback port is busy (revives #306)

### DIFF
--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -119,6 +119,38 @@ impl OAuthConfig {
             OAuthProviderType::Anthropic
         }
     }
+
+    /// Rewrites the port of a loopback `redirect_uri`, leaving other URIs untouched.
+    ///
+    /// Only `localhost`, `127.0.0.1`, and `[::1]` redirects are rewritten. This keeps
+    /// the callback `redirect_uri` aligned with the port the local callback server
+    /// actually bound when the configured port was busy.
+    ///
+    /// Apply this **only** to providers that accept any loopback port per RFC 8252
+    /// (OAuth 2.0 for Native Apps) — e.g. Gemini. Providers with a server-pinned
+    /// redirect (OpenAI Codex registers `localhost:1455` and rejects any mismatch)
+    /// must keep their original URI, so this is intentionally not applied to them.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let cfg = OAuthConfig::gemini().with_callback_port(13_460);
+    /// assert!(cfg.redirect_uri.contains(":13460/"));
+    /// ```
+    #[must_use]
+    pub fn with_callback_port(mut self, port: u16) -> Self {
+        if !is_localhost_url(&self.redirect_uri) {
+            return self;
+        }
+        // NOTE: set_port fails only on cannot-be-a-base URLs; loopback http(s)
+        // URIs are always base URLs, so a parse failure leaves the URI unchanged.
+        if let Ok(mut url) = url::Url::parse(&self.redirect_uri) {
+            if url.set_port(Some(port)).is_ok() {
+                self.redirect_uri = url.to_string();
+            }
+        }
+        self
+    }
 }
 
 impl OAuthConfig {
@@ -618,5 +650,28 @@ mod tests {
         assert!(auth_url.url.contains("code_challenge="));
         assert!(auth_url.url.contains("code_challenge_method=S256"));
         assert!(auth_url.url.contains("scope="));
+    }
+
+    #[test]
+    fn test_with_callback_port_rewrites_gemini_loopback() {
+        let cfg = OAuthConfig::gemini().with_callback_port(13_460);
+        assert_eq!(
+            cfg.redirect_uri,
+            "http://localhost:13460/api/oauth/callback"
+        );
+    }
+
+    #[test]
+    fn test_with_callback_port_preserves_path_and_scheme() {
+        let cfg = OAuthConfig::openai_codex().with_callback_port(1456);
+        // Loopback rewrite only touches the port; scheme and path are preserved.
+        assert_eq!(cfg.redirect_uri, "http://localhost:1456/auth/callback");
+    }
+
+    #[test]
+    fn test_with_callback_port_leaves_remote_redirect_alone() {
+        let original = OAuthConfig::anthropic().redirect_uri;
+        let cfg = OAuthConfig::anthropic().with_callback_port(9999);
+        assert_eq!(cfg.redirect_uri, original);
     }
 }

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -8,8 +8,13 @@ use super::{oauth_handlers, AppState};
 use crate::models::config::AppConfig;
 use axum::{routing::get, Router as AxumRouter};
 use std::sync::Arc;
-use tokio::net::TcpListener;
 use tracing::{error, info, warn};
+
+/// Number of adjacent ports the OAuth callback server tries before giving up.
+///
+/// The configured `server.oauth_callback_port` is attempt one; each later attempt
+/// increments the port by one.
+const OAUTH_CALLBACK_BIND_ATTEMPTS: u16 = crate::shared::net::DEFAULT_PORT_RETRY_ATTEMPTS;
 
 /// Binds the server socket and serves with optional TLS and graceful shutdown.
 pub(super) async fn bind_and_serve(
@@ -114,30 +119,56 @@ pub(super) async fn drain_in_flight(state: &Arc<AppState>) {
     }
 }
 
-/// Spawn the OAuth callback server (required for OpenAI Codex OAuth)
+/// Spawns the OAuth callback server (required for OpenAI Codex OAuth).
+///
+/// Tries the configured `server.oauth_callback_port` first, then up to
+/// [`OAUTH_CALLBACK_BIND_ATTEMPTS`] adjacent ports if it is busy. The port that
+/// actually bound is recorded in [`AppState::actual_oauth_callback_port`] so OAuth
+/// handlers can build loopback `redirect_uri` values that match the live listener.
+///
+/// Binds to `127.0.0.1` because OAuth providers (OpenAI Codex, Gemini) redirect to a
+/// literal loopback callback URL. Note that OpenAI Codex pins its redirect to the
+/// registered port (1455) and rejects any other; a fallback port keeps the callback
+/// server diagnosable but only providers that accept any loopback port (Gemini) will
+/// complete the flow on it. This is surfaced via a `warn!` when the port differs.
 pub(super) fn spawn_oauth_callback(oauth_state: Arc<AppState>) {
-    let port = oauth_state.snapshot().config.server.oauth_callback_port;
+    let configured_port = oauth_state.snapshot().config.server.oauth_callback_port;
     tokio::spawn(async move {
         let oauth_callback_app = AxumRouter::new()
             .route("/auth/callback", get(oauth_handlers::oauth_callback))
-            .with_state(oauth_state);
+            .with_state(oauth_state.clone());
 
-        let oauth_addr = format!("127.0.0.1:{}", port);
-        match TcpListener::bind(&oauth_addr).await {
-            Ok(oauth_listener) => {
-                info!("OAuth callback server listening on {}", oauth_addr);
+        match crate::shared::net::bind_with_port_retry(
+            "127.0.0.1",
+            configured_port,
+            OAUTH_CALLBACK_BIND_ATTEMPTS,
+        )
+        .await
+        {
+            Ok((oauth_listener, actual_port)) => {
+                oauth_state
+                    .actual_oauth_callback_port
+                    .store(actual_port, std::sync::atomic::Ordering::Relaxed);
+                if actual_port == configured_port {
+                    info!("OAuth callback server listening on 127.0.0.1:{actual_port}");
+                } else {
+                    warn!(
+                        "OAuth callback port {configured_port} busy; bound 127.0.0.1:{actual_port} instead. \
+                         Providers with a pinned redirect (e.g. OpenAI Codex on {configured_port}) will reject this port."
+                    );
+                }
                 if let Err(e) = axum::serve(oauth_listener, oauth_callback_app).await {
-                    error!("OAuth callback server error: {}", e);
+                    error!("OAuth callback server error: {e}");
                 }
             }
             Err(e) => {
+                let last_port =
+                    configured_port.saturating_add(OAUTH_CALLBACK_BIND_ATTEMPTS.saturating_sub(1));
                 error!(
-                    "Failed to bind OAuth callback server on {}: {}",
-                    oauth_addr, e
+                    "Failed to bind OAuth callback server on 127.0.0.1 in port range {configured_port}..={last_port}: {e:#}"
                 );
                 error!(
-                    "OpenAI Codex OAuth will not work. Port {} must be available.",
-                    port
+                    "OpenAI Codex / Gemini OAuth will not work. Free a port in {configured_port}..={last_port} or set server.oauth_callback_port."
                 );
             }
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -177,6 +177,14 @@ pub struct AppState {
     pub active_requests: std::sync::atomic::AtomicU64,
     /// Server start time (for health/upgrade coordination)
     pub started_at: chrono::DateTime<chrono::Utc>,
+    /// TCP port the OAuth callback server actually bound to.
+    ///
+    /// The configured `server.oauth_callback_port` is the preferred port; the
+    /// callback listener falls back to an adjacent port when it is busy. Handlers
+    /// building loopback `redirect_uri` values read this to stay aligned with the
+    /// live listener. A value of `0` means the callback server has not bound yet
+    /// (or failed to bind).
+    pub actual_oauth_callback_port: std::sync::atomic::AtomicU16,
 
     /// Metrics, tracing, spend tracking
     pub observability: ObservabilityState,
@@ -279,6 +287,7 @@ pub async fn start_server(
         config_source,
         active_requests: std::sync::atomic::AtomicU64::new(0),
         started_at: chrono::Utc::now(),
+        actual_oauth_callback_port: std::sync::atomic::AtomicU16::new(0),
         event_bus,
         log_exporter,
         #[cfg(feature = "mcp")]

--- a/src/server/oauth_handlers.rs
+++ b/src/server/oauth_handlers.rs
@@ -80,17 +80,39 @@ pub struct TokenInfo {
     pub needs_refresh: bool,
 }
 
+/// Returns the port the OAuth callback server actually bound to.
+///
+/// Falls back to the configured `server.oauth_callback_port` when the callback server
+/// has not yet recorded its port (e.g. before [`spawn_oauth_callback`] binds).
+///
+/// [`spawn_oauth_callback`]: super::lifecycle::spawn_oauth_callback
+fn live_oauth_callback_port(state: &AppState) -> u16 {
+    let actual = state
+        .actual_oauth_callback_port
+        .load(std::sync::atomic::Ordering::Relaxed);
+    if actual != 0 {
+        actual
+    } else {
+        state.snapshot().config.server.oauth_callback_port
+    }
+}
+
 /// Get authorization URL
 pub async fn oauth_authorize(
     State(state): State<Arc<AppState>>,
     Json(req): Json<OAuthAuthorizeRequest>,
 ) -> Result<Json<OAuthAuthorizeResponse>, (StatusCode, String)> {
+    // NOTE: Gemini follows RFC 8252 and accepts any loopback port, so its callback
+    // redirect is realigned with the port the local server actually bound. OpenAI
+    // Codex pins its redirect server-side (localhost:1455) and is left untouched.
+    let callback_port = live_oauth_callback_port(&state);
+
     // Create OAuth config based on type
     let config = match req.oauth_type.as_str() {
         "max" => OAuthConfig::anthropic(),
         "console" => OAuthConfig::anthropic_console(),
         "openai-codex" => OAuthConfig::openai_codex(),
-        "gemini" => OAuthConfig::gemini(),
+        "gemini" => OAuthConfig::gemini().with_callback_port(callback_port),
         _ => {
             return Err((
                 StatusCode::BAD_REQUEST,
@@ -134,11 +156,15 @@ pub async fn oauth_exchange(
         req.oauth_type
     );
 
+    // Gemini's loopback redirect is realigned with the live callback port (RFC 8252);
+    // OpenAI Codex keeps its server-pinned redirect. See `oauth_authorize`.
+    let callback_port = live_oauth_callback_port(&state);
+
     // Determine OAuth config based on oauth_type if provided, otherwise fall back to provider_id
     let config = if let Some(ref oauth_type) = req.oauth_type {
         match oauth_type.as_str() {
             "openai-codex" => OAuthConfig::openai_codex(),
-            "gemini" => OAuthConfig::gemini(),
+            "gemini" => OAuthConfig::gemini().with_callback_port(callback_port),
             "console" => OAuthConfig::anthropic_console(),
             "max" => OAuthConfig::anthropic(),
             _ => {
@@ -265,6 +291,8 @@ pub async fn oauth_refresh_token(
     State(state): State<Arc<AppState>>,
     Json(req): Json<DeleteTokenRequest>,
 ) -> Result<Json<OAuthExchangeResponse>, (StatusCode, String)> {
+    let callback_port = live_oauth_callback_port(&state);
+
     // Determine OAuth config based on provider_id
     let config = if req.provider_id.to_lowercase().contains("openai")
         || req.provider_id.to_lowercase().contains("codex")
@@ -274,7 +302,8 @@ pub async fn oauth_refresh_token(
     } else if req.provider_id.to_lowercase().contains("gemini")
         || req.provider_id.to_lowercase().contains("google")
     {
-        OAuthConfig::gemini()
+        // Gemini accepts any loopback port (RFC 8252); keep its redirect aligned.
+        OAuthConfig::gemini().with_callback_port(callback_port)
     } else {
         OAuthConfig::anthropic()
     };

--- a/src/shared/net.rs
+++ b/src/shared/net.rs
@@ -94,6 +94,54 @@ pub fn bind_reuseport_std(addr: &str) -> Result<std::net::TcpListener> {
     TcpListener::bind(addr).with_context(|| format!("Failed to bind to {}", addr))
 }
 
+/// Default span of ports [`bind_with_port_retry`] tries: the base plus 9 fallbacks.
+pub const DEFAULT_PORT_RETRY_ATTEMPTS: u16 = 10;
+
+/// Binds `host:base_port`, falling back to adjacent ports up to `attempts` total.
+///
+/// Tries `base_port`, then `base_port + 1`, up to `base_port + attempts - 1`, and
+/// returns the first listener that binds along with the port it claimed. A plain
+/// `tokio::net::TcpListener` is used deliberately: unlike [`bind_reuseport`], it does
+/// **not** set `SO_REUSEPORT`, so a busy port reliably fails and the next candidate is
+/// tried. This suits ephemeral local servers — such as the OAuth callback — where a
+/// stable port is preferred but any free adjacent port is acceptable.
+///
+/// # Errors
+///
+/// Returns an error if `attempts` is zero, if the port range would overflow `u16`, or
+/// if every port in `base_port..base_port + attempts` is already in use.
+pub async fn bind_with_port_retry(
+    host: &str,
+    base_port: u16,
+    attempts: u16,
+) -> Result<(tokio::net::TcpListener, u16)> {
+    if attempts == 0 {
+        anyhow::bail!("bind_with_port_retry: attempts must be greater than zero");
+    }
+
+    let mut last_err: Option<anyhow::Error> = None;
+    let mut last_port = base_port;
+    for offset in 0..attempts {
+        // NOTE: Stop before wrapping past u16::MAX (e.g. base_port near 65535).
+        let Some(port) = base_port.checked_add(offset) else {
+            break;
+        };
+        last_port = port;
+        let addr = crate::cli::format_bind_addr(host, port);
+        match tokio::net::TcpListener::bind(&addr).await {
+            Ok(listener) => return Ok((listener, port)),
+            Err(e) => last_err = Some(anyhow::Error::new(e).context(format!("bind {}", addr))),
+        }
+    }
+
+    let err = last_err
+        .unwrap_or_else(|| anyhow::anyhow!("bind_with_port_retry: no ports attempted on {}", host));
+    Err(err.context(format!(
+        "could not bind any port in range {}..={} on {}",
+        base_port, last_port, host
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,5 +182,67 @@ mod tests {
     #[test]
     fn test_invalid_addr() {
         assert!(bind_reuseport_std("not_an_addr").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_bind_with_port_retry_uses_base_port_when_free() {
+        // Grab an ephemeral port to use as the base, then release it so the
+        // retry helper can claim that exact port on its first attempt.
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let (_listener, port) = bind_with_port_retry("127.0.0.1", base_port, 5)
+            .await
+            .expect("base port should be free");
+        assert_eq!(port, base_port);
+    }
+
+    #[tokio::test]
+    async fn test_bind_with_port_retry_falls_back_to_next_port() {
+        // Hold the base port for the whole test so the helper must advance.
+        let blocker = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_port = blocker.local_addr().unwrap().port();
+
+        let (_listener, port) = bind_with_port_retry("127.0.0.1", base_port, 5)
+            .await
+            .expect("a fallback port should be free");
+        assert!(
+            port > base_port && port < base_port.saturating_add(5),
+            "expected fallback in {}..{}, got {port}",
+            base_port + 1,
+            base_port + 5
+        );
+        drop(blocker);
+    }
+
+    #[tokio::test]
+    async fn test_bind_with_port_retry_zero_attempts_errors() {
+        let err = bind_with_port_retry("127.0.0.1", 50_000, 0)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("attempts must be greater than zero"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bind_with_port_retry_reports_range_when_busy() {
+        // A single busy port with attempts=1 deterministically exhausts the
+        // range and yields the range-exhausted context message.
+        let blocker = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let busy_port = blocker.local_addr().unwrap().port();
+
+        let err = bind_with_port_retry("127.0.0.1", busy_port, 1)
+            .await
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("could not bind any port in range"),
+            "unexpected error: {msg}"
+        );
+        drop(blocker);
     }
 }


### PR DESCRIPTION
## Summary

Revives and corrects #306. When the configured `server.oauth_callback_port` (default 1455) is busy, the OAuth callback server now retries a bounded run of adjacent ports instead of failing outright with a bare "Port X must be available" error.

Supersedes #306.

## What changed

- `shared::net::bind_with_port_retry(host, base_port, attempts)` — tries `base_port`, `base_port+1`, … up to `attempts` total and returns the first listener plus the port it claimed. Uses a plain (non-`SO_REUSEPORT`) `TcpListener` so a busy port reliably fails and the next candidate is tried. Guards against zero attempts and `u16` overflow.
- `AppState::actual_oauth_callback_port` (`AtomicU16`) records the port that actually bound; `0` means not-yet-bound.
- `spawn_oauth_callback` uses the retry helper, stores the chosen port, logs at `info` when it equals the configured port and `warn` (with a clear note about pinned-redirect providers) when it differs.
- `OAuthConfig::with_callback_port(port)` rewrites the port of a loopback `redirect_uri` only (`localhost`/`127.0.0.1`/`[::1]`), leaving remote redirects untouched.
- OAuth handlers (`oauth_authorize`, `oauth_exchange`, `oauth_refresh_token`) realign the loopback redirect to the live port via a small `live_oauth_callback_port` helper.

## Kept / rewrote / dropped vs original #306

**Kept (sound):**
- The `bind_with_port_retry` helper concept and the `actual_oauth_callback_port` `AtomicU16` on `AppState`.
- The loopback-only `with_callback_port` rewrite and the `live_oauth_callback_port` fallback helper.

**Rewrote:**
- **Correctness fix (the important one):** the original applied `with_callback_port` to **OpenAI Codex** as well. OpenAI's Codex OAuth app pins `redirect_uri=http://localhost:1455/auth/callback` server-side and rejects any mismatch — RFC 8252 loopback any-port flexibility does *not* apply because the app registration is fixed. Rewriting Codex's redirect to a fallback port would silently produce a `redirect_uri_mismatch` and a broken-but-"successful-looking" flow. This revision applies the rewrite **only to Gemini** (Google installed-app, which honors RFC 8252 any-port loopback) and instead emits a `warn!` when Codex's port is unavailable.
- Tightened the helper: dropped the off-by-one `end_port` (now reports the real last attempted port in the range message), simplified error wording, and made `lifecycle.rs` use inline-formatted log strings consistent with surrounding code.
- Doc comments brought in line with repo conventions (RFC-505 third-person summaries, `# Errors`/`# Examples` sections, intra-doc links, WHY-focused inline `// NOTE:`s).

**Dropped:**
- The original `test_bind_with_port_retry_reports_range_when_all_busy` test, which allocated 3 ports, then admitted it couldn't guarantee contiguity and fell back to testing a single busy port anyway. Replaced with a deterministic single-busy-port + `attempts=1` test.

## Tests

7 new unit tests: 4 for `bind_with_port_retry` (base-port-free, fallback, zero-attempts error, range-exhausted error) and 3 for `with_callback_port` (Gemini rewrite, port-only rewrite preserves scheme/path, remote redirect untouched).

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --all-targets -D warnings` — clean
- `cargo clippy --no-default-features --features dlp,oauth,tap,compliance,mcp,watch,policies,socket-opts,dirs -D warnings` — clean
- `cargo test --lib` — 1154 passed; `cargo test --test lib` — 266 passed
- `RUSTDOCFLAGS='-W missing-docs' cargo doc --no-deps` — zero missing-docs warnings, no new warnings attributable to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)