### PR TITLE
chore: release v0.36.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.47](https://github.com/azerozero/grob/compare/v0.36.46...v0.36.47) - 2026-05-27
+
+### Added
+
+- *(oauth)* retry adjacent ports when OAuth callback port is busy
+
+### Other
+
+- use values()/values_mut() to satisfy clippy::for_kv_map
+- Merge pull request #347 from azerozero/fix/fanout-budget-enforcement
+
 ## [0.36.46](https://github.com/azerozero/grob/compare/v0.36.45...v0.36.46) - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.46"
+version = "0.36.47"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.46"
+version = "0.36.47"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.46 -> 0.36.47

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.47](https://github.com/azerozero/grob/compare/v0.36.46...v0.36.47) - 2026-05-27

### Added

- *(oauth)* retry adjacent ports when OAuth callback port is busy

### Other

- use values()/values_mut() to satisfy clippy::for_kv_map
- Merge pull request #347 from azerozero/fix/fanout-budget-enforcement
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).