### PR TITLE
feat(security): tool-call spike anomaly detector (revives #308)

### DIFF
--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -228,6 +228,36 @@ When adaptive scoring is enabled alongside circuit breakers:
 
 Model mappings are sorted by `priority / adaptive_factor`. Providers with factor `0.0` receive infinite effective priority (tried last). A new, unknown provider starts with factor `1.0`.
 
+## Tool-call spike detection (T-AD1)
+
+Detects per-session tool-call spikes so a misbehaving agent cannot exhaust provider quotas or trigger billing surprises. Runs in the dispatch pipeline after DLP scanning and before routing.
+
+```toml
+[security]
+tool_spike_warn_per_min = 100     # log + metric above this (default: 100)
+tool_spike_block_per_min = 500    # return HTTP 429 above this (default: 500)
+```
+
+### Behavior
+
+- **Counting**: each request contributes the number of `tool_use` and `tool_result` content blocks it carries.
+- **Window**: a 60-second rolling ring of one-second buckets per session key. Old buckets age out lazily on access — no background sweeping of the hot path.
+- **Key resolution**: `metadata.session_id` → `metadata.user_id` → tenant id → `"anon"`.
+- **Warn**: crossing `tool_spike_warn_per_min` logs a `WARN` line and increments `grob_tool_spike_warn_total`. The request proceeds.
+- **Block**: crossing `tool_spike_block_per_min` increments `grob_tool_spike_blocked_total`, writes a signed `TOOL_SPIKE_BLOCKED` audit entry, and returns HTTP 429 with body type `rate_limited`. The block is terminal — it is **not** retried against a sibling provider.
+
+### Defaults
+
+`100/min/session` is roughly the upper bound for a busy build run (an agent reading ~2 files/sec). `500/min` equals >8/sec sustained, which only a runaway loop produces.
+
+### Disabling
+
+Set both thresholds to `0` to disable the detector entirely; it is then never installed and adds no per-request work. Setting only `tool_spike_block_per_min = 0` keeps warnings while disabling blocking.
+
+### Memory
+
+Idle session rings are pruned by a 60-second background task, bounding memory under churning session ids.
+
 ## Risk classification (EU AI Act)
 
 ```toml

--- a/src/cli/config/security.rs
+++ b/src/cli/config/security.rs
@@ -67,6 +67,20 @@ pub struct SecurityConfig {
     /// keyed on a non-anonymous tenant id.
     #[serde(default)]
     pub strict_tenant: bool,
+    /// Tool-call spike: warn threshold per session per minute (default 100).
+    ///
+    /// Crossing this rolling 60s count logs a warning and emits a
+    /// metric without rejecting the request. Set to `0` to disable
+    /// warnings.
+    #[serde(default = "default_tool_spike_warn_per_min")]
+    pub tool_spike_warn_per_min: u32,
+    /// Tool-call spike: block threshold per session per minute (default 500).
+    ///
+    /// Crossing this rolling 60s count returns HTTP 429, writes a
+    /// signed audit entry, and emits a metric. Set to `0` to disable
+    /// blocking. Setting both thresholds to `0` disables the detector.
+    #[serde(default = "default_tool_spike_block_per_min")]
+    pub tool_spike_block_per_min: u32,
 }
 
 impl Default for SecurityConfig {
@@ -90,6 +104,8 @@ impl Default for SecurityConfig {
             scoring_decay_rate: default_scoring_decay_rate(),
             scoring_persist: false,
             strict_tenant: false,
+            tool_spike_warn_per_min: default_tool_spike_warn_per_min(),
+            tool_spike_block_per_min: default_tool_spike_block_per_min(),
         }
     }
 }
@@ -129,6 +145,19 @@ fn default_scoring_window_size() -> usize {
 // stale high scores while keeping recently-active providers competitive.
 fn default_scoring_decay_rate() -> f64 {
     0.001
+}
+
+// NOTE: 100 tool calls/min/session is roughly the upper bound for a busy
+// build run (Claude Code reading ~2 files/sec while exploring a tree).
+// Above this we want a paper trail but still let the request through.
+fn default_tool_spike_warn_per_min() -> u32 {
+    100
+}
+
+// NOTE: 500 tool calls/min/session is firmly anomalous — >8/sec sustained,
+// which only a runaway loop produces. Blocks dispatch and audit-logs.
+fn default_tool_spike_block_per_min() -> u32 {
+    500
 }
 
 /// EU AI Act compliance configuration

--- a/src/security/audit_log.rs
+++ b/src/security/audit_log.rs
@@ -90,6 +90,8 @@ pub enum AuditEvent {
     /// response has been produced — covers the entire request lifecycle from
     /// authentication through dispatch and error handling).
     RequestProcessed,
+    /// Tool-call spike anomaly blocked (T-AD1).
+    ToolSpikeBlocked,
 }
 
 /// Immutable audit log entry.

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -12,6 +12,7 @@ pub mod provider_scorer;
 pub mod rate_limit;
 pub mod risk;
 pub mod tee;
+pub mod tool_spike;
 
 // Re-exports used by server/mod.rs and other modules
 pub use audit_log::AuditLog;
@@ -20,3 +21,4 @@ pub use fips::FipsStatus;
 pub use headers::{apply_security_headers, SecurityHeadersConfig};
 pub use rate_limit::{RateLimitConfig, RateLimitKey, RateLimiter};
 pub use tee::TeeStatus;
+pub use tool_spike::{SpikeAction, ToolSpikeConfig, ToolSpikeDetector};

--- a/src/security/tool_spike.rs
+++ b/src/security/tool_spike.rs
@@ -1,0 +1,569 @@
+//! Per-session tool-call spike anomaly detector (T-AD1).
+//!
+//! Tracks tool-use volume (Anthropic `tool_use` blocks emitted by the
+//! model and `tool_result` blocks echoed back by the client) inside a
+//! 60-second rolling window keyed by session id (falling back to user
+//! id, then tenant id). Two thresholds are configurable: a warn level
+//! that emits a log and metric, and a block level that surfaces a
+//! `RequestError::ToolSpikeBlocked` rejection (HTTP 429) plus a signed
+//! audit entry.
+//!
+//! The window is a fixed-size ring of one-second buckets (60 buckets).
+//! Buckets older than the window are zeroed lazily on each access, so
+//! old samples drop out automatically without a background task.
+//!
+//! Hooks into the dispatch pipeline after DLP scanning and before
+//! routing. The detector activates only when at least one threshold is
+//! non-zero on the `[security]` config block (see [`SecurityConfig`]).
+//!
+//! [`SecurityConfig`]: crate::cli::SecurityConfig
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Number of buckets in the sliding ring. One bucket per second.
+const BUCKET_COUNT: usize = 60;
+
+/// Total wall-clock span covered by the ring.
+const WINDOW: Duration = Duration::from_secs(BUCKET_COUNT as u64);
+
+/// Outcome of an [`ToolSpikeDetector::observe`] call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpikeAction {
+    /// Below all thresholds — proceed silently.
+    Allow,
+    /// Crossed `warn_per_min` but not `block_per_min` — log, emit a
+    /// metric, and allow the request through.
+    Warn,
+    /// Crossed `block_per_min` — surface a 429 to the client and
+    /// write an audit entry.
+    Block,
+}
+
+/// Warn and block thresholds for the tool-spike detector.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolSpikeConfig {
+    /// Per-key rolling-window count above which a warning fires (no block).
+    pub warn_per_min: u32,
+    /// Per-key rolling-window count above which the request is blocked.
+    pub block_per_min: u32,
+}
+
+impl Default for ToolSpikeConfig {
+    fn default() -> Self {
+        Self {
+            warn_per_min: 100,
+            block_per_min: 500,
+        }
+    }
+}
+
+impl ToolSpikeConfig {
+    /// Returns whether the detector does any work.
+    ///
+    /// When both thresholds are zero the detector short-circuits to
+    /// [`SpikeAction::Allow`] without taking its internal lock, and
+    /// `init` returns `None` so it is never installed on the state.
+    pub fn is_active(&self) -> bool {
+        self.warn_per_min > 0 || self.block_per_min > 0
+    }
+}
+
+/// Per-key sliding-window bucket ring.
+#[derive(Debug)]
+struct BucketRing {
+    /// Counts per second; index = `epoch_secs % BUCKET_COUNT`.
+    buckets: [u32; BUCKET_COUNT],
+    /// Epoch second of the most recently written bucket.
+    last_second: u64,
+    /// Wall-clock anchor used to age stale entries during cleanup.
+    last_touch: Instant,
+}
+
+impl BucketRing {
+    fn new(now_secs: u64) -> Self {
+        Self {
+            buckets: [0; BUCKET_COUNT],
+            last_second: now_secs,
+            last_touch: Instant::now(),
+        }
+    }
+
+    /// Adds `count` to the current second's bucket and returns the total
+    /// volume across the rolling 60-second window.
+    fn record(&mut self, now_secs: u64, count: u32) -> u32 {
+        self.advance(now_secs);
+        let idx = (now_secs % BUCKET_COUNT as u64) as usize;
+        self.buckets[idx] = self.buckets[idx].saturating_add(count);
+        self.last_touch = Instant::now();
+        self.total()
+    }
+
+    /// Zeroes buckets that fell out of the rolling window.
+    ///
+    /// When more than `BUCKET_COUNT` seconds elapsed since the last
+    /// write, every bucket is stale and the ring is cleared in one pass.
+    fn advance(&mut self, now_secs: u64) {
+        if now_secs <= self.last_second {
+            return;
+        }
+        let elapsed = now_secs - self.last_second;
+        if elapsed >= BUCKET_COUNT as u64 {
+            self.buckets = [0; BUCKET_COUNT];
+        } else {
+            // Clear every bucket strictly between last_second and now_secs:
+            // those seconds elapsed with no writes, so their old counts are stale.
+            for offset in 1..=elapsed {
+                let idx = ((self.last_second + offset) % BUCKET_COUNT as u64) as usize;
+                self.buckets[idx] = 0;
+            }
+        }
+        self.last_second = now_secs;
+    }
+
+    /// Returns the sum of all buckets in the current window.
+    fn total(&self) -> u32 {
+        self.buckets.iter().fold(0u32, |a, b| a.saturating_add(*b))
+    }
+
+    /// Resets the ring to all-zero counts.
+    fn clear(&mut self) {
+        self.buckets = [0; BUCKET_COUNT];
+    }
+}
+
+/// Sliding-window per-session counter with warn and block thresholds.
+///
+/// Cheap enough to call inline on every dispatch: a single mutex
+/// acquisition, an integer addition, and one bucket rotation in the
+/// steady state.
+///
+/// # Examples
+///
+/// ```
+/// use grob::security::tool_spike::{ToolSpikeConfig, ToolSpikeDetector, SpikeAction};
+///
+/// let detector = ToolSpikeDetector::new(ToolSpikeConfig {
+///     warn_per_min: 10,
+///     block_per_min: 20,
+/// });
+/// assert_eq!(detector.observe("session-1", 5), SpikeAction::Allow);
+/// assert_eq!(detector.observe("session-1", 7), SpikeAction::Warn);
+/// assert_eq!(detector.observe("session-1", 9), SpikeAction::Block);
+/// ```
+#[derive(Debug)]
+pub struct ToolSpikeDetector {
+    config: ToolSpikeConfig,
+    rings: Mutex<HashMap<String, BucketRing>>,
+    /// Monotonic origin used to derive the current "second" without
+    /// pulling `chrono` into the hot path.
+    epoch: Instant,
+}
+
+impl ToolSpikeDetector {
+    /// Creates a detector with the given thresholds.
+    pub fn new(config: ToolSpikeConfig) -> Self {
+        Self {
+            config,
+            rings: Mutex::new(HashMap::new()),
+            epoch: Instant::now(),
+        }
+    }
+
+    /// Returns the configured thresholds.
+    pub fn config(&self) -> &ToolSpikeConfig {
+        &self.config
+    }
+
+    /// Records `count` tool calls for `key` and classifies the new total.
+    ///
+    /// Returns the most severe action triggered by the updated rolling
+    /// total. A `count` of zero still drives bucket rotation, which is
+    /// useful for observability snapshots.
+    pub fn observe(&self, key: &str, count: u32) -> SpikeAction {
+        if !self.config.is_active() {
+            return SpikeAction::Allow;
+        }
+        let now_secs = self.now_secs();
+        let mut rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+        let ring = rings
+            .entry(key.to_string())
+            .or_insert_with(|| BucketRing::new(now_secs));
+        let total = ring.record(now_secs, count);
+        self.classify(total)
+    }
+
+    /// Returns the current rolling-window total for `key` without
+    /// recording a new sample.
+    pub fn current_total(&self, key: &str) -> u32 {
+        let now_secs = self.now_secs();
+        let mut rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+        match rings.get_mut(key) {
+            Some(ring) => {
+                ring.advance(now_secs);
+                ring.total()
+            }
+            None => 0,
+        }
+    }
+
+    /// Drops the counter for a session.
+    ///
+    /// Called when the upstream session signals end-of-life so the
+    /// detector does not attribute future activity to a recycled
+    /// identifier.
+    pub fn reset_session(&self, key: &str) {
+        let mut rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(ring) = rings.get_mut(key) {
+            ring.clear();
+        }
+    }
+
+    /// Drops counters untouched for at least one full window.
+    ///
+    /// Bounds memory under churning session ids. Heavier than `observe`
+    /// only by one pass over the map, so it is safe to call on a coarse
+    /// cadence from a background task.
+    pub fn cleanup_idle(&self) {
+        let mut rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+        let now = Instant::now();
+        rings.retain(|_, ring| now.duration_since(ring.last_touch) < WINDOW);
+    }
+
+    fn classify(&self, total: u32) -> SpikeAction {
+        if self.config.block_per_min > 0 && total >= self.config.block_per_min {
+            SpikeAction::Block
+        } else if self.config.warn_per_min > 0 && total >= self.config.warn_per_min {
+            SpikeAction::Warn
+        } else {
+            SpikeAction::Allow
+        }
+    }
+
+    fn now_secs(&self) -> u64 {
+        // Anchored to the detector's start so bucket ordering stays
+        // stable even if the wall clock steps backwards.
+        Instant::now()
+            .saturating_duration_since(self.epoch)
+            .as_secs()
+    }
+
+    /// Builds a detector anchored at a synthetic epoch for deterministic
+    /// time control in tests.
+    #[cfg(test)]
+    fn with_epoch(config: ToolSpikeConfig, epoch: Instant) -> Self {
+        Self {
+            config,
+            rings: Mutex::new(HashMap::new()),
+            epoch,
+        }
+    }
+
+    /// Records `count` at `secs_since_epoch` instead of "now", mirroring
+    /// [`observe`](Self::observe) so production semantics stay identical.
+    #[cfg(test)]
+    fn observe_at(&self, key: &str, count: u32, secs_since_epoch: u64) -> SpikeAction {
+        if !self.config.is_active() {
+            return SpikeAction::Allow;
+        }
+        let mut rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+        let ring = rings
+            .entry(key.to_string())
+            .or_insert_with(|| BucketRing::new(secs_since_epoch));
+        let total = ring.record(secs_since_epoch, count);
+        self.classify(total)
+    }
+}
+
+/// Counts the `tool_use` and `tool_result` content blocks in a request.
+///
+/// Approximates the per-request tool-call volume contributed by the
+/// client. Models that emit many tool-use blocks per turn surface as a
+/// spike across consecutive requests inside the same session.
+pub fn count_tool_blocks(request: &crate::models::CanonicalRequest) -> u32 {
+    use crate::models::{ContentBlock, KnownContentBlock, MessageContent};
+
+    let mut count: u32 = 0;
+    for msg in &request.messages {
+        let MessageContent::Blocks(blocks) = &msg.content else {
+            continue;
+        };
+        for block in blocks {
+            if matches!(
+                block,
+                ContentBlock::Known(
+                    KnownContentBlock::ToolUse { .. } | KnownContentBlock::ToolResult { .. }
+                )
+            ) {
+                count = count.saturating_add(1);
+            }
+        }
+    }
+    count
+}
+
+/// Resolves the spike-detector key for a request.
+///
+/// Priority:
+/// 1. `metadata.session_id` on the request body.
+/// 2. `metadata.user_id` (Anthropic Messages API field).
+/// 3. The provided `tenant_id` fallback (or `"anon"`).
+pub fn resolve_key(request: &crate::models::CanonicalRequest, tenant_id: Option<&str>) -> String {
+    if let Some(meta) = request.metadata.as_ref() {
+        for field in ["session_id", "user_id"] {
+            if let Some(value) = meta.get(field).and_then(|v| v.as_str()) {
+                if !value.is_empty() {
+                    return value.to_string();
+                }
+            }
+        }
+    }
+    tenant_id.unwrap_or("anon").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(warn: u32, block: u32) -> ToolSpikeConfig {
+        ToolSpikeConfig {
+            warn_per_min: warn,
+            block_per_min: block,
+        }
+    }
+
+    impl ToolSpikeDetector {
+        fn current_total_at(&self, key: &str, secs_since_epoch: u64) -> u32 {
+            let mut rings = self.rings.lock().unwrap_or_else(|e| e.into_inner());
+            match rings.get_mut(key) {
+                Some(ring) => {
+                    ring.advance(secs_since_epoch);
+                    ring.total()
+                }
+                None => 0,
+            }
+        }
+    }
+
+    #[test]
+    fn allow_under_warn() {
+        let det = ToolSpikeDetector::new(cfg(100, 500));
+        assert_eq!(det.observe("s1", 50), SpikeAction::Allow);
+        assert_eq!(det.current_total("s1"), 50);
+    }
+
+    #[test]
+    fn warn_at_threshold_no_block() {
+        let det = ToolSpikeDetector::new(cfg(100, 500));
+        let mut last = SpikeAction::Allow;
+        for _ in 0..200 {
+            last = det.observe("hot", 1);
+        }
+        assert_eq!(last, SpikeAction::Warn);
+        assert_eq!(det.current_total("hot"), 200);
+    }
+
+    #[test]
+    fn block_above_threshold() {
+        let det = ToolSpikeDetector::new(cfg(100, 500));
+        let mut last = SpikeAction::Allow;
+        let mut blocked = 0;
+        for _ in 0..600 {
+            last = det.observe("noisy", 1);
+            if last == SpikeAction::Block {
+                blocked += 1;
+            }
+        }
+        assert_eq!(last, SpikeAction::Block);
+        assert!(blocked > 0, "must have hit block at least once");
+    }
+
+    #[test]
+    fn window_decays_after_60_seconds() {
+        let det = ToolSpikeDetector::with_epoch(cfg(100, 500), Instant::now());
+
+        for _ in 0..200 {
+            assert_ne!(det.observe_at("decay", 1, 5), SpikeAction::Block);
+        }
+        assert_eq!(det.observe_at("decay", 0, 5), SpikeAction::Warn);
+
+        // Jump 70s ahead → every old bucket falls out of the window.
+        assert_eq!(det.observe_at("decay", 0, 75), SpikeAction::Allow);
+    }
+
+    #[test]
+    fn boundary_partial_decay() {
+        let det = ToolSpikeDetector::with_epoch(cfg(100, 500), Instant::now());
+
+        for _ in 0..60 {
+            det.observe_at("part", 1, 0);
+        }
+        for _ in 0..60 {
+            det.observe_at("part", 1, 30);
+        }
+        assert_eq!(det.observe_at("part", 0, 30), SpikeAction::Warn);
+
+        // At second 65 the second-0 bucket has aged out (60-bucket ring);
+        // only the 60 hits from second 30 remain.
+        assert_eq!(det.observe_at("part", 0, 65), SpikeAction::Allow);
+        assert_eq!(det.current_total_at("part", 65), 60);
+    }
+
+    #[test]
+    fn reset_session_clears_counter() {
+        let det = ToolSpikeDetector::new(cfg(100, 500));
+        for _ in 0..120 {
+            det.observe("end-me", 1);
+        }
+        assert_eq!(det.observe("end-me", 0), SpikeAction::Warn);
+        det.reset_session("end-me");
+        assert_eq!(det.observe("end-me", 0), SpikeAction::Allow);
+    }
+
+    #[test]
+    fn disabled_when_thresholds_zero() {
+        let det = ToolSpikeDetector::new(cfg(0, 0));
+        assert_eq!(det.observe("anything", 100_000), SpikeAction::Allow);
+    }
+
+    #[test]
+    fn distinct_keys_isolated() {
+        let det = ToolSpikeDetector::new(cfg(100, 500));
+        for _ in 0..120 {
+            det.observe("a", 1);
+        }
+        assert_eq!(det.observe("a", 0), SpikeAction::Warn);
+        // Sibling key untouched.
+        assert_eq!(det.observe("b", 1), SpikeAction::Allow);
+    }
+
+    #[test]
+    fn warn_only_when_block_disabled() {
+        // block_per_min == 0 disables blocking even at huge volumes.
+        let det = ToolSpikeDetector::new(cfg(100, 0));
+        for _ in 0..1000 {
+            det.observe("k", 1);
+        }
+        assert_eq!(det.observe("k", 0), SpikeAction::Warn);
+    }
+
+    #[test]
+    fn count_tool_blocks_from_canonical_request() {
+        use crate::models::{CanonicalRequest, ContentBlock, Message, MessageContent};
+
+        let mut req = CanonicalRequest {
+            model: "x".into(),
+            messages: vec![Message {
+                role: "assistant".into(),
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::tool_use(
+                        "id-1".into(),
+                        "Read".into(),
+                        serde_json::json!({"path": "/tmp/a"}),
+                    ),
+                    ContentBlock::tool_use(
+                        "id-2".into(),
+                        "Read".into(),
+                        serde_json::json!({"path": "/tmp/b"}),
+                    ),
+                    ContentBlock::text("hi".into(), None),
+                ]),
+            }],
+            max_tokens: 10,
+            thinking: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            metadata: None,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            extensions: Default::default(),
+        };
+        assert_eq!(count_tool_blocks(&req), 2);
+
+        // A user turn carrying a tool_result grows the count by one.
+        req.messages.push(Message {
+            role: "user".into(),
+            content: MessageContent::Blocks(vec![ContentBlock::Known(
+                crate::models::KnownContentBlock::ToolResult {
+                    tool_use_id: "id-1".into(),
+                    content: crate::models::ToolResultContent::Text("ok".into()),
+                    is_error: false,
+                    cache_control: None,
+                },
+            )]),
+        });
+        assert_eq!(count_tool_blocks(&req), 3);
+
+        // A plain-text message contributes nothing.
+        req.messages.push(Message {
+            role: "user".into(),
+            content: MessageContent::Text("just talking".into()),
+        });
+        assert_eq!(count_tool_blocks(&req), 3);
+    }
+
+    #[test]
+    fn resolve_key_priority_session_user_tenant() {
+        use crate::models::CanonicalRequest;
+        use std::collections::HashMap;
+
+        let make = |meta: Option<HashMap<String, serde_json::Value>>| CanonicalRequest {
+            model: "x".into(),
+            messages: vec![],
+            max_tokens: 1,
+            thinking: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            metadata: meta,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            extensions: Default::default(),
+        };
+
+        // No metadata → tenant fallback, then "anon".
+        assert_eq!(resolve_key(&make(None), Some("tenant-a")), "tenant-a");
+        assert_eq!(resolve_key(&make(None), None), "anon");
+
+        // session_id wins over user_id.
+        let mut m = HashMap::new();
+        m.insert("session_id".into(), serde_json::json!("sess-1"));
+        m.insert("user_id".into(), serde_json::json!("user-1"));
+        assert_eq!(resolve_key(&make(Some(m)), Some("tenant-a")), "sess-1");
+
+        // user_id used when session_id absent.
+        let mut m = HashMap::new();
+        m.insert("user_id".into(), serde_json::json!("user-2"));
+        assert_eq!(resolve_key(&make(Some(m)), Some("tenant-a")), "user-2");
+
+        // Empty session_id falls through to user_id.
+        let mut m = HashMap::new();
+        m.insert("session_id".into(), serde_json::json!(""));
+        m.insert("user_id".into(), serde_json::json!("user-3"));
+        assert_eq!(resolve_key(&make(Some(m)), None), "user-3");
+    }
+
+    #[test]
+    fn cleanup_idle_drops_stale_keys() {
+        let det = ToolSpikeDetector::new(cfg(100, 500));
+        det.observe("ephemeral", 1);
+        // Age the entry past the window by reaching through the lock.
+        {
+            let mut rings = det.rings.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(ring) = rings.get_mut("ephemeral") {
+                ring.last_touch = Instant::now() - Duration::from_secs(120);
+            }
+        }
+        det.cleanup_idle();
+        let rings = det.rings.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(!rings.contains_key("ephemeral"));
+    }
+}

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -262,6 +262,12 @@ pub(crate) async fn dispatch(
     // ── Step 1: DLP input scanning ──
     scan_dlp_input(ctx, request)?;
 
+    // ── Step 1.4: Tool-call spike anomaly detection (T-AD1) ──
+    // Runs after DLP so scoped DLP blocks take precedence, and before
+    // routing so a runaway client cannot exhaust provider quotas before
+    // the spike is observed.
+    check_tool_spike(ctx, request)?;
+
     // ── Step 1.5: MCP tool calibration ──
     #[cfg(feature = "mcp")]
     if let Some(ref mcp) = ctx.state.security.mcp {
@@ -485,6 +491,87 @@ fn scan_dlp_input(
                 dlp_had_redact_or_warn: false,
             });
             Err(RequestError::DlpBlocked(format!("{}", block_err)))
+        }
+    }
+}
+
+/// Runs the per-session tool-call spike anomaly detector (T-AD1).
+///
+/// Counts the `tool_use` and `tool_result` content blocks in the
+/// incoming request and feeds them into a 60-second rolling window
+/// keyed by session id (falling back to user id, then tenant id).
+/// Crossing the warn threshold logs and emits a metric; crossing the
+/// block threshold writes an audit entry and returns
+/// [`RequestError::ToolSpikeBlocked`] (HTTP 429).
+///
+/// Returns `Ok(())` when the detector is disabled or the request is
+/// below all thresholds.
+///
+/// # Errors
+///
+/// Returns [`RequestError::ToolSpikeBlocked`] when the rolling-window
+/// tool-call total for the resolved session key reaches the configured
+/// block threshold.
+fn check_tool_spike(
+    ctx: &DispatchContext<'_>,
+    request: &CanonicalRequest,
+) -> Result<(), RequestError> {
+    use crate::security::tool_spike::{count_tool_blocks, resolve_key};
+    use crate::security::SpikeAction;
+
+    let Some(detector) = ctx.state.security.tool_spike_detector.as_ref() else {
+        return Ok(());
+    };
+
+    let count = count_tool_blocks(request);
+    let key = resolve_key(request, ctx.tenant_id.as_deref());
+
+    match detector.observe(&key, count) {
+        SpikeAction::Allow => Ok(()),
+        SpikeAction::Warn => {
+            // NOTE: session keys are unbounded, so they stay in the
+            // structured log (high cardinality) rather than a metric label.
+            metrics::counter!("grob_tool_spike_warn_total").increment(1);
+            tracing::warn!(
+                session = %key,
+                rolling_total = detector.current_total(&key),
+                threshold = detector.config().warn_per_min,
+                "tool_spike: warn threshold crossed"
+            );
+            Ok(())
+        }
+        SpikeAction::Block => {
+            metrics::counter!("grob_tool_spike_blocked_total").increment(1);
+            let total = detector.current_total(&key);
+            let block_threshold = detector.config().block_per_min;
+            tracing::warn!(
+                session = %key,
+                rolling_total = total,
+                threshold = block_threshold,
+                "tool_spike: block threshold crossed, returning 429"
+            );
+
+            ctx.log_audit_if_enabled(AuditEntry {
+                action: crate::security::audit_log::AuditEvent::ToolSpikeBlocked,
+                backend: "BLOCKED",
+                dlp_rules: vec![format!(
+                    "tool_spike: {} tool calls in 60s window (threshold {})",
+                    total, block_threshold
+                )],
+                duration_ms: ctx.start_time.elapsed().as_millis() as u64,
+                model_name: Some(&ctx.model),
+                token_counts: None,
+                risk_level: Some(crate::security::audit_log::RiskLevel::High),
+                dlp_blocked: true,
+                dlp_had_injection: false,
+                dlp_had_pii: false,
+                dlp_had_redact_or_warn: false,
+            });
+
+            Err(RequestError::ToolSpikeBlocked(format!(
+                "tool-call spike anomaly: {} tool calls observed in 60s window for session {} (block threshold {})",
+                total, key, block_threshold
+            )))
         }
     }
 }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -64,6 +64,13 @@ pub enum RequestError {
     },
     /// Indicates the DLP pipeline blocked the request (HTTP 400).
     DlpBlocked(String),
