### PR TITLE
fix(dispatch): per-provider retry + hot-reload race (revives #323)

### DIFF
--- a/src/cli/config/providers.rs
+++ b/src/cli/config/providers.rs
@@ -117,6 +117,17 @@ pub struct ProviderConfig {
     /// signals agree.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_check: Option<HealthCheckProviderConfig>,
+
+    /// Per-provider retry budget before falling back to the next mapping.
+    ///
+    /// Different providers benefit from different retry counts: Anthropic
+    /// (smaller scale, frequent 429) is well served by the tight global
+    /// default of 2, while OpenAI / OpenRouter / DeepSeek tolerate 3 thanks
+    /// to better queueing and only occasional 5xx. Absent → use the global
+    /// `MAX_RETRIES` default (2). An explicit `0` disables retries entirely
+    /// (single attempt before falling through to the next mapping).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_retries: Option<u32>,
 }
 
 impl ProviderConfig {

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -622,6 +622,7 @@ mod tests {
                 circuit_breaker: None,
 
                 health_check: None,
+                max_retries: None,
             },
             ProviderConfig {
                 name: "provider-b".to_string(),
@@ -645,6 +646,7 @@ mod tests {
                 circuit_breaker: None,
 
                 health_check: None,
+                max_retries: None,
             },
         ];
 
@@ -756,6 +758,7 @@ mod tests {
             pool: None,
             circuit_breaker: None,
             health_check: None,
+            max_retries: None,
         }];
 
         let registry = ProviderRegistry::from_configs_with_models(

--- a/src/server/budget.rs
+++ b/src/server/budget.rs
@@ -12,7 +12,36 @@ use super::{AppState, ReloadableState, RequestError};
 /// NOTE: 2 retries (3 total attempts) balances latency vs resilience — most
 /// transient 429/5xx errors resolve within 2 exponential-backoff cycles (~1-4s),
 /// while more retries would unacceptably delay user-facing LLM responses.
+///
+/// Acts as the **global default**. Individual providers can override the
+/// budget via `[[providers]] max_retries = N` — see [`provider_max_retries`]
+/// for the per-provider lookup helper.
 pub(crate) const MAX_RETRIES: u32 = 2;
+
+/// Resolves the retry budget for a named provider.
+///
+/// Returns the value of `[[providers]] max_retries = N` when set, or the
+/// global [`MAX_RETRIES`] default when the provider is absent or did not
+/// override the budget. Used by the dispatch retry loop so per-provider
+/// tuning applies without hard-coding provider names in the dispatch path.
+pub(crate) fn provider_max_retries(inner: &Arc<ReloadableState>, provider_name: &str) -> u32 {
+    resolve_max_retries(&inner.config.providers, provider_name)
+}
+
+/// Pure lookup helper backing [`provider_max_retries`].
+///
+/// Decoupled from [`ReloadableState`] so unit tests can pass a literal
+/// `[ProviderConfig]` slice without standing up the full app state graph.
+pub(crate) fn resolve_max_retries(
+    providers: &[crate::cli::ProviderConfig],
+    provider_name: &str,
+) -> u32 {
+    providers
+        .iter()
+        .find(|p| p.name == provider_name)
+        .and_then(|p| p.max_retries)
+        .unwrap_or(MAX_RETRIES)
+}
 
 /// Data needed to record Prometheus metrics for a completed request.
 pub(crate) struct RequestMetrics<'a> {
@@ -530,5 +559,76 @@ mod tests {
     fn estimate_output_counts_text_blocks() {
         // "abcd efgh" = 9 chars → ceil(9/4) = 3 tokens.
         assert_eq!(estimate_output_tokens(&response_with_text("abcd efgh")), 3);
+    }
+
+    // ── per-provider max_retries resolution ────────────────────────────────
+
+    /// Builds a stub provider config carrying only the fields the lookup reads.
+    fn provider_with_retries(name: &str, max_retries: Option<u32>) -> crate::cli::ProviderConfig {
+        crate::cli::ProviderConfig {
+            name: name.into(),
+            provider_type: "stub".into(),
+            auth_type: crate::cli::AuthType::ApiKey,
+            api_key: None,
+            oauth_provider: None,
+            project_id: None,
+            location: None,
+            base_url: None,
+            headers: None,
+            models: vec![],
+            enabled: Some(true),
+            budget_usd: None,
+            region: None,
+            pass_through: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            pool: None,
+            circuit_breaker: None,
+            health_check: None,
+            max_retries,
+        }
+    }
+
+    #[test]
+    fn resolve_max_retries_falls_back_to_default_for_unknown_provider() {
+        let providers = vec![provider_with_retries("anthropic", Some(5))];
+        assert_eq!(resolve_max_retries(&providers, "openai"), MAX_RETRIES);
+    }
+
+    #[test]
+    fn resolve_max_retries_falls_back_to_default_when_unset() {
+        let providers = vec![provider_with_retries("anthropic", None)];
+        assert_eq!(resolve_max_retries(&providers, "anthropic"), MAX_RETRIES);
+    }
+
+    #[test]
+    fn resolve_max_retries_honors_override() {
+        // OpenAI: better queueing — 3 retries amortise transient 429s.
+        let providers = vec![provider_with_retries("openai", Some(3))];
+        assert_eq!(resolve_max_retries(&providers, "openai"), 3);
+    }
+
+    #[test]
+    fn resolve_max_retries_honors_zero_override() {
+        // Explicit `max_retries = 0` disables retries (single attempt, no fallback retry).
+        let providers = vec![provider_with_retries("flaky", Some(0))];
+        assert_eq!(resolve_max_retries(&providers, "flaky"), 0);
+    }
+
+    #[test]
+    fn resolve_max_retries_isolates_per_provider_overrides() {
+        // Distinct budgets must not leak between providers.
+        let providers = vec![
+            provider_with_retries("anthropic", Some(2)),
+            provider_with_retries("openai", Some(3)),
+            provider_with_retries("default-provider", None),
+        ];
+        assert_eq!(resolve_max_retries(&providers, "anthropic"), 2);
+        assert_eq!(resolve_max_retries(&providers, "openai"), 3);
+        assert_eq!(
+            resolve_max_retries(&providers, "default-provider"),
+            MAX_RETRIES
+        );
     }
 }

--- a/src/server/config_api.rs
+++ b/src/server/config_api.rs
@@ -207,8 +207,16 @@ pub(crate) async fn update_config_json(
     })))
 }
 
-/// Reload configuration without restarting the server
+/// Reload configuration without restarting the server.
+///
+/// The handler **awaits** validation against the candidate provider registry
+/// before swapping the live config. If any router model has no healthy
+/// provider the reload is rejected with a 4xx and the in-flight `inner`
+/// snapshot is left untouched, so requests never observe a half-validated
+/// config and a misconfigured reload cannot briefly serve traffic.
 pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Response {
+    use axum::http::StatusCode;
+
     info!("🔄 Configuration reload requested via UI");
 
     // 1. Read and parse new config from source
@@ -216,7 +224,14 @@ pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Respons
         Ok(c) => c,
         Err(e) => {
             error!("Failed to reload config: {}", e);
-            return Json(serde_json::json!({"status": "error", "message": format!("Failed to reload config: {}", e)})).into_response();
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "status": "error",
+                    "message": format!("Failed to reload config: {}", e),
+                })),
+            )
+                .into_response();
         }
     };
 
@@ -239,18 +254,53 @@ pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Respons
         Ok(r) => Arc::new(r),
         Err(e) => {
             error!("Failed to init providers: {}", e);
-            return Json(serde_json::json!({"status": "error", "message": format!("Failed to init providers: {}", e)})).into_response();
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "status": "error",
+                    "message": format!("Failed to init providers: {}", e),
+                })),
+            )
+                .into_response();
         }
     };
 
-    // 4. Create new reloadable state
+    // 4. Validate the candidate config BEFORE swapping. Awaiting here is
+    //    intentional — if validation fails we must surface the error and keep
+    //    the live snapshot intact, so in-flight requests never observe a
+    //    half-validated config.
+    info!("🔍 Validating reloaded config...");
+    let validation = crate::preset::validate_config(&new_config, &new_registry).await;
+    crate::preset::log_validation_results(&validation);
+
+    if let Some(rejection) = reject_if_validation_broken(&validation) {
+        error!(
+            "Configuration reload rejected: validation failed for {}",
+            rejection.detail
+        );
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "status": "error",
+                "message": format!(
+                    "Validation failed — config not reloaded. Models with no healthy provider: {}",
+                    rejection.detail,
+                ),
+                "broken_models": rejection.broken_models,
+            })),
+        )
+            .into_response();
+    }
+
+    // 5. Create new reloadable state and atomically swap (write lock held for
+    //    microseconds). In-flight requests continue on the old snapshot because
+    //    they hold an `Arc<ReloadableState>` taken before the swap.
     let new_inner = Arc::new(ReloadableState::new(new_config, new_router, new_registry));
 
-    // 5. Atomic swap (write lock held for microseconds)
     let active = state
         .active_requests
         .load(std::sync::atomic::Ordering::Relaxed);
-    *state.inner.write().unwrap_or_else(|e| e.into_inner()) = new_inner.clone();
+    *state.inner.write().unwrap_or_else(|e| e.into_inner()) = new_inner;
 
     if active > 0 {
         info!(
@@ -261,13 +311,155 @@ pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Respons
         info!("✅ Configuration reloaded successfully");
     }
 
-    // 6. Validate new config in background (non-blocking)
-    tokio::spawn(async move {
-        info!("🔍 Validating reloaded config...");
-        let results =
-            crate::preset::validate_config(&new_inner.config, &new_inner.provider_registry).await;
-        crate::preset::log_validation_results(&results);
-    });
+    Json(serde_json::json!({
+        "status": "success",
+        "message": "Configuration reloaded",
+        "active_requests": active,
+    }))
+    .into_response()
+}
 
-    Json(serde_json::json!({"status": "success", "message": "Configuration reloaded", "active_requests": active})).into_response()
+/// Internal carrier for a validation rejection — feeds the 4xx response body.
+///
+/// Extracted so the rejection logic can be unit-tested without standing up an
+/// [`AppState`] or a full router.
+struct ValidationRejection {
+    detail: String,
+    broken_models: Vec<serde_json::Value>,
+}
+
+/// Returns `Some(rejection)` when a router model has zero healthy providers.
+///
+/// Reports the first failing router model(s) so the reload handler can
+/// short-circuit and leave the live config untouched, upholding the
+/// "in-flight requests keep using the old snapshot" invariant. Returns `None`
+/// when every router model has at least one healthy mapping (or none are
+/// declared, preserving the soft contract for minimal configs).
+fn reject_if_validation_broken(
+    validation: &[crate::preset::ModelValidation],
+) -> Option<ValidationRejection> {
+    let broken: Vec<&crate::preset::ModelValidation> =
+        validation.iter().filter(|m| !m.any_ok()).collect();
+    if broken.is_empty() {
+        return None;
+    }
+    let detail = broken
+        .iter()
+        .map(|m| format!("{} [{}]", m.model_name, m.role))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let broken_models = broken
+        .iter()
+        .map(|m| {
+            serde_json::json!({
+                "model": m.model_name,
+                "role": m.role,
+            })
+        })
+        .collect();
+    Some(ValidationRejection {
+        detail,
+        broken_models,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preset::{MappingResult, ModelValidation};
+
+    fn ok_mapping() -> MappingResult {
+        MappingResult {
+            priority: 1,
+            provider: "p".into(),
+            actual_model: "m".into(),
+            ok: true,
+            detail: "OK (12ms)".into(),
+        }
+    }
+
+    fn broken_mapping(detail: &str) -> MappingResult {
+        MappingResult {
+            priority: 1,
+            provider: "p".into(),
+            actual_model: "m".into(),
+            ok: false,
+            detail: detail.into(),
+        }
+    }
+
+    #[test]
+    fn empty_validation_passes() {
+        // No router models declared → nothing to validate → no rejection.
+        // Preserves the prior "soft" reload contract for minimal configs.
+        assert!(reject_if_validation_broken(&[]).is_none());
+    }
+
+    #[test]
+    fn all_ok_validation_passes() {
+        let results = vec![ModelValidation {
+            model_name: "default".into(),
+            role: "default".into(),
+            mappings: vec![ok_mapping()],
+        }];
+        assert!(reject_if_validation_broken(&results).is_none());
+    }
+
+    #[test]
+    fn at_least_one_healthy_mapping_passes() {
+        // any_ok() — a single healthy mapping is enough; a fallback being
+        // rate-limited at reload time should not block the reload.
+        let results = vec![ModelValidation {
+            model_name: "default".into(),
+            role: "default".into(),
+            mappings: vec![ok_mapping(), broken_mapping("429 - rate limited")],
+        }];
+        assert!(reject_if_validation_broken(&results).is_none());
+    }
+
+    #[test]
+    fn rejects_when_any_router_model_has_zero_healthy_mappings() {
+        // Regression guard for the race this fix targets: a config where a
+        // router slot points at a model with no working provider must NOT be
+        // swapped in.
+        let results = vec![
+            ModelValidation {
+                model_name: "default".into(),
+                role: "default".into(),
+                mappings: vec![ok_mapping()],
+            },
+            ModelValidation {
+                model_name: "missing-think-model".into(),
+                role: "think".into(),
+                mappings: vec![broken_mapping("Model not found in [[models]]")],
+            },
+        ];
+        let rejection = reject_if_validation_broken(&results)
+            .expect("expected rejection for the broken router model");
+        assert!(rejection.detail.contains("missing-think-model [think]"));
+        assert_eq!(rejection.broken_models.len(), 1);
+        assert_eq!(rejection.broken_models[0]["model"], "missing-think-model");
+        assert_eq!(rejection.broken_models[0]["role"], "think");
+    }
+
+    #[test]
+    fn rejects_with_multiple_broken_models_in_detail() {
+        let results = vec![
+            ModelValidation {
+                model_name: "default".into(),
+                role: "default".into(),
+                mappings: vec![broken_mapping("connection refused")],
+            },
+            ModelValidation {
+                model_name: "think".into(),
+                role: "think".into(),
+                mappings: vec![broken_mapping("connection refused")],
+            },
+        ];
+        let rejection =
+            reject_if_validation_broken(&results).expect("expected rejection for broken models");
+        assert!(rejection.detail.contains("default [default]"));
+        assert!(rejection.detail.contains("think [think]"));
+        assert_eq!(rejection.broken_models.len(), 2);
+    }
 }

--- a/src/server/dispatch/retry.rs
+++ b/src/server/dispatch/retry.rs
@@ -15,7 +15,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tracing::{info, warn};
 
-use super::super::{is_auth_revoked_error, is_retryable, retry_delay, MAX_RETRIES};
+use super::super::{is_auth_revoked_error, is_retryable, provider_max_retries, retry_delay};
 use super::telemetry::{
     calculate_and_record_metrics, record_success_telemetry, store_response_cache,
 };
@@ -99,6 +99,7 @@ fn classify_and_handle_error(
     mapping: &crate::cli::ModelMapping,
     e: &crate::providers::error::ProviderError,
     attempt: u32,
+    max_retries: u32,
 ) -> bool {
     if let Some(ref trace_id) = ctx.trace_id {
         ctx.state
@@ -107,7 +108,7 @@ fn classify_and_handle_error(
             .trace_error(trace_id, &e.to_string());
     }
     emit_provider_error_metrics(mapping, e);
-    is_retryable(e) && attempt < MAX_RETRIES
+    is_retryable(e) && attempt < max_retries
 }
 
 /// Log provider error metrics for the streaming path.
@@ -265,23 +266,29 @@ pub(super) async fn dispatch_non_streaming(
         0
     };
 
+    // Resolve the per-provider retry budget (`[[providers]] max_retries = N`),
+    // falling back to the global default. Looked up once per dispatch — config
+    // is static for the lifetime of this loop (a hot reload swaps the snapshot
+    // for *future* requests, never an in-flight one).
+    let max_retries = provider_max_retries(ctx.inner, &attempt.mapping.provider);
+
     // Wrap in Option so we can move (not clone) on the final attempt.
     let mut owned_request = Some(provider_request);
-    for retry in 0..=MAX_RETRIES {
+    for retry in 0..=max_retries {
         if retry > 0 {
             let delay = retry_delay(retry - 1);
             warn!(
                 "Retrying provider {} (attempt {}/{}), backoff {}ms",
                 attempt.mapping.provider,
                 retry + 1,
-                MAX_RETRIES + 1,
+                max_retries + 1,
                 delay.as_millis()
             );
             tokio::time::sleep(delay).await;
         }
 
         // Clone for earlier attempts; move on the last to avoid an extra allocation.
-        let req = if retry < MAX_RETRIES {
+        let req = if retry < max_retries {
             owned_request.as_ref().expect("set before loop").clone()
         } else {
             owned_request.take().expect("set before loop")
@@ -364,7 +371,7 @@ pub(super) async fn dispatch_non_streaming(
                     return Err(ProviderLoopAction::AuthRevoked(e.to_string()));
                 }
 
-                if classify_and_handle_error(ctx, attempt.mapping, &e, retry) {
+                if classify_and_handle_error(ctx, attempt.mapping, &e, retry, max_retries) {
                     // On 429, try rotating to next pooled key before retrying.
                     if is_upstream_rate_limit(&e) && provider.rotate_key_pool() {
                         info!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -36,8 +36,8 @@ pub(crate) use audit::{log_audit, AuditCompliance, AuditParams};
 pub(crate) use budget::{
     calculate_cost, check_budget_for_tenant, effective_token_counts, estimate_input_tokens,
     estimate_output_tokens, is_auth_revoked_error, is_estimate_mode, is_provider_subscription,
-    is_retryable, record_request_metrics, record_spend, retry_delay, tokens_from_chars,
-    RequestMetrics, MAX_RETRIES,
+    is_retryable, provider_max_retries, record_request_metrics, record_spend, retry_delay,
+    tokens_from_chars, RequestMetrics,
 };
 pub use error::{ErrorVariantTag, RequestError};
 pub(crate) use helpers::{

--- a/src/server/rpc/server_ns.rs
+++ b/src/server/rpc/server_ns.rs
@@ -38,6 +38,11 @@ pub async fn status(
 }
 
 /// Triggers an atomic configuration reload.
+///
+/// Awaits validation against the candidate registry **before** swapping the
+/// live snapshot. A failure surfaces as a JSON-RPC error and the in-flight
+/// `inner` snapshot stays untouched — the same contract the HTTP
+/// `/api/config/reload` endpoint enforces.
 pub async fn reload_config(
     state: &Arc<AppState>,
     caller: &CallerIdentity,
@@ -75,19 +80,33 @@ pub async fn reload_config(
     .map(Arc::new)
     .map_err(|e| rpc_err(ERR_INTERNAL, format!("Failed to init providers: {e}")))?;
 
+    // Awaited validation BEFORE the swap so a misconfigured reload cannot
+    // briefly serve traffic. In-flight requests continue on the old snapshot
+    // via their cached `Arc<ReloadableState>`.
+    let validation = crate::preset::validate_config(&new_config, &new_registry).await;
+    crate::preset::log_validation_results(&validation);
+    let broken: Vec<&crate::preset::ModelValidation> =
+        validation.iter().filter(|m| !m.any_ok()).collect();
+    if !broken.is_empty() {
+        let detail = broken
+            .iter()
+            .map(|m| format!("{} [{}]", m.model_name, m.role))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(rpc_err(
+            ERR_INTERNAL,
+            format!(
+                "Validation failed — config not reloaded. Models with no healthy provider: {detail}"
+            ),
+        ));
+    }
+
     let new_inner = Arc::new(ReloadableState::new(new_config, new_router, new_registry));
 
     let active = state
         .active_requests
         .load(std::sync::atomic::Ordering::Relaxed);
-    *state.inner.write().unwrap_or_else(|e| e.into_inner()) = new_inner.clone();
-
-    // Background validation (non-blocking)
-    tokio::spawn(async move {
-        let results =
-            crate::preset::validate_config(&new_inner.config, &new_inner.provider_registry).await;
-        crate::preset::log_validation_results(&results);
-    });
+    *state.inner.write().unwrap_or_else(|e| e.into_inner()) = new_inner;
 
     Ok(StatusResponse {
         status: "ok".into(),

--- a/src/storage/secrets.rs
+++ b/src/storage/secrets.rs
@@ -311,6 +311,7 @@ mod tests {
             pool: None,
             circuit_breaker: None,
             health_check: None,
+            max_retries: None,
         }
     }
 

--- a/tests/helpers/fixtures.rs
+++ b/tests/helpers/fixtures.rs
@@ -126,6 +126,7 @@ pub fn base_provider_config(name: &str) -> grob::providers::ProviderConfig {
         circuit_breaker: None,
 
         health_check: None,
+        max_retries: None,
     }
 }
 

--- a/tests/unit/provider_test.rs
+++ b/tests/unit/provider_test.rs
@@ -32,6 +32,7 @@ mod tests {
             circuit_breaker: None,
 
             health_check: None,
+            max_retries: None,
         };
 
         assert!(config.is_enabled());
@@ -62,6 +63,7 @@ mod tests {
             circuit_breaker: None,
 
             health_check: None,
+            max_retries: None,
         };
 
         assert!(!config.is_enabled());


### PR DESCRIPTION
Revives the still-relevant work from #323 (`fix/dispatch-retry-and-reload`, ~1 month stale, conflicting, CI red), rebased cleanly on the current dispatch path. The recent streaming spend accounting, estimate-mode token counting, and per-tenant fan-out budget checks are all left intact — this PR sits on top of them, not against them.

**Supersedes #323.**

## Per-concern verdict

### 1. Per-provider retry budget — KEPT (re-implemented on current loop)
`main` only had a global `MAX_RETRIES = 2` const. This adds an optional `max_retries` to `ProviderConfig`:
- Absent → global default (2); explicit `0` → retries disabled (single attempt).
- `provider_max_retries` / `resolve_max_retries` (in `budget.rs`) resolve the budget from the live config snapshot; no provider names hard-coded in the hot path.
- The non-streaming retry loop and `classify_and_handle_error` consume the resolved budget instead of the const. Looked up once per dispatch (config is static for the loop's lifetime; a reload only affects future requests).

### 2. `RateLimitHandler` trait — DROPPED (already handled on main)
`main` already centralises 429 / 401-rate-limit-payload classification in `retry::is_upstream_rate_limit`, wired into all three call sites. #323's `RateLimitHandler` trait (`err.is_rate_limit()`) was a strict duplicate of existing handling and would add an abstraction with no new behaviour. Dropped.

### 3. Hot-reload validation race — KEPT (rewritten for current code)
Verified the race **still exists** on current `main`: both `/api/config/reload` (`config_api.rs`) and the JSON-RPC `grob/server/reload_config` (`rpc/server_ns.rs`) swapped the live `ReloadableState` **first**, then validated in a detached `tokio::spawn`. A config whose router model has no healthy provider would briefly serve traffic.

Fix: both paths now **await** `validate_config` against the candidate registry **before** the atomic swap. If any router model has zero healthy mappings (`!any_ok()`), the reload is rejected (HTTP `422 Unprocessable Entity` / RPC error) and the live snapshot is left untouched. The rejection logic is extracted into the testable `reject_if_validation_broken`.

## How it sits on top of recent work
- Retry change touches only `dispatch_non_streaming`'s loop bound and `classify_and_handle_error`; the streaming `SpendStream` wrap, `estimate_input_tokens` capture, and `try_rotate_and_retry` rate-limit handling are untouched.
- The fan-out per-mapping `check_budget_for_tenant` in `provider_loop.rs` is unchanged.
- `is_upstream_rate_limit` is kept as the single rate-limit classifier (the trait was not introduced).

## Test coverage
- `budget.rs`: 5 cases for per-provider budget resolution (unknown provider → default, unset → default, override honoured, `0` disables, per-provider isolation).
- `config_api.rs`: 5 cases for `reject_if_validation_broken` (empty passes, all-ok passes, `any_ok` single-healthy passes, single broken model rejected with detail, multiple broken models).
- Existing `tests/unit/provider_test.rs` and `tests/helpers/fixtures.rs` updated for the new `max_retries` field.

Gates: `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, the restricted-feature clippy set, `cargo test --lib` (1157 passed), `cargo test --test lib` (266 passed), and `RUSTDOCFLAGS='-W missing-docs' cargo doc --no-deps` (39 warnings = baseline, no new) all pass.

## Risks / notes for the reviewer
- **Third reload path not covered:** `config_guard::reload_state` (used by `update_config_json`, the web-UI config-write path) is a synchronous function that does NOT run live `validate_config`. It was out of scope for #323 and is left as-is; closing it requires making that path async. Worth a follow-up.
- **Behavioural change on reload:** a previously-tolerated reload with a broken router model now hard-fails with 4xx instead of silently swapping. This is the intended fix, but any tooling that relied on best-effort reloads should be aware.
- **Reload latency:** the HTTP/RPC reload now blocks on live validation (network probes to providers) before returning, rather than returning immediately and validating in the background. Reload calls are slower but correct.
- **529 not added:** #323's trait also classified HTTP 529 (Anthropic "Overloaded") as rate-limit; `main`'s `is_upstream_rate_limit`/`is_retryable` do not. I deliberately did NOT smuggle that behaviour change in here (it would also need a `budget::is_retryable` change). Flagging as a possible separate follow-up.
- **RPC error code:** the RPC reload rejection reuses `ERR_INTERNAL` (no dedicated validation error code in the RPC types); the HTTP path uses a precise `422`.

Original #323 quality verdict: the per-provider-retry and reload-race work were sound and well-tested; the `RateLimitHandler` trait was redundant given `main` already grew `is_upstream_rate_limit`. The reload fix needed adapting to the current `validate_config`/`ModelValidation` shapes but the core approach held up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
