### PR TITLE
docs: fix claude-code-router fork leftovers (broken examples, ghost presets, model names)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ grob watch
 │  11:24:04  ← claude-sonnet-4-6    anthropic   834 tok  1.4s  $0.02 │
 │  11:24:05  DLP: 1 secret redacted (AWS key pattern)                 │
 │  11:24:09  FALLBACK: anthropic 429 → openrouter                     │
-│  11:24:10  ← gemini-3-flash       openrouter  412 tok  0.6s  $0.001│
+│  11:24:10  ← gemini-2.5-pro       openrouter  412 tok  0.6s  $0.001│
 ├─ Alerts ─────────────────────────────────────────────────────────────┤
 │  DLP: 3 secrets | 1 PII | 0 injections   Circuit: all OK            │
 └──────────────────────────────────────────────────────────────────────┘
@@ -128,24 +128,28 @@ flowchart LR
     R[Request] --> CL[Classify]
     CL --> M[Model] --> P1["Provider (P1)"]
     P1 -->|fail| P2["Provider (P2)"]
-    CL -->|extended thinking?| O[Opus 4.6]
-    CL -->|web_search tool?| GP[Gemini 3 Pro]
-    CL -->|background task?| GF[Gemini 3 Flash]
+    CL -->|extended thinking?| O[Opus 4.7]
+    CL -->|web_search tool?| GP[Gemini 2.5 Pro]
+    CL -->|background task?| GF[Haiku 4.5]
     CL -->|regex match?| CM[custom model]
     CL -->|default| S[Sonnet 4.6]
 ```
 
 Presets configure everything in one command:
 
-| Preset | Think | Default | Cost |
-|--------|-------|---------|------|
-| **perf** | Opus 4.6 (Anthropic) | Sonnet 4.6 (Anthropic) | Max subscription |
-| **medium** | Opus 4.6 (Anthropic) | Kimi K2.5 (OpenRouter) | Max sub + ~$0.30/M |
-| **cheap** | DeepSeek R1 (OpenRouter) | GLM-5 (z.ai) | ~$0.15/M |
-| **local** | Opus 4.6 (Anthropic) | Qwen 2.5 Coder (Ollama) | Max sub + free |
+| Preset | What it sets up | Cost |
+|--------|-----------------|------|
+| **perf** | Pure Anthropic OAuth (Pro/Max) — auto-maps `claude-*` to native | Max subscription |
+| **ultra-cheap** | Stacked free tiers (Groq + Cerebras + Z.ai + OpenRouter `:free`) | ~€0-2/month |
+| **gdpr** | EU-only routing — Mistral, Scaleway, OVH (`region = "eu"`) | Pay-as-you-go |
+| **eu-ai-act** | EU AI Act compliant — EU providers + transparency headers + risk classification | Pay-as-you-go |
+| **eu-eco** | Strict-EU sovereign, budget — Scaleway FR + Nebius `eu-north1` | Pay-as-you-go |
+| **eu-pro** | Strict-EU sovereign, balanced — Hermes-4-405B + Qwen3.5-397B | Pay-as-you-go |
+| **eu-max** | Strict-EU sovereign, premium — preemptive 397B/405B everywhere | Pay-as-you-go |
 
 ```bash
 grob preset apply perf
+grob preset list   # see every available preset
 ```
 
 ## Supported providers
@@ -157,12 +161,12 @@ grob preset apply perf
 | **Gemini** | API key / OAuth (Pro) | Google AI Studio |
 | **Vertex AI** | ADC | Google Cloud |
 | **OpenRouter** | API key | 200+ models |
-| **DeepSeek** | API key | V3, R1 |
+| **DeepSeek** | API key | DeepSeek V4, R1 |
 | **Mistral** | API key | Devstral, Codestral |
 | **Groq** | API key | Fast inference |
-| **z.ai** | API key | GLM-5 |
+| **z.ai** | API key | GLM-4 family |
 | **MiniMax** | API key | MiniMax models |
-| **Kimi Coding** | API key | Kimi K2.5 |
+| **Kimi Coding** | API key | Kimi K2 |
 | **Zenmux** | API key | Aggregated routing |
 | **Ollama** | none | Local inference |
 
@@ -244,7 +248,7 @@ actual_model = "claude-sonnet-4-6"
 priority = 1
 [[models.mappings]]
 provider = "openrouter"
-actual_model = "openai/gpt-5.4"
+actual_model = "openai/gpt-5"
 priority = 2
 
 [router]

--- a/docs/examples/claude-max-oauth.toml
+++ b/docs/examples/claude-max-oauth.toml
@@ -25,6 +25,7 @@ provider_type = "anthropic"
 auth_type = "oauth"  # Use OAuth instead of api_key
 oauth_provider = "anthropic-max"  # References token in TokenStore
 enabled = true
+models = []  # Models are declared in the [[models]] blocks below.
 
 [[models]]
 name = "claude-sonnet"

--- a/docs/examples/deepseek.toml
+++ b/docs/examples/deepseek.toml
@@ -1,27 +1,43 @@
 # DeepSeek Configuration Template
+#
+# Single-provider setup routing everything to DeepSeek's OpenAI-compatible
+# API. The DeepSeek provider speaks the OpenAI wire format, so use
+# provider_type = "openai" with a custom base_url.
 
 [server]
-port = 3456
 host = "127.0.0.1"
+port = 13456
 log_level = "info"
+
+[server.timeouts]
+api_timeout_ms = 600000
+connect_timeout_ms = 10000
 
 [[providers]]
 name = "deepseek"
-api_base_url = "https://api.deepseek.com/chat/completions"
+provider_type = "openai"
+base_url = "https://api.deepseek.com"
 api_key = "$DEEPSEEK_API_KEY"
+enabled = true
 models = ["deepseek-chat", "deepseek-reasoner"]
 
-[providers.transformers]
-use = ["deepseek"]
+[[models]]
+name = "deepseek-chat"
 
-# Optional: Override automatic context detection
-[providers.model_context]
-"deepseek-chat" = 64000
-"deepseek-reasoner" = 64000
+[[models.mappings]]
+provider = "deepseek"
+actual_model = "deepseek-chat"
+priority = 1
+
+[[models]]
+name = "deepseek-reasoner"
+
+[[models.mappings]]
+provider = "deepseek"
+actual_model = "deepseek-reasoner"
+priority = 1
 
 [router]
-default = "deepseek.deepseek-chat"
-background = "deepseek.deepseek-chat"
-think = "deepseek.deepseek-reasoner"
-
-# No longContext configured - Claude Code native mode
+default = "deepseek-chat"
+background = "deepseek-chat"
+think = "deepseek-reasoner"

--- a/docs/examples/mixed.toml
+++ b/docs/examples/mixed.toml
@@ -1,49 +1,70 @@
-# Mixed Provider Configuration with Smart Context Routing
+# Mixed Provider Configuration
+#
+# Combines a local Ollama model for most tasks, DeepSeek for heavier
+# reasoning, and OpenRouter for large-context work. All three speak an
+# OpenAI-compatible wire format. Models with multiple mappings fall back
+# in priority order (lowest priority number first).
 
 [server]
-port = 3456
 host = "127.0.0.1"
+port = 13456
 log_level = "info"
 
-# Local model for most tasks
+[server.timeouts]
+api_timeout_ms = 600000
+connect_timeout_ms = 10000
+
+# Local model for most tasks.
 [[providers]]
 name = "ollama"
-api_base_url = "http://localhost:11434/v1/chat/completions"
-api_key = "ollama"
+provider_type = "openai"
+base_url = "http://localhost:11434/v1"
+api_key = "ollama" # Ollama ignores the key; any non-empty value works.
+enabled = true
 models = ["qwen2.5-coder:latest"]
 
-[providers.model_context]
-"qwen2.5-coder:latest" = 32768
-
-# Cloud model for complex reasoning
+# Cloud model for complex reasoning.
 [[providers]]
 name = "deepseek"
-api_base_url = "https://api.deepseek.com/chat/completions"
+provider_type = "openai"
+base_url = "https://api.deepseek.com"
 api_key = "$DEEPSEEK_API_KEY"
-models = ["deepseek-chat", "deepseek-reasoner"]
+enabled = true
+models = ["deepseek-reasoner"]
 
-[providers.transformers]
-use = ["deepseek"]
-
-[providers.model_context]
-"deepseek-chat" = 64000
-"deepseek-reasoner" = 64000
-
-# Cloud model for large context
+# Cloud model with large context windows.
 [[providers]]
 name = "openrouter"
-api_base_url = "https://openrouter.ai/api/v1/chat/completions"
+provider_type = "openrouter"
 api_key = "$OPENROUTER_API_KEY"
-models = ["google/gemini-2.0-flash-exp"]
+enabled = true
+models = ["google/gemini-2.5-pro"]
 
-[providers.model_context]
-"google/gemini-2.0-flash-exp" = 1000000
+[[models]]
+name = "local-coder"
+
+[[models.mappings]]
+provider = "ollama"
+actual_model = "qwen2.5-coder:latest"
+priority = 1
+
+[[models]]
+name = "reasoner"
+
+[[models.mappings]]
+provider = "deepseek"
+actual_model = "deepseek-reasoner"
+priority = 1
+
+[[models]]
+name = "long-context"
+
+[[models.mappings]]
+provider = "openrouter"
+actual_model = "google/gemini-2.5-pro"
+priority = 1
 
 [router]
-default = "ollama.qwen2.5-coder:latest"
-background = "ollama.qwen2.5-coder:latest"
-think = "deepseek.deepseek-reasoner"
-
-# Optional: Long context routing for large codebases
-longContext = "openrouter.google/gemini-2.0-flash-exp"
-longContextThreshold = 60000                     # Switch when >60K tokens
+default = "local-coder"
+background = "local-coder"
+think = "reasoner"

--- a/docs/examples/models.toml
+++ b/docs/examples/models.toml
@@ -1,43 +1,85 @@
 # Model Mapping Configuration
-# Maps external model names to multiple providers with fallback support
+#
+# Demonstrates how to map one external model name to multiple providers with
+# priority-ordered fallback. A request for `claude-sonnet-4-6` tries the
+# primary provider first (priority 1) and falls back to the next mapping on
+# failure. Every provider referenced by a mapping must have a matching
+# [[providers]] block.
 
-# Example: claude-sonnet-4-6 can use multiple providers
+[server]
+host = "127.0.0.1"
+port = 13456
+log_level = "info"
+
+# ── Providers ────────────────────────────────────────────────────
+[[providers]]
+name = "anthropic-native"
+provider_type = "anthropic"
+api_key = "$ANTHROPIC_API_KEY"
+enabled = true
+models = []
+
+[[providers]]
+name = "openai"
+provider_type = "openai"
+api_key = "$OPENAI_API_KEY"
+enabled = true
+models = []
+
+[[providers]]
+name = "openrouter"
+provider_type = "openrouter"
+api_key = "$OPENROUTER_API_KEY"
+enabled = true
+models = []
+
+[[providers]]
+name = "cerebras"
+provider_type = "openai"
+base_url = "https://api.cerebras.ai/v1"
+api_key = "$CEREBRAS_API_KEY"
+enabled = true
+models = []
+
+# ── Models ───────────────────────────────────────────────────────
+# Multi-provider fallback: Anthropic native first, OpenRouter as backup.
 [[models]]
-name = "claude-sonnet-4-6"  # External model name (used in API requests)
+name = "claude-sonnet-4-6"
 
-  # Primary provider
-  [[models.mappings]]
-  priority = 1
-  provider = "anthropic-native"
-  actual_model = "claude-sonnet-4-6"
+[[models.mappings]]
+priority = 1
+provider = "anthropic-native"
+actual_model = "claude-sonnet-4-6"
 
-  # Fallback provider 1
-  [[models.mappings]]
-  priority = 2
-  provider = "openrouter"
-  actual_model = "anthropic/claude-sonnet-4-6"
+[[models.mappings]]
+priority = 2
+provider = "openrouter"
+actual_model = "anthropic/claude-sonnet-4-6"
 
-# Example: gpt-5.1 mapping
+# Another fallback chain across two providers.
 [[models]]
-name = "gpt-5.1"
+name = "gpt-5"
 
-  [[models.mappings]]
-  priority = 1
-  provider = "openai"
-  actual_model = "gpt-5.1"
+[[models.mappings]]
+priority = 1
+provider = "openai"
+actual_model = "gpt-5"
 
-  [[models.mappings]]
-  priority = 2
-  provider = "openrouter"
-  actual_model = "openai/gpt-5.1"
+[[models.mappings]]
+priority = 2
+provider = "openrouter"
+actual_model = "openai/gpt-5"
 
-# Example: GLM-4.6 with continuation prompt injection
-# Some models stop prematurely after tool calls, inject_continuation_prompt fixes this
+# Continuation-prompt injection: some models stop prematurely after a tool
+# call. inject_continuation_prompt nudges them to keep going.
 [[models]]
-name = "GLM-4.6"
+name = "glm-4-plus"
 
-  [[models.mappings]]
-  priority = 1
-  provider = "cerebras1"
-  actual_model = "zai-glm-4.6"
-  inject_continuation_prompt = true  # Injects "Please continue with the next task." after tool results
+[[models.mappings]]
+priority = 1
+provider = "cerebras"
+actual_model = "zai-glm-4-plus"
+inject_continuation_prompt = true
+
+[router]
+default = "claude-sonnet-4-6"

--- a/docs/examples/ollama.toml
+++ b/docs/examples/ollama.toml
@@ -1,24 +1,42 @@
 # Ollama Local Development Configuration
+#
+# Routes requests to a local Ollama instance via its OpenAI-compatible
+# endpoint. Ollama does not require a real API key, but the OpenAI provider
+# type still expects one, so any placeholder string works.
 
 [server]
-port = 3456
 host = "127.0.0.1"
+port = 13456
 log_level = "info"
+
+[server.timeouts]
+api_timeout_ms = 600000
+connect_timeout_ms = 10000
 
 [[providers]]
 name = "ollama"
-api_base_url = "http://localhost:11434/v1/chat/completions"
-api_key = "ollama"  # Ollama doesn't require real API key
+provider_type = "openai"
+base_url = "http://localhost:11434/v1"
+api_key = "ollama" # Ollama ignores the key; any non-empty value works.
+enabled = true
 models = ["qwen2.5-coder:latest", "deepseek-r1:latest"]
 
-[providers.model_context]
-"qwen2.5-coder:latest" = 32768
-"deepseek-r1:latest" = 64000
+[[models]]
+name = "qwen2.5-coder"
+
+[[models.mappings]]
+provider = "ollama"
+actual_model = "qwen2.5-coder:latest"
+priority = 1
+
+[[models]]
+name = "deepseek-r1"
+
+[[models.mappings]]
+provider = "ollama"
+actual_model = "deepseek-r1:latest"
+priority = 1
 
 [router]
-default = "ollama.qwen2.5-coder:latest"
-think = "ollama.deepseek-r1:latest"
-
-# Optional: Enable long context routing for large files
-longContext = "ollama.deepseek-r1:latest"
-longContextThreshold = 32000                # Switch when >32K tokens
+default = "qwen2.5-coder"
+think = "deepseek-r1"

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -10,7 +10,7 @@ This tutorial walks you through installing Grob, configuring it with a preset, a
 
 ## Step 1: Install Grob
 
-Choose one of three methods:
+Grob ships as a standalone binary. Choose one of two methods:
 
 **Option A: Install script (recommended)**
 
@@ -24,11 +24,9 @@ curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install
 brew install azerozero/tap/grob
 ```
 
-**Option C: Build from source**
-
-```bash
-cargo install --git https://github.com/azerozero/grob
-```
+The install script fetches the latest release binary for your platform from
+[GitHub Releases](https://github.com/azerozero/grob/releases). Container users
+can pull `ghcr.io/azerozero/grob:latest` instead.
 
 Verify the installation:
 
@@ -54,27 +52,28 @@ If you have an Anthropic Pro or Max subscription and want to use OAuth instead o
 
 ## Step 3: Apply a preset
 
-Presets are pre-built configurations that set up providers, models, and routing in one command. Pick the one that matches your setup:
+Presets are pre-built configurations that set up providers, models, and routing in one command. List them with `grob preset list`, then pick the one that matches your setup:
 
-| Preset | Primary provider | Fallback | Monthly cost estimate |
-|--------|-----------------|----------|----------------------|
-| `perf` | Anthropic (Opus + Sonnet) | Anthropic | Subscription only |
-| `medium` | Anthropic OAuth | OpenRouter | Subscription + ~$10-100 |
-| `cheap` | DeepSeek R1 (OpenRouter) | GLM-5 (z.ai) | ~$0.15/M tokens |
-| `local` | Anthropic OAuth | Ollama (local) | Subscription + free |
+| Preset | What it sets up | Monthly cost estimate |
+|--------|-----------------|----------------------|
+| `perf` | Pure Anthropic OAuth (Pro/Max), auto-maps `claude-*` to native | Subscription only |
+| `ultra-cheap` | Stacked free tiers (Groq + Cerebras + Z.ai + OpenRouter `:free`) | ~€0-2/month |
+| `gdpr` | EU-only routing (Mistral, Scaleway, OVH) + DLP | Pay-as-you-go |
+| `eu-ai-act` | EU AI Act compliant (EU providers + transparency headers) | Pay-as-you-go |
+| `eu-eco` / `eu-pro` / `eu-max` | Strict-EU sovereign tiers (budget / balanced / premium) | Pay-as-you-go |
 
-Apply the `medium` preset:
+Apply the `perf` preset (simplest — one Anthropic subscription, no fallbacks):
 
 ```bash
-grob preset apply medium
+grob preset apply perf
 ```
 
-This creates `~/.grob/config.toml` with Anthropic OAuth as the primary for thinking tasks and OpenRouter models for everything else.
+This creates `~/.grob/config.toml` with Anthropic OAuth for every `claude-*` model.
 
 To see what a preset contains before applying:
 
 ```bash
-grob preset info medium
+grob preset info perf
 ```
 
 ## Step 4: Start Grob and launch your tool
@@ -110,7 +109,7 @@ You should see output like:
 ```
 Grob is running (PID 12345)
   Port: 13456
-  Preset: medium
+  Preset: perf
   Spend: $0.00 / $0.00 (no limit)
 ```
 

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -321,7 +321,7 @@ impl AppConfig {
 
             eprintln!("Created default config file at: {}", path.display());
             eprintln!("Please edit the config file to add your providers and models.");
-            eprintln!("Run 'grob preset apply medium' for a quick multi-provider setup.");
+            eprintln!("Run 'grob preset list' to see presets, then 'grob preset apply <name>'.");
         }
 
         Ok(())

--- a/src/preset/README.md
+++ b/src/preset/README.md
@@ -3,7 +3,7 @@
 > Manages builtin and installed config presets: load, apply, overlay, export, validate, sync, credentials.
 
 ## Purpose
-Provides curated TOML config bundles (`perf`, `medium`, `local`, `cheap`, `fast`, `gdpr`, `eu-ai-act`) plus user-installed presets in `~/.grob/presets/`. Merges a preset into an existing config while preserving `[server]` and `[user]`, validates that every routing target resolves to a real provider+model, and orchestrates the credential wizard for providers a preset requires.
+Provides curated TOML config bundles (`perf`, `ultra-cheap`, `gdpr`, `eu-ai-act`, `eu-eco`, `eu-pro`, `eu-max`) plus user-installed presets in `~/.grob/presets/`. Merges a preset into an existing config while preserving `[server]` and `[user]`, validates that every routing target resolves to a real provider+model, and orchestrates the credential wizard for providers a preset requires.
 
 ## Public API
 | Item | Location | Used by |
@@ -16,7 +16,7 @@ Provides curated TOML config bundles (`perf`, `medium`, `local`, `cheap`, `fast`
 | `parse_interval`, `spawn_background_sync`, `sync_presets`, `install_from_source` | `sync.rs` | `start`, `commands::preset` |
 
 ## Owns
-- Seven builtin presets shipped via `include_str!` from `presets/*.toml`.
+- Seven builtin presets auto-discovered via `include_dir!` from `presets/*.toml` (`index.toml` is skipped).
 - TOML merge logic: replaces `[router]`, `[[providers]]`, `[[models]]`, `[security]`, `[compliance]`, `[dlp]` while keeping `[server]` and `[user]` intact, sets `presets.active`.
 - Compliance overlay path: merges only `[security]`, `[compliance]`, `[dlp]`, plus `router.gdpr`/`router.region`.
 - Backup-before-write (`config.toml.backup`) on every apply.

--- a/tests/unit/example_configs_test.rs
+++ b/tests/unit/example_configs_test.rs
@@ -1,0 +1,63 @@
+//! Verifies that every shipped example config in `docs/examples/` parses
+//! into [`AppConfig`] under the current schema.
+//!
+//! These examples were inherited from a `claude-code-router` fork and used
+//! fork-era keys (`api_base_url`, `[providers.transformers]`,
+//! `[providers.model_context]`) that the current `#[serde(deny_unknown_fields)]`
+//! schema rejects. This test pins them to the live schema so the drift cannot
+//! silently return: a malformed example fails CI instead of a user's first run.
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use grob::cli::AppConfig;
+
+    /// Returns the absolute path to the repository's `docs/examples` directory.
+    fn examples_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/examples")
+    }
+
+    /// Collects every `*.toml` file under `docs/examples/`, sorted by name.
+    fn example_toml_files() -> Vec<PathBuf> {
+        let mut files: Vec<PathBuf> = std::fs::read_dir(examples_dir())
+            .expect("docs/examples directory must exist")
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("toml"))
+            .collect();
+        files.sort();
+        files
+    }
+
+    /// Every example TOML deserializes into [`AppConfig`] and passes validation.
+    ///
+    /// Uses `toml::from_str` (schema check) followed by `validate()` (semantic
+    /// check: provider references, regex compilation, auth wiring). Env-var
+    /// resolution is intentionally skipped so the test stays hermetic — a
+    /// literal `"$DEEPSEEK_API_KEY"` placeholder satisfies the api_key
+    /// presence check without requiring the variable to be set.
+    #[test]
+    fn all_example_configs_parse_into_appconfig() {
+        let files = example_toml_files();
+        assert!(
+            !files.is_empty(),
+            "expected at least one example TOML in docs/examples"
+        );
+
+        for path in files {
+            let content = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+            let config: AppConfig = toml::from_str(&content).unwrap_or_else(|e| {
+                panic!(
+                    "example config {} does not parse into AppConfig: {e}",
+                    path.display()
+                )
+            });
+
+            config.validate().unwrap_or_else(|e| {
+                panic!("example config {} failed validation: {e}", path.display())
+            });
+        }
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,5 +1,6 @@
 // Unit tests module
 mod config_test;
+mod example_configs_test;
 mod fan_out_test;
 mod inference_test;
 mod jwt_cache_test;


### PR DESCRIPTION
Repairs a cluster of fork-era artifacts inherited from `claude-code-router`: example configs that no longer parse, README/docs advertising presets that do not exist, model display names drifted from the pricing source of truth, and a `cargo install` line that contradicts the binary-only distribution model.

`pricing.rs` and the real `presets/` directory are treated as the sources of truth — only docs/configs were changed.

## 1. Broken example configs → rewritten to the current schema

`docs/examples/{deepseek,ollama,mixed}.toml` used fork-era keys (`api_base_url`, `[providers.transformers]`, `[providers.model_context]`, `longContext`) and omitted `provider_type`. Since `ProviderConfig`/`AppConfig` carry `#[serde(deny_unknown_fields)]`, they hard-failed to parse.

**Before** (deepseek.toml):
```toml
[[providers]]
name = "deepseek"
api_base_url = "https://api.deepseek.com/chat/completions"
models = ["deepseek-chat", "deepseek-reasoner"]
[providers.transformers]
use = ["deepseek"]
[providers.model_context]
"deepseek-chat" = 64000
[router]
default = "deepseek.deepseek-chat"
```

**After**:
```toml
[[providers]]
name = "deepseek"
provider_type = "openai"
base_url = "https://api.deepseek.com"
api_key = "$DEEPSEEK_API_KEY"
enabled = true
models = ["deepseek-chat", "deepseek-reasoner"]
[[models]]
name = "deepseek-chat"
[[models.mappings]]
provider = "deepseek"
actual_model = "deepseek-chat"
priority = 1
[router]
default = "deepseek-chat"
```

While adding the regression test I found two more examples that also failed to parse:
- `claude-max-oauth.toml` — missing the required `models` field on its provider block → added `models = []`.
- `models.toml` — a fragment with no `[router]` and referencing undeclared providers → made self-contained (real `[[providers]]` + `[router]`), and aligned its example model names to `pricing.rs` (`gpt-5.1`→`gpt-5`, `GLM-4.6`→`glm-4-plus`).

### Verification that the configs now parse
Added `tests/unit/example_configs_test.rs::all_example_configs_parse_into_appconfig`, which globs **every** `docs/examples/*.toml`, runs `toml::from_str::<AppConfig>` (schema check) and `AppConfig::validate()` (semantic check), and panics with the file path on any failure.

- Before the fixes the test failed on `deepseek.toml`/`ollama.toml`/`mixed.toml` (unknown fields), then surfaced the `claude-max-oauth.toml` (`missing field models`) and `models.toml` (`missing field router`) gaps.
- After the fixes: `cargo test --test lib all_example_configs_parse_into_appconfig` → `1 passed`.
- Full suite: `cargo test --lib` → `1178 passed`; `cargo test --test lib` → `267 passed`.

## 2. Ghost presets → real presets

README + `src/preset/README.md` advertised `medium`, `cheap`, `local`, `fast` — none of which exist; `grob preset apply cheap` fails. The real shipped presets (auto-discovered from `presets/*.toml` via `include_dir!`) are: **perf, ultra-cheap, gdpr, eu-ai-act, eu-eco, eu-pro, eu-max**.

- **README.md**: preset table rewritten to the 7 real presets using their `[meta] description` text.
- **src/preset/README.md**: Purpose line `perf, medium, local, cheap, fast, gdpr, eu-ai-act` → the 7 real names; also corrected "shipped via `include_str!`" → "auto-discovered via `include_dir!` (`index.toml` skipped)".
- **getting-started.md**: preset table + `apply`/`info` commands + status sample switched from `medium` to real presets (`perf` as the tutorial default).
- **src/models/config.rs**: first-run hint `Run 'grob preset apply medium'` → `Run 'grob preset list' ... 'grob preset apply <name>'` (it was emitting a command that fails).

## 3. Model display names → aligned to `pricing.rs` SSOT

`pricing.rs` only knows `gemini-2.5-pro` (no flash), `glm-4*`, `kimi-k2*`, `claude-opus-4-7`. Routing to a marketed-but-unknown name silently misses spend tracking.

| Location | Before | After |
|----------|--------|-------|
| README routing diagram | `Opus 4.6` | `Opus 4.7` (`claude-opus-4-7`) |
| README routing diagram | `Gemini 3 Pro` | `Gemini 2.5 Pro` (`gemini-2.5-pro`) |
| README routing diagram | `Gemini 3 Flash` | `Haiku 4.5` (`claude-haiku-4-5`, the real `perf` background model) |
| README watch sample | `gemini-3-flash` | `gemini-2.5-pro` |
| README providers table | DeepSeek `V3, R1` | `DeepSeek V4, R1` |
| README providers table | z.ai `GLM-5` | `GLM-4 family` |
| README providers table | Kimi `Kimi K2.5` | `Kimi K2` |
| README config example | `openai/gpt-5.4` | `openai/gpt-5` |

`Sonnet 4.6` was left untouched (`claude-sonnet-4-6` is in `pricing.rs`).

## 4. Install instructions → binary-only model

`getting-started.md:30` showed `cargo install --git https://github.com/azerozero/grob`, which contradicts the binary-only distribution (crates.io/grob is the unrelated Coding-Badly project). Replaced "Option C: Build from source" with a note that the install script fetches release binaries, plus the container image reference. install.sh / Homebrew paths retained.

## Gates
- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --all-targets --no-default-features --features dlp,oauth,tap,compliance,mcp,watch,policies,socket-opts,dirs -- -D warnings` — clean
- `cargo test --lib` — 1178 passed
- `cargo test --test lib` — 267 passed (incl. the new example-config-loads test)
- `markdownlint-cli2` — not installed locally (skipped per gate); `.markdownlint.json` disables MD013/line-length and allows tables/HTML, which the edits respect.
- Pre-commit + pre-push hooks (gitleaks, cargo-deny, cargo-audit, doc-coverage, machete, lychee link check) — all passed on commit and push.

## Out of scope (follow-up)
The same ghost-preset references (`grob preset apply medium`) and model-name drift (`GLM-5`, `Gemini Flash`) still exist in `docs/reference/{operations,cli,errors}.md` and `docs/explanation/design-principles.md`. Left untouched to keep this PR aligned with the audit's named files; worth a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)