### PR TITLE
fix(policies): key/sign decision & HIT tokens (was unkeyed SHA-256)

### DIFF
--- a/src/features/policies/decision_token.rs
+++ b/src/features/policies/decision_token.rs
@@ -2,10 +2,17 @@
 //!
 //! A decision token is an MCP token emitted by a boss agent, invisible to the
 //! target agent. Grob reads the `mode` claim to route toward the correct backend
-//! (paper for training, real for live). The agent cannot read or modify this token.
+//! (paper for training, real for live). The token travels over the MCP transport
+//! and is serialized to JSON, so it crosses a trust boundary: an adversary on
+//! that path could otherwise flip `mode` (training → live) to escape the paper
+//! sandbox. To prevent this, each token carries an HMAC-SHA256 tag keyed by the
+//! process policy secret (see [`crate::features::policies::signing`]); only a
+//! holder of that secret can mint or alter a token, so a tampered token fails
+//! [`DecisionToken::verify_integrity`].
 
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+
+use super::signing;
 
 /// Operating mode carried by a decision token.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -59,8 +66,8 @@ pub enum DecisionTokenError {
     /// Mode claim has an unrecognized value.
     #[error("unknown decision token mode: {0}")]
     UnknownMode(String),
-    /// Token hash does not match computed hash (tampered).
-    #[error("decision token integrity check failed")]
+    /// Token authentication tag does not match (tampered or wrong key).
+    #[error("decision token authentication failed")]
     IntegrityFailure,
     /// Token issuer is not authorized.
     #[error("decision token issuer '{0}' is not authorized")]
@@ -89,7 +96,8 @@ pub struct DecisionClaims {
 
 /// A decision token issued by a boss agent.
 ///
-/// Contains claims readable only by grob, plus a SHA-256 integrity hash.
+/// Contains claims readable only by grob, plus a keyed HMAC-SHA256 tag that
+/// authenticates the claims against the policy secret.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DecisionToken {
     /// Unique token identifier.
@@ -100,8 +108,8 @@ pub struct DecisionToken {
     pub claims: DecisionClaims,
     /// ISO-8601 timestamp of issuance.
     pub issued_at: String,
-    /// SHA-256 integrity hash.
-    pub hash: String,
+    /// Hex-encoded HMAC-SHA256 authentication tag over the token fields.
+    pub mac: String,
 }
 
 /// Discriminates session tokens from decision tokens.
@@ -136,7 +144,7 @@ pub struct AgentVisibleToken {
 }
 
 impl DecisionToken {
-    /// Creates a new decision token with computed integrity hash.
+    /// Creates a new decision token signed with the policy key.
     pub fn new(token_id: String, claims: DecisionClaims) -> Self {
         let issued_at = chrono::Utc::now().to_rfc3339();
         let mut token = Self {
@@ -144,35 +152,43 @@ impl DecisionToken {
             token_type: TokenType::Decision,
             claims,
             issued_at,
-            hash: String::new(),
+            mac: String::new(),
         };
-        token.hash = token.compute_hash();
+        token.mac = signing::compute_tag(&token.signing_bytes());
         token
     }
 
-    /// Computes SHA-256 hash over token fields for integrity verification.
-    fn compute_hash(&self) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(self.token_id.as_bytes());
-        hasher.update(self.token_type.to_string().as_bytes());
-        hasher.update(self.claims.mode.to_string().as_bytes());
-        hasher.update(self.claims.issuer.as_bytes());
-        hasher.update(self.claims.audience.as_bytes());
-        hasher.update(self.issued_at.as_bytes());
-        if let Some(ref exp) = self.claims.expires_at {
-            hasher.update(exp.as_bytes());
+    /// Returns the canonical byte string the MAC authenticates.
+    ///
+    /// Field order and the `\0` separator are part of the wire contract: the
+    /// separator prevents adjacent fields from being shifted across boundaries
+    /// (e.g. issuer `"a"` + audience `"bc"` colliding with `"ab"` + `"c"`).
+    fn signing_bytes(&self) -> Vec<u8> {
+        let mut data = Vec::new();
+        for part in [
+            self.token_id.as_str(),
+            self.token_type.to_string().as_str(),
+            self.claims.mode.to_string().as_str(),
+            self.claims.issuer.as_str(),
+            self.claims.audience.as_str(),
+            self.issued_at.as_str(),
+            self.claims.expires_at.as_deref().unwrap_or(""),
+        ] {
+            data.extend_from_slice(part.as_bytes());
+            data.push(0);
         }
-        hex::encode(hasher.finalize())
+        data
     }
 
-    /// Verifies token integrity (hash matches computed value).
+    /// Verifies the token's HMAC tag against the policy key.
     ///
     /// # Errors
     ///
-    /// Returns [`DecisionTokenError::IntegrityFailure`] if the stored
-    /// hash does not match the recomputed hash.
+    /// Returns [`DecisionTokenError::IntegrityFailure`] if the stored tag is
+    /// not a valid HMAC-SHA256 over the token fields under the policy key,
+    /// i.e. the token was tampered with or signed with a different key.
     pub fn verify_integrity(&self) -> Result<(), DecisionTokenError> {
-        if self.hash != self.compute_hash() {
+        if !signing::verify_tag(&self.signing_bytes(), &self.mac) {
             return Err(DecisionTokenError::IntegrityFailure);
         }
         Ok(())
@@ -182,8 +198,8 @@ impl DecisionToken {
     ///
     /// # Errors
     ///
-    /// Returns [`DecisionTokenError::IntegrityFailure`] if integrity
-    /// verification fails before resolving the backend.
+    /// Returns [`DecisionTokenError::IntegrityFailure`] if authentication
+    /// fails before resolving the backend.
     pub fn resolve_backend(&self) -> Result<BackendTarget, DecisionTokenError> {
         self.verify_integrity()?;
         Ok(match self.claims.mode {
@@ -328,6 +344,36 @@ mod tests {
     }
 
     #[test]
+    fn test_forged_token_with_recomputed_plain_hash_rejected() {
+        // The original attack: flip Training -> Live and recompute a *plain*
+        // SHA-256 over the fields. Without the policy key, the recomputed
+        // digest is not a valid HMAC tag, so verification must still fail.
+        use sha2::{Digest as _, Sha256};
+
+        let token =
+            DecisionToken::new("tok-forge".to_string(), boss_claims(DecisionMode::Training));
+        let mut forged = token.clone();
+        forged.claims.mode = DecisionMode::Live;
+
+        // Attacker recomputes an unkeyed hash over the tampered fields.
+        let mut hasher = Sha256::new();
+        hasher.update(forged.token_id.as_bytes());
+        hasher.update(forged.token_type.to_string().as_bytes());
+        hasher.update(forged.claims.mode.to_string().as_bytes());
+        hasher.update(forged.claims.issuer.as_bytes());
+        hasher.update(forged.claims.audience.as_bytes());
+        hasher.update(forged.issued_at.as_bytes());
+        forged.mac = hex::encode(hasher.finalize());
+
+        assert_eq!(
+            forged.verify_integrity(),
+            Err(DecisionTokenError::IntegrityFailure),
+            "forged token with recomputed plain hash must be rejected"
+        );
+        assert_eq!(route_by_decision_token(&forged), BackendTarget::Deny);
+    }
+
+    #[test]
     fn test_mode_from_str() {
         assert_eq!(
             "training".parse::<DecisionMode>().unwrap(),
@@ -369,7 +415,7 @@ mod tests {
         let deserialized: DecisionToken = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.token_id, token.token_id);
         assert_eq!(deserialized.claims.mode, token.claims.mode);
-        assert_eq!(deserialized.hash, token.hash);
+        assert_eq!(deserialized.mac, token.mac);
         assert!(deserialized.verify_integrity().is_ok());
     }
 }

--- a/src/features/policies/hit_auth.rs
+++ b/src/features/policies/hit_auth.rs
@@ -1,7 +1,21 @@
-//! HIT authorization: per-action cryptographic proof of human approval.
+//! HIT authorization: per-action keyed proof of human approval.
+//!
+//! Each [`HitAuthorization`] records that a human approved or denied a tool_use
+//! action. Receipts are serialized to JSON, persisted to the audit log on disk,
+//! and posted over HTTP to the approval endpoint, so they cross trust
+//! boundaries: an adversary with write access to a persisted receipt could
+//! otherwise flip `decision` (deny → approve) and recompute the hash.
+//!
+//! To make the proof meaningful against such an adversary, each receipt carries
+//! a keyed HMAC-SHA256 tag (the `hash` field) over its fields and the previous
+//! receipt's tag. Only a holder of the policy secret (see
+//! [`crate::features::policies::signing`]) can mint a receipt or extend the
+//! chain, so a forged or tampered receipt fails [`HitAuthorization::verify`].
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
+use super::signing;
 
 /// Authorization decision for a tool_use action.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -64,7 +78,7 @@ pub struct HitAuthParams {
     pub auth_method: AuthMethod,
     /// Who approved (user identifier).
     pub signer: String,
-    /// SHA-256 hash of the previous authorization (chain link).
+    /// Keyed HMAC tag of the previous authorization (chain link).
     pub previous_hash: Option<String>,
 }
 
@@ -85,10 +99,10 @@ pub struct HitAuthorization {
     pub signer: String,
     /// ISO-8601 timestamp.
     pub timestamp: String,
-    /// SHA-256 hash of the previous authorization (chain link).
+    /// Keyed HMAC tag of the previous authorization (chain link).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub previous_hash: Option<String>,
-    /// SHA-256 hash of this authorization entry.
+    /// Keyed HMAC-SHA256 tag of this authorization entry.
     pub hash: String,
 }
 
@@ -110,34 +124,46 @@ impl HitAuthorization {
             hash: String::new(),
         };
 
-        entry.hash = entry.compute_hash();
+        entry.hash = signing::compute_tag(&entry.signing_bytes());
         entry
     }
 
-    /// Computes the SHA-256 hash of this entry (for chain integrity).
+    /// Returns the canonical byte string the HMAC tag authenticates.
     ///
-    /// NOTE: auth_method and signer were added to the hash input in v0.x.
-    /// This is a breaking change: hashes computed before this change will
-    /// not match hashes computed after it. Existing chains must be
-    /// re-hashed or treated as legacy.
-    fn compute_hash(&self) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(self.request_id.as_bytes());
-        hasher.update(self.tool_name.as_bytes());
-        hasher.update(self.tool_input_hash.as_bytes());
-        hasher.update(self.decision.to_string().as_bytes());
-        hasher.update(self.auth_method.to_string().as_bytes());
-        hasher.update(self.signer.as_bytes());
-        hasher.update(self.timestamp.as_bytes());
-        if let Some(ref prev) = self.previous_hash {
-            hasher.update(prev.as_bytes());
+    /// The `\0` separator after each field prevents adjacent fields from being
+    /// shifted across boundaries without changing the tag. Chaining the
+    /// previous tag binds each receipt to its predecessor, so a tampered or
+    /// reordered chain cannot be re-tagged without the policy key.
+    ///
+    /// NOTE: `auth_method` and `signer` are part of the signed input. Tags
+    /// computed before they were added do not match; legacy chains must be
+    /// re-signed or treated as legacy.
+    fn signing_bytes(&self) -> Vec<u8> {
+        let mut data = Vec::new();
+        for part in [
+            self.request_id.as_str(),
+            self.tool_name.as_str(),
+            self.tool_input_hash.as_str(),
+            self.decision.to_string().as_str(),
+            self.auth_method.to_string().as_str(),
+            self.signer.as_str(),
+            self.timestamp.as_str(),
+            self.previous_hash.as_deref().unwrap_or(""),
+        ] {
+            data.extend_from_slice(part.as_bytes());
+            data.push(0);
         }
-        hex::encode(hasher.finalize())
+        data
     }
 
-    /// Verifies the hash chain integrity of this entry.
+    /// Verifies this entry's keyed HMAC tag against the policy key.
+    ///
+    /// Returns `true` only when `hash` is a valid HMAC-SHA256 over the entry
+    /// fields (including the chained `previous_hash`) under the policy key.
+    /// A tampered receipt, or one forged without the key, returns `false`.
+    #[must_use]
     pub fn verify(&self) -> bool {
-        self.hash == self.compute_hash()
+        signing::verify_tag(&self.signing_bytes(), &self.hash)
     }
 }
 
@@ -213,6 +239,68 @@ mod tests {
 
         auth.decision = AuthDecision::Deny;
         assert!(!auth.verify());
+    }
+
+    #[test]
+    fn test_forged_receipt_with_recomputed_plain_hash_rejected() {
+        // The original attack: flip Deny -> Approve and recompute a *plain*
+        // SHA-256 over the fields. Without the policy key the digest is not a
+        // valid HMAC tag, so verification must still fail.
+        let auth = HitAuthorization::new(test_params("user", AuthDecision::Deny));
+        let mut forged = auth.clone();
+        forged.decision = AuthDecision::Approve;
+
+        let mut hasher = Sha256::new();
+        hasher.update(forged.request_id.as_bytes());
+        hasher.update(forged.tool_name.as_bytes());
+        hasher.update(forged.tool_input_hash.as_bytes());
+        hasher.update(forged.decision.to_string().as_bytes());
+        hasher.update(forged.auth_method.to_string().as_bytes());
+        hasher.update(forged.signer.as_bytes());
+        hasher.update(forged.timestamp.as_bytes());
+        forged.hash = hex::encode(hasher.finalize());
+
+        assert!(
+            !forged.verify(),
+            "forged receipt with recomputed plain hash must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_chain_tamper_rebuild_rejected() {
+        // An adversary editing a persisted chain cannot re-tag it without the
+        // key: re-running the unkeyed hash over a tampered chain still fails.
+        let a1 = HitAuthorization::new(test_params("alice", AuthDecision::Approve));
+        let mut a2 = HitAuthorization::new(HitAuthParams {
+            request_id: "req-2".into(),
+            tool_name: "Bash".into(),
+            tool_input: "rm -rf /".into(),
+            decision: AuthDecision::Deny,
+            auth_method: AuthMethod::Prompt,
+            signer: "bob".into(),
+            previous_hash: Some(a1.hash.clone()),
+        });
+        assert!(a2.verify());
+
+        // Flip the decision and naively re-tag with an unkeyed hash.
+        a2.decision = AuthDecision::Approve;
+        let mut hasher = Sha256::new();
+        hasher.update(a2.request_id.as_bytes());
+        hasher.update(a2.tool_name.as_bytes());
+        hasher.update(a2.tool_input_hash.as_bytes());
+        hasher.update(a2.decision.to_string().as_bytes());
+        hasher.update(a2.auth_method.to_string().as_bytes());
+        hasher.update(a2.signer.as_bytes());
+        hasher.update(a2.timestamp.as_bytes());
+        if let Some(ref prev) = a2.previous_hash {
+            hasher.update(prev.as_bytes());
+        }
+        a2.hash = hex::encode(hasher.finalize());
+
+        assert!(
+            !a2.verify(),
+            "re-tagged tampered chain link must be rejected"
+        );
     }
 
     #[test]

--- a/src/features/policies/mod.rs
+++ b/src/features/policies/mod.rs
@@ -15,5 +15,6 @@ pub mod multisig;
 pub mod quorum;
 pub mod resolved;
 pub mod scoring;
+pub mod signing;
 #[cfg(feature = "policies")]
 pub mod stream;

--- a/src/features/policies/signing.rs
+++ b/src/features/policies/signing.rs
@@ -1,0 +1,133 @@
+//! Keyed authentication for policy tokens (decision tokens, HIT receipts).
+//!
+//! Policy tokens cross trust boundaries: decision tokens travel over the MCP
+//! transport between a boss agent and grob, and HIT authorization receipts are
+//! serialized to disk and posted over HTTP. A plain (unkeyed) hash provides no
+//! protection there — an adversary who can edit a serialized token simply
+//! recomputes the hash. These functions bind a token to a secret key via
+//! HMAC-SHA256 so that only a holder of the key can produce a valid tag.
+//!
+//! The key is derived from `GROB_POLICY_SECRET` (falling back to the existing
+//! `GROB_DLP_SECRET`) using the same HMAC-based key-derivation pattern as the
+//! DLP name anonymizer. When neither is set a random per-process key is
+//! generated: tokens stay unforgeable within a run but do not survive a
+//! restart, and a warning is logged.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::sync::OnceLock;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Process-wide derived policy signing key, computed once on first use.
+static POLICY_KEY: OnceLock<[u8; 32]> = OnceLock::new();
+
+/// Returns the process-wide policy signing key, deriving it on first call.
+///
+/// The key is derived once and cached for the lifetime of the process so that
+/// every token shares a single, stable key without re-reading the environment.
+fn policy_key() -> &'static [u8; 32] {
+    POLICY_KEY.get_or_init(derive_key)
+}
+
+/// Derives a 32-byte signing key from the configured policy secret.
+///
+/// Prefers `GROB_POLICY_SECRET`, then `GROB_DLP_SECRET`, so deployments that
+/// already provision a DLP secret keep stable tokens without extra config.
+/// Falls back to a random per-process key when no secret is configured.
+fn derive_key() -> [u8; 32] {
+    // NOTE: Domain separator for the HMAC-based KDF. This is a public constant
+    // for domain separation, not a secret; the secret comes from the env var.
+    const KDF_DOMAIN: &[u8] = b"grob-policy-token-key-derivation-v1"; // CodeQL: hard-coded-cryptographic-value — intentional domain separator, not a secret.
+
+    let secret = std::env::var("GROB_POLICY_SECRET")
+        .or_else(|_| std::env::var("GROB_DLP_SECRET"))
+        .ok();
+
+    match secret {
+        Some(secret) => {
+            let mut mac = HmacSha256::new_from_slice(KDF_DOMAIN)
+                .expect("invariant: KDF_DOMAIN is a fixed non-empty key, always valid for HMAC");
+            mac.update(secret.as_bytes());
+            mac.finalize().into_bytes().into()
+        }
+        None => {
+            tracing::warn!(
+                "policies: neither GROB_POLICY_SECRET nor GROB_DLP_SECRET is set; \
+                 generating a random per-process policy signing key. Decision tokens \
+                 and HIT receipts will not verify across restarts or across hosts. \
+                 Set GROB_POLICY_SECRET to a shared secret for stable, cross-process tokens."
+            );
+            let mut key = [0u8; 32]; // CodeQL: hard-coded-cryptographic-value — zero-initialized buffer, immediately overwritten with CSPRNG output.
+            rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut key);
+            key
+        }
+    }
+}
+
+/// Computes a hex-encoded HMAC-SHA256 tag over `data` using the policy key.
+///
+/// The returned tag authenticates `data`: only a holder of the policy key can
+/// produce a tag that [`verify_tag`] accepts, so a tampered token is rejected.
+#[must_use]
+pub fn compute_tag(data: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(policy_key())
+        .expect("invariant: policy_key is [u8; 32], always valid for HMAC-SHA256");
+    mac.update(data);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+/// Verifies a hex-encoded HMAC-SHA256 tag against `data` in constant time.
+///
+/// Returns `true` only when `tag_hex` is the valid tag for `data` under the
+/// policy key. Comparison is constant-time to avoid leaking the tag via timing.
+#[must_use]
+pub fn verify_tag(data: &[u8], tag_hex: &str) -> bool {
+    let Ok(provided) = hex::decode(tag_hex) else {
+        return false;
+    };
+    let mut mac = HmacSha256::new_from_slice(policy_key())
+        .expect("invariant: policy_key is [u8; 32], always valid for HMAC-SHA256");
+    mac.update(data);
+    let expected = mac.finalize().into_bytes();
+    // Length check first; ct_eq over mismatched lengths would short-circuit anyway.
+    if provided.len() != expected.len() {
+        return false;
+    }
+    provided.ct_eq(&expected).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag_roundtrips() {
+        let tag = compute_tag(b"decision-token-fields");
+        assert!(verify_tag(b"decision-token-fields", &tag));
+    }
+
+    #[test]
+    fn tampered_data_fails() {
+        let tag = compute_tag(b"mode=training");
+        assert!(!verify_tag(b"mode=live", &tag));
+    }
+
+    #[test]
+    fn garbage_tag_fails() {
+        assert!(!verify_tag(b"data", "not-hex-zzzz"));
+        assert!(!verify_tag(b"data", "deadbeef"));
+    }
+
+    #[test]
+    fn tag_is_keyed_not_plain_sha256() {
+        // A plain SHA-256 over the same bytes must NOT match the HMAC tag,
+        // proving the tag depends on the secret key, not just the data.
+        use sha2::Digest as _;
+        let data = b"authorize";
+        let plain = hex::encode(Sha256::digest(data));
+        let keyed = compute_tag(data);
+        assert_ne!(plain, keyed, "HMAC tag must differ from unkeyed SHA-256");
+    }
+}


### PR DESCRIPTION
## Finding (Critical)

Decision tokens and HIT authorization receipts presented "integrity" / "cryptographic proof of human approval" but were backed only by an **unkeyed SHA-256** over the token's own fields.

## Threat model (investigated first)

Both token types cross trust boundaries, so the unkeyed hash is forgeable:

- **`DecisionToken`** (`decision_token.rs`) — an MCP token a boss agent emits to route an agent to the paper (training) vs real (live) backend. It is `Serialize`/`Deserialize` and travels over the MCP transport. An adversary on that path can flip `mode: Training -> Live` (escaping the paper sandbox), recompute the plain SHA-256, and pass `verify_integrity`.
- **`HitAuthorization`** (`hit_auth.rs`) — a per-action human-approval receipt. It is serialized to JSON, **persisted to the on-disk audit log** (`backend_routed: receipt_json` in `stream/mod.rs`), **posted over HTTP** to `hit_approve_handler` (`server/mod.rs`), and collected by `MultiSigCollector`. An adversary with write access to a persisted receipt can flip `decision: Deny -> Approve` and recompute the hash. The `previous_hash` chain offered no protection either: an unkeyed chain can be fully recomputed after tampering.

Both clearly cross adversarial boundaries, so the **keyed** path is the correct fix (not the doc-downgrade path).

## Fix chosen + rationale

Bind both token types to a process **policy secret** via **HMAC-SHA256**, reusing the repo's existing `GROB_DLP_SECRET`-style pattern (`dlp/names.rs`) and constant-time comparison (`subtle`, as in `server/middleware.rs`):

- **New `features::policies::signing`** — derives a 32-byte key from `GROB_POLICY_SECRET` (falling back to the existing `GROB_DLP_SECRET` so deployments that already provision a DLP secret keep stable, cross-process tokens), via an HMAC-based KDF with a domain separator. Random per-process key + warning when no secret is set. `compute_tag` / `verify_tag` (constant-time).
- **`DecisionToken`** — `hash` field replaced by a keyed `mac`; `verify_integrity` checks the HMAC under the policy key. Canonical signing bytes use a NUL field separator to prevent field-boundary ambiguity.
- **`HitAuthorization`** — the `hash` / `previous_hash` chain is now keyed HMAC-SHA256, so the chain is meaningful against an adversary (no key -> can't re-tag a tampered chain).
- **Docs rewritten** to describe keyed authentication, dropping the security-theater "integrity" claims.

No call sites needed changes: `DecisionToken` is used only within its own module, and the `HitAuthorization` chain field names (`hash` / `previous_hash`) were preserved.

## Test coverage

- `signing`: tag roundtrip, tampered-data rejection, garbage/short tag rejection, and a test proving the tag differs from an unkeyed SHA-256 (i.e. it is keyed).
- `decision_token`: **forged token with a recomputed *plain* SHA-256 is rejected** (the original Training->Live attack) and routes to `Deny`.
- `hit_auth`: **forged receipt with a recomputed plain hash is rejected** (Deny->Approve), and a **naively re-tagged tampered chain link fails verification**.
- All pre-existing tests (incl. multisig chain) still pass.

## Gates

- `cargo fmt --all` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo clippy --all-targets --no-default-features --features dlp,oauth,tap,compliance,mcp,watch,policies,socket-opts,dirs -- -D warnings` — pass
- `cargo test --lib` (1185 passed) / `cargo test --test lib` (266 passed) — pass
- `RUSTDOCFLAGS='-W missing-docs' cargo doc --no-deps` — no new missing-docs / broken links

## Risks / follow-ups

- **Key rollout**: receipts/tokens minted before this change verify only if the same secret was already in use; without a configured secret, tokens are per-process (documented + warned). An operator-facing config knob for the policy signing key (mirroring the audit-log signer) is a reasonable follow-up but out of scope here.
- HMAC is symmetric: any holder of the secret can mint tokens. If asymmetric provenance (only the boss can mint) is later required, `signed_config.rs`'s ECDSA P-256 path is the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