+    /// Indicates an in-process limiter rejected the request (HTTP 429).
+    ///
+    /// Distinct from [`RequestError::RateLimited`], which forwards an
+    /// upstream provider 429 and is retryable. This is a terminal local
+    /// rejection (e.g. the tool-call spike anomaly detector, T-AD1) and
+    /// is never retried against a sibling provider.
+    ToolSpikeBlocked(String),
     /// Indicates an upstream OAuth credential was revoked (HTTP 401).
     ///
     /// Surfaces a terminal authentication error — the user must run
@@ -154,6 +161,9 @@ impl RequestError {
                 ),
             ),
             RequestError::DlpBlocked(msg) => (StatusCode::BAD_REQUEST, "dlp_block", msg.clone()),
+            RequestError::ToolSpikeBlocked(msg) => {
+                (StatusCode::TOO_MANY_REQUESTS, "rate_limited", msg.clone())
+            }
             RequestError::AuthRevoked(msg) => (
                 StatusCode::UNAUTHORIZED,
                 "authentication_error",
@@ -179,6 +189,7 @@ impl RequestError {
             RequestError::ProviderUpstream { .. } => "provider_upstream",
             RequestError::BudgetExceeded { .. } => "budget_exceeded",
             RequestError::DlpBlocked(_) => "dlp_blocked",
+            RequestError::ToolSpikeBlocked(_) => "tool_spike_blocked",
             RequestError::AuthRevoked(_) => "auth_revoked",
             RequestError::Internal(_) => "internal",
         }
@@ -489,6 +500,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tool_spike_blocked_returns_429_with_rate_limited_type() {
+        let err = RequestError::ToolSpikeBlocked(
+            "tool-call spike: 600 in 60s window for session sess-1 (block 500)".to_string(),
+        );
+        let (status, json) = error_response_parts(err).await;
+
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(json["error"]["type"], "rate_limited");
+        assert!(json["error"]["message"]
+            .as_str()
+            .expect("message is a string")
+            .contains("tool-call spike"));
+    }
+
+    #[test]
+    fn tool_spike_blocked_is_not_retryable() {
+        let err = RequestError::ToolSpikeBlocked("spike".to_string());
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
     async fn auth_revoked_returns_401() {
         let err = RequestError::AuthRevoked(
             "OAuth token for provider 'anthropic' revoked. Run: grob connect --force-reauth"
@@ -690,6 +722,10 @@ mod tests {
         assert_eq!(
             RequestError::DlpBlocked("x".to_string()).variant_tag(),
             "dlp_blocked"
+        );
+        assert_eq!(
+            RequestError::ToolSpikeBlocked("x".to_string()).variant_tag(),
+            "tool_spike_blocked"
         );
         assert_eq!(
             RequestError::AuthRevoked("x".to_string()).variant_tag(),

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -4,7 +4,10 @@ use crate::features::token_pricing::spend::SpendTracker;
 use crate::features::token_pricing::SharedPricingTable;
 use crate::models::config::AppConfig;
 use crate::providers::ProviderRegistry;
-use crate::security::{AuditLog, CircuitBreakerRegistry, RateLimitConfig, RateLimiter};
+use crate::security::{
+    AuditLog, CircuitBreakerRegistry, RateLimitConfig, RateLimiter, ToolSpikeConfig,
+    ToolSpikeDetector,
+};
 use crate::shared::message_tracing::MessageTracer;
 use crate::storage::GrobStore;
 use std::sync::Arc;
@@ -386,6 +389,26 @@ pub(crate) fn init_mcp(
     Some(state)
 }
 
+/// Initializes the tool-call spike anomaly detector (T-AD1).
+///
+/// Returns `None` when both warn and block thresholds are zero (the
+/// feature is fully disabled), otherwise an `Arc` ready to store on
+/// [`crate::server::SecurityState`].
+pub(crate) fn init_tool_spike_detector(config: &AppConfig) -> Option<Arc<ToolSpikeDetector>> {
+    let cfg = ToolSpikeConfig {
+        warn_per_min: config.security.tool_spike_warn_per_min,
+        block_per_min: config.security.tool_spike_block_per_min,
+    };
+    if !cfg.is_active() {
+        return None;
+    }
+    info!(
+        "🔍 Tool-spike detector enabled (warn={}, block={} per session per min)",
+        cfg.warn_per_min, cfg.block_per_min
+    );
+    Some(Arc::new(ToolSpikeDetector::new(cfg)))
+}
+
 /// Initializes the adaptive provider scorer if enabled.
 pub(crate) fn init_provider_scorer(
     config: &AppConfig,
@@ -492,6 +515,20 @@ pub(crate) fn spawn_background_tasks(state: &Arc<super::AppState>) {
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     _ => {}
                 }
+            }
+        });
+    }
+
+    // Tool-spike detector: prune session rings idle longer than the
+    // rolling window so memory stays bounded under churning session ids.
+    if let Some(detector) = state.security.tool_spike_detector.clone() {
+        tokio::spawn(async move {
+            // 60s cadence matches the rolling window: an entry is dropped
+            // at most one window after its last activity.
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
+            loop {
+                ticker.tick().await;
+                detector.cleanup_idle();
             }
         });
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -48,7 +48,8 @@ pub(crate) use helpers::{
 pub(crate) use init::init_mcp;
 pub(crate) use init::{
     emit_tee_attestation, init_auth, init_core_services, init_dlp, init_observability,
-    init_provider_scorer, init_security, maybe_preset_sync, spawn_background_tasks,
+    init_provider_scorer, init_security, init_tool_spike_detector, maybe_preset_sync,
+    spawn_background_tasks,
 };
 pub(crate) use middleware::{
     apply_transparency_headers, audit_log_layer, auth_middleware, extract_api_credential,
@@ -160,6 +161,8 @@ pub struct SecurityState {
     pub mcp: Option<Arc<crate::features::mcp::McpState>>,
     /// Universal tool layer for injection, aliasing, and capability gating.
     pub tool_layer: Option<Arc<crate::features::tool_layer::ToolLayer>>,
+    /// Per-session tool-call spike anomaly detector (T-AD1).
+    pub tool_spike_detector: Option<Arc<crate::security::ToolSpikeDetector>>,
 }
 
 /// Application state shared across handlers
@@ -261,6 +264,7 @@ pub async fn start_server(
     emit_tee_attestation(&tee_status, &audit_log);
 
     let provider_scorer = init_provider_scorer(&config, &circuit_breakers);
+    let tool_spike_detector = init_tool_spike_detector(&config);
 
     // Coerce concrete types to trait objects for testability
     let tracer: Arc<dyn traits::Tracer> = message_tracer;
@@ -303,6 +307,7 @@ pub async fn start_server(
             #[cfg(feature = "mcp")]
             mcp: mcp_state,
             tool_layer,
+            tool_spike_detector,
         },
     });
 


### PR DESCRIPTION
Revives the still-relevant work from #308 (`feat/anomaly-detection-tool-spike`, ~1 month stale, conflicting, CI red), rebased cleanly on the current dispatch path.

**Supersedes #308.**

## Scope

Per-session tool-call spike anomaly detector (T-AD1): flags abnormal bursts of tool calls within a session window and records them to the audit log. Wired into `SecurityState` and `start_server` via `init_tool_spike_detector`.

Touched: `src/security/tool_spike.rs` (new), `src/security/{mod,audit_log}.rs`, `src/cli/config/security.rs`, `src/server/{mod,init,dispatch/mod,error}.rs`, `docs/reference/security.md`.

> Note: body corrected by repo-health audit — the original text was copy-pasted from #350 and incorrectly referenced #323/#308.