### PR TITLE
refactor: break features↔models & auth↔providers cycles, split two god functions

### DIFF
--- a/src/auth/auto_flow.rs
+++ b/src/auth/auto_flow.rs
@@ -11,7 +11,12 @@ use std::io::{self, BufRead, Write};
 use crate::auth::device_code::{device_auth_url_for, headless_requested, DeviceCodeClient};
 use crate::auth::oauth::{OAuthClient, OAuthConfig};
 use crate::auth::token_store::TokenStore;
-use crate::providers::{AuthType, ProviderConfig};
+// NOTE: Import config types from their canonical home `cli::config` (re-exported
+// at `crate::cli`) rather than the `providers` re-export. `providers` depends on
+// `auth` (for `TokenStore`/OAuth), so reaching into `providers` here closed an
+// `auth ↔ providers` cycle. `auth → cli::config` is the sanctioned dependency
+// direction documented in `auth/README.md`.
+use crate::cli::{AuthType, ProviderConfig};
 
 /// Status of a single provider's credentials.
 pub enum CredentialStatus {

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -3,7 +3,7 @@
 > Defines the clap argument tree, the static TOML schema, and validated newtypes.
 
 ## Purpose
-Owns the user-facing surface of grob: every CLI flag, every subcommand declaration, and the strongly-typed config structs that the TOML loader deserializes into. Stays a leaf module so the rest of the crate depends on it without forming a cycle. Re-exports `AppConfig` from `models::config` for backwards compatibility.
+Owns the user-facing surface of grob: every CLI flag, every subcommand declaration, and the strongly-typed config structs that the TOML loader deserializes into. Stays a leaf module so the rest of the crate depends on it without forming a cycle. Re-exports `AppConfig` from `crate::config` for backwards compatibility.
 
 ## Public API
 | Item | Location | Used by |
@@ -11,7 +11,7 @@ Owns the user-facing surface of grob: every CLI flag, every subcommand declarati
 | `Cli`, `Commands` (clap derive) | `args.rs` | `main.rs`, `commands/*` |
 | `detect_bare_trailing_cmd` | `args.rs` | `main.rs` (UX guard) |
 | `*Action` enums (`KeyAction`, `SecretsAction`, `PresetAction`, `LogsAction`, `HarnessAction`) | `args.rs` | `commands/*` dispatchers |
-| `ServerConfig`, `RouterConfig`, `ProviderConfig`, `ModelConfig` | `config/{server,routing,providers}.rs` | `models::config`, providers |
+| `ServerConfig`, `RouterConfig`, `ProviderConfig`, `ModelConfig` | `config/{server,routing,providers}.rs` | `crate::config`, providers |
 | `SecurityConfig`, `ComplianceConfig`, `TeeConfig`, `FipsConfig` | `config/security.rs` | `security/*` |
 | `BudgetConfig`, `CacheConfig`, `TracingConfig`, `OtelConfig` | `config/{budget,cache,telemetry}.rs` | features layer |
 | `SecretsConfig`, `SecretsBackend`, `SecretsFileConfig` | `config/secrets.rs` | `auth::secrets` |
@@ -28,10 +28,10 @@ Owns the user-facing surface of grob: every CLI flag, every subcommand declarati
 ## Depends on
 - `clap`, `clap_complete`, `serde`, `toml` for derive plumbing.
 - `crate::features::log_export::LogExportConfig` and `crate::features::tool_layer::config::ToolLayerConfig` (re-exported).
-- `crate::models::config::AppConfig` (re-exported to break the historical cycle).
+- `crate::config::AppConfig` (re-exported for backwards compatibility).
 
 ## Non-goals
-- Reading or writing config files (`models::config` and `commands::*` handle I/O).
+- Reading or writing config files (`crate::config` and `commands::*` handle I/O).
 - Implementing subcommand logic (lives in `commands/*`).
 - Runtime configuration mutation. Config is static once loaded; see ADR-0001.
 - Provider behaviour or routing logic.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,11 +21,10 @@ pub use config::{
 };
 pub use newtypes::{BodySizeLimit, BudgetUsd, ConfigSource, Port};
 
-// Re-export AppConfig and related helpers from models::config for backwards
-// compatibility. Canonical path is `crate::models::config::AppConfig` — this
-// re-export keeps existing `crate::cli::AppConfig` call sites working while
-// breaking the dependency edge that previously made `cli` part of the mega-SCC.
-pub use crate::models::config::{find_project_config, merge_project_config, AppConfig};
+// Re-export AppConfig and related helpers from the top-level `config` module for
+// backwards compatibility. Canonical path is `crate::config::AppConfig` — this
+// re-export keeps existing `crate::cli::AppConfig` call sites working.
+pub use crate::config::{find_project_config, merge_project_config, AppConfig};
 
 /// Format a bind address with proper IPv6 bracket notation.
 /// IPv6 hosts (containing `:`) are wrapped in brackets: `[::1]:13456`

--- a/src/commands/bench/mod.rs
+++ b/src/commands/bench/mod.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 
 use crate::auth::virtual_keys::{generate_key, VirtualKeyRecord};
-use crate::models::config::AppConfig;
+use crate::config::AppConfig;
 use crate::storage::GrobStore;
 
 use mock::{start_mock_backend, start_proxy, ProxyState};

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -89,7 +89,7 @@ pub async fn stop_service(pid: u32) -> anyhow::Result<()> {
 
 /// Starts the Grob server in the foreground, writing the PID file and handling SIGTERM for graceful shutdown.
 pub async fn start_foreground(
-    config: crate::models::config::AppConfig,
+    config: crate::config::AppConfig,
     config_source: crate::cli::ConfigSource,
 ) -> anyhow::Result<()> {
     if let Err(e) = crate::shared::pid::write_pid() {

--- a/src/commands/harness.rs
+++ b/src/commands/harness.rs
@@ -1,8 +1,8 @@
 //! CLI command: `grob harness record` / `grob harness replay`.
 
 use crate::cli::args::HarnessAction;
+use crate::config::AppConfig;
 use crate::features::harness::{load_tape, Driver, DriverConfig, MockBackend, MockConfig};
-use crate::models::config::AppConfig;
 use std::path::PathBuf;
 
 /// Dispatches harness subcommands.

--- a/src/commands/setup/output.rs
+++ b/src/commands/setup/output.rs
@@ -142,7 +142,7 @@ pub(in crate::commands::setup) fn print_exports(c: &Choices) {
 
 /// Chains `grob doctor` after the wizard writes the config.
 pub(in crate::commands::setup) async fn chain_doctor(config_path: &Path) {
-    let Ok(config) = crate::models::config::AppConfig::from_file(config_path) else {
+    let Ok(config) = crate::config::AppConfig::from_file(config_path) else {
         return;
     };
     let source = crate::cli::ConfigSource::File(config_path.to_path_buf());
@@ -166,7 +166,7 @@ pub(in crate::commands::setup) async fn chain_auto_flow(config_path: &Path, flag
     if flags.yes || !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         return;
     }
-    let Ok(config) = crate::models::config::AppConfig::from_file(config_path) else {
+    let Ok(config) = crate::config::AppConfig::from_file(config_path) else {
         return;
     };
     let Ok(store) = crate::storage::GrobStore::open(&crate::storage::GrobStore::default_path())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,14 @@
 //! Top-level application configuration.
 //!
-//! [`AppConfig`] lives here (rather than under `crate::cli`) so consumers
-//! can depend on a leaf module instead of pulling the whole `cli` graph.
+//! [`AppConfig`](crate::config::AppConfig) aggregates every config section, including feature config
+//! structs (`DlpConfig`, `McpConfig`, `PledgeConfig`, `TapConfig`,
+//! `PolicyConfig`). Because those feature modules import core types from
+//! `crate::models`, this aggregator must sit ABOVE both `models` and
+//! `features` in the dependency graph: it is a top-level module
+//! (`crate::config`), NOT a child of `crate::models`. Housing it under
+//! `models` closed a `models → features → models` cycle. See the
+//! `crate::pricing` leaf for the same anti-cycle pattern.
+//!
 //! Sub-configs (`ServerConfig`, `RouterConfig`, `ProviderConfig`, ...)
 //! remain in `crate::cli::config` and are re-imported here.
 
@@ -406,6 +413,10 @@ default = "placeholder-model"
 
     /// Validates configuration for common errors.
     ///
+    /// Runs each per-section validator in a fixed order; the first failing
+    /// section determines the returned error (validation short-circuits on the
+    /// first hard error, matching the original single-function behaviour).
+    ///
     /// # Errors
     ///
     /// Returns an error if model mappings reference unknown providers,
@@ -414,11 +425,36 @@ default = "placeholder-model"
     pub fn validate(&self) -> Result<()> {
         use std::collections::HashSet;
 
+        // Built once and shared by reference with the section validators to keep
+        // the hot validation path allocation-equivalent with the original.
         let provider_names: HashSet<&str> =
             self.providers.iter().map(|p| p.name.as_str()).collect();
+        let model_names: HashSet<&str> = self.models.iter().map(|m| m.name.as_str()).collect();
 
-        // Check model mappings reference existing providers
-        for model in &self.models {
+        // Order is load-bearing: callers rely on the first hard error surfacing,
+        // so the section sequence below must not be reordered.
+        Self::validate_model_mappings(&self.models, &provider_names)?;
+        Self::validate_provider_auth(&self.providers)?;
+        Self::validate_router_regexes(&self.router)?;
+        Self::warn_unknown_router_models(&self.router, &model_names);
+        Self::validate_acme(&self.server)?;
+        Self::validate_auth_mode(&self.auth)?;
+        Self::validate_fan_out(&self.models, &model_names)?;
+        Self::validate_tiers(&self.tiers, &provider_names)?;
+
+        Ok(())
+    }
+
+    /// Verifies every model mapping references a declared provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error naming the first mapping whose provider is unknown.
+    fn validate_model_mappings(
+        models: &[ModelConfig],
+        provider_names: &std::collections::HashSet<&str>,
+    ) -> Result<()> {
+        for model in models {
             for mapping in &model.mappings {
                 if !provider_names.contains(mapping.provider.as_str()) {
                     anyhow::bail!(
@@ -430,13 +466,21 @@ default = "placeholder-model"
                 }
             }
         }
+        Ok(())
+    }
 
-        // Check enabled providers have auth configured
-        for provider in &self.providers {
+    /// Verifies every enabled provider carries the credentials its auth type needs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for the first enabled provider missing an API key
+    /// (except `vertex-ai`, which may use ADC) or an `oauth_provider`.
+    fn validate_provider_auth(providers: &[ProviderConfig]) -> Result<()> {
+        use crate::cli::AuthType;
+        for provider in providers {
             if !provider.is_enabled() {
                 continue;
             }
-            use crate::cli::AuthType;
             match provider.auth_type {
                 AuthType::ApiKey => {
                     let key_missing = provider.api_key.is_none();
@@ -460,29 +504,41 @@ default = "placeholder-model"
                 }
             }
         }
+        Ok(())
+    }
 
-        // Validate regex patterns compile
-        if let Some(ref pattern) = self.router.auto_map_regex {
+    /// Compiles every configured router regex to surface invalid patterns early.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `auto_map_regex`, `background_regex`, or any
+    /// `prompt_rules` pattern fails to compile.
+    fn validate_router_regexes(router: &RouterConfig) -> Result<()> {
+        if let Some(ref pattern) = router.auto_map_regex {
             if !pattern.is_empty() {
                 regex::Regex::new(pattern)
                     .with_context(|| format!("Invalid auto_map_regex: '{}'", pattern))?;
             }
         }
-        if let Some(ref pattern) = self.router.background_regex {
+        if let Some(ref pattern) = router.background_regex {
             if !pattern.is_empty() {
                 regex::Regex::new(pattern)
                     .with_context(|| format!("Invalid background_regex: '{}'", pattern))?;
             }
         }
-        for (i, rule) in self.router.prompt_rules.iter().enumerate() {
+        for (i, rule) in router.prompt_rules.iter().enumerate() {
             regex::Regex::new(&rule.pattern).with_context(|| {
                 format!("Invalid prompt_rule[{}] pattern: '{}'", i, rule.pattern)
             })?;
         }
+        Ok(())
+    }
 
-        // Warn if router models don't exist in [[models]]
-        let model_names: HashSet<&str> = self.models.iter().map(|m| m.name.as_str()).collect();
-
+    /// Warns (without failing) when a router model name is absent from `[[models]]`.
+    fn warn_unknown_router_models(
+        router: &RouterConfig,
+        model_names: &std::collections::HashSet<&str>,
+    ) {
         let check_router_model = |name: &str, field: &str| {
             if !model_names.contains(name) && !model_names.is_empty() {
                 eprintln!(
@@ -492,42 +548,66 @@ default = "placeholder-model"
             }
         };
 
-        check_router_model(&self.router.default, "default");
-        if let Some(ref m) = self.router.background {
+        check_router_model(&router.default, "default");
+        if let Some(ref m) = router.background {
             check_router_model(m, "background");
         }
-        if let Some(ref m) = self.router.think {
+        if let Some(ref m) = router.think {
             check_router_model(m, "think");
         }
-        if let Some(ref m) = self.router.websearch {
+        if let Some(ref m) = router.websearch {
             check_router_model(m, "websearch");
         }
+    }
 
-        // Validate ACME config (require domains + contacts when enabled)
-        if self.server.tls.acme.enabled {
-            if self.server.tls.acme.domains.is_empty() {
+    /// Verifies ACME has domains and contacts whenever it is enabled.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if ACME is enabled with empty `domains` or `contacts`.
+    fn validate_acme(server: &ServerConfig) -> Result<()> {
+        if server.tls.acme.enabled {
+            if server.tls.acme.domains.is_empty() {
                 anyhow::bail!(
                     "ACME is enabled but no domains configured. Set [server.tls.acme] domains = [\"example.com\"]"
                 );
             }
-            if self.server.tls.acme.contacts.is_empty() {
+            if server.tls.acme.contacts.is_empty() {
                 anyhow::bail!(
                     "ACME is enabled but no contacts configured. Set [server.tls.acme] contacts = [\"admin@example.com\"]"
                 );
             }
         }
+        Ok(())
+    }
 
-        // Validate auth mode
-        match self.auth.mode.as_str() {
+    /// Verifies the inbound auth mode is one of the supported values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `auth.mode` is not `none`, `api_key`, or `jwt`.
+    fn validate_auth_mode(auth: &AuthConfig) -> Result<()> {
+        match auth.mode.as_str() {
             "none" | "api_key" | "jwt" => {}
             other => anyhow::bail!(
                 "Invalid auth.mode '{}'. Must be one of: none, api_key, jwt",
                 other
             ),
         }
+        Ok(())
+    }
 
-        // Validate fan_out config consistency
-        for model in &self.models {
+    /// Verifies fan-out models carry a `[fan_out]` block and warns on unknown judges.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for the first `strategy=fan_out` model lacking a
+    /// `[fan_out]` config block.
+    fn validate_fan_out(
+        models: &[ModelConfig],
+        model_names: &std::collections::HashSet<&str>,
+    ) -> Result<()> {
+        for model in models {
             if model.strategy == ModelStrategy::FanOut && model.fan_out.is_none() {
                 anyhow::bail!(
                     "Model '{}' has strategy=fan_out but no [fan_out] config block",
@@ -546,10 +626,22 @@ default = "placeholder-model"
                 }
             }
         }
+        Ok(())
+    }
 
-        // Validate tier config: provider names must exist (skip when no providers defined)
+    /// Verifies every tier references a declared provider (skipped when none exist).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error naming the first tier whose provider is unknown.
+    fn validate_tiers(
+        tiers: &[TierConfig],
+        provider_names: &std::collections::HashSet<&str>,
+    ) -> Result<()> {
+        // Skip when no providers are defined: an empty provider set means no
+        // declared names to validate against, matching the original guard.
         if !provider_names.is_empty() {
-            for tier in &self.tiers {
+            for tier in tiers {
                 for prov in &tier.providers {
                     if !provider_names.contains(prov.as_str()) {
                         anyhow::bail!(
@@ -562,7 +654,6 @@ default = "placeholder-model"
                 }
             }
         }
-
         Ok(())
     }
 }

--- a/src/features/dlp/README.md
+++ b/src/features/dlp/README.md
@@ -12,7 +12,7 @@ Sanitizes outbound LLM requests and inbound responses against secret leaks, PII 
 |------|----------|---------|
 | `DlpEngine` | `mod.rs` | `server::dispatch`, `server::handlers` |
 | `DlpAction`, `DlpRuleType`, `DlpActionReport`, `DlpBlockError` | `mod.rs` | dispatch, audit log |
-| `DlpConfig` and per-subsystem config structs | `config.rs` | `models::config`, server init |
+| `DlpConfig` and per-subsystem config structs | `config.rs` | `config`, server init |
 | `dfa::SecretScanner`, `dfa::DlpEvent` | `dfa.rs` | `DlpEngine` internals |
 | `pii::PiiScanner`, `pii::PiiType` | `pii.rs` | `DlpEngine` internals |
 | `prompt_injection::InjectionDetector` | `prompt_injection.rs` | `DlpEngine` internals |

--- a/src/features/mcp/README.md
+++ b/src/features/mcp/README.md
@@ -11,7 +11,7 @@ Exposes grob's control plane as MCP tools (query, bench, calibrate, hint, config
 | Item | Location | Used by |
 |------|----------|---------|
 | `McpState` | `mod.rs` | `server::mod`, `server::mcp_handlers` |
-| `McpConfig`, `McpServerConfig`, `BenchConfig`, `ToolRoutingConfig`, `ToolChain` | `config.rs` | `models::config` |
+| `McpConfig`, `McpServerConfig`, `BenchConfig`, `ToolRoutingConfig`, `ToolChain` | `config.rs` | `config` |
 | `ToolMatrix`, `ToolEntry`, `ToolSchema`, `ProviderToolCapability`, `ToolScore`, `RuntimeScores` | `matrix.rs` | router, MCP server |
 | `ToolScorer`, `ToolMetric` | `scorer.rs` | bench engine |
 | `calibration::calibrate_tools` | `calibration.rs` | dispatch — per-request tool gating |

--- a/src/features/policies/README.md
+++ b/src/features/policies/README.md
@@ -13,7 +13,7 @@ Evaluates a [`context::RequestContext`] against glob-based [`config::MatchRules`
 | `PolicyMatcher` | `matcher.rs` | `server::dispatch`, `server::init` |
 | `RequestContext` | `context.rs` | dispatch, handlers |
 | `ResolvedPolicy` | `resolved.rs` | dispatch, retry |
-| `PolicyConfig`, `MatchRules`, `*Override` structs | `config.rs` | `models::config` |
+| `PolicyConfig`, `MatchRules`, `*Override` structs | `config.rs` | `config` |
 | `HitOverride`, `HitDecision`, `ToolUseInfo`, `evaluate_tool_use*` | `hit.rs` | dispatch, stream approval |
 | `HitAuthorization`, `HitAuthParams`, `AuthDecision`, `AuthMethod` | `hit_auth.rs` | HIT gateway handlers |
 | `MultiSigCollector`, `MultiSigStatus` | `multisig.rs` | HIT approval flow |

--- a/src/features/tap/README.md
+++ b/src/features/tap/README.md
@@ -10,7 +10,7 @@ Provides a fire-and-forget observability sink: every request and its assembled S
 
 | Item | Location | Used by |
 |------|----------|---------|
-| `TapConfig` | `mod.rs` | `models::config`, server init |
+| `TapConfig` | `mod.rs` | `config`, server init |
 | `TapEvent` (`Request`, `StreamChunk`, `StreamEnd`) | `mod.rs` | dispatch, retry, streaming layer |
 | `TapSender` | `mod.rs` | `server::mod`, `server::dispatch::retry` |
 | `init_tap` | `mod.rs` | `server::init` |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,14 @@ pub mod cache;
 pub mod cli;
 /// CLI command implementations (start, stop, exec, doctor, etc.).
 pub mod commands;
+/// Top-level application configuration aggregate ([`config::AppConfig`]).
+///
+/// INTENTIONALLY a top-level module (not under `models/`): [`config::AppConfig`]
+/// aggregates feature config structs (`DlpConfig`, `McpConfig`, ...) whose
+/// modules import core types from `models`. Keeping the aggregate above both
+/// `models` and `features` breaks an otherwise circular dependency between them,
+/// mirroring the `pricing` leaf pattern below.
+pub mod config;
 /// Generic control engine for unified CLI / MCP / UI dispatch.
 pub mod control;
 /// Optional features: DLP, MCP, TAP, token pricing.

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -23,7 +23,7 @@ in [`extensions::RequestExtensions`] for lossless roundtrips.
 | `CountTokensRequest`, `CountTokensResponse` | `mod.rs` | `LlmProvider::count_tokens` |
 | `RouteDecision`, `RouteType` | `mod.rs` | `routing::classify::Router`, transparency headers |
 | `default_max_tokens` | `mod.rs` | `openai_compat::transform` |
-| `config::AppConfig` | `config.rs` | `server::ReloadableState`, every CLI command |
+| `crate::config::AppConfig` | `../config.rs` | `server::ReloadableState`, every CLI command |
 | `extensions::RequestExtensions` | `extensions.rs` | provider-specific lossless roundtrips |
 
 ## Owns
@@ -49,7 +49,7 @@ in [`extensions::RequestExtensions`] for lossless roundtrips.
 
 - `tests/unit/models_test.rs` covers canonical request shapes and serialization.
 - `#[cfg(test)] mod tests` inside `mod.rs` covers `default_max_tokens` for Anthropic, OpenAI, Gemini, and fallback families.
-- `#[cfg(test)] mod tests` inside `extensions.rs`, `config.rs` cover extension preservation and config defaults.
+- `#[cfg(test)] mod tests` inside `extensions.rs` covers extension preservation. Config-default tests live in `crate::config` (`../config.rs`), which moved out of this module.
 
 ## Related ADRs
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,7 +1,10 @@
 //! Shared data models: canonical request/response types, routing types.
+//!
+//! NOTE: [`AppConfig`](crate::config::AppConfig) no longer lives here. It moved
+//! to the top-level `crate::config` module because it aggregates feature config
+//! structs whose modules depend on these core types, which would otherwise form
+//! a `models → features → models` cycle.
 
-/// Top-level application configuration ([`config::AppConfig`]).
-pub mod config;
 /// Provider-specific request extensions for lossless roundtrips.
 pub mod extensions;
 /// Spend tracking data types shared between storage and pricing.

--- a/src/preset/README.md
+++ b/src/preset/README.md
@@ -24,7 +24,7 @@ Provides curated TOML config bundles (`perf`, `ultra-cheap`, `gdpr`, `eu-ai-act`
 - Background sync from a Git source URL, periodic refresh, install-from-source.
 
 ## Depends on
-- `crate::cli` (config structs), `crate::models::config::AppConfig`.
+- `crate::cli` (config structs), `crate::config::AppConfig`.
 - `crate::providers::registry::ProviderRegistry`, `crate::auth::TokenStore`.
 - `toml`, `anyhow`, `tempfile` (tests).
 

--- a/src/preset/validation.rs
+++ b/src/preset/validation.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use std::sync::Arc;
 
 use crate::auth::TokenStore;
-use crate::models::config::AppConfig;
+use crate::config::AppConfig;
 use crate::models::{CanonicalRequest, Message, MessageContent};
 use crate::providers::ProviderRegistry;
 use crate::storage::GrobStore;

--- a/src/routing/classify/mod.rs
+++ b/src/routing/classify/mod.rs
@@ -31,7 +31,7 @@ pub(crate) mod tier_match;
 // awkward `routing::classify::classify::ComplexityTier`.
 pub use classify::{classify_complexity, ComplexityTier, ScoringConfig, ScoringWeights};
 
-use crate::models::config::AppConfig;
+use crate::config::AppConfig;
 use crate::models::{CanonicalRequest, RouteDecision, RouteType};
 use anyhow::Result;
 use regex::Regex;

--- a/src/server/config_api.rs
+++ b/src/server/config_api.rs
@@ -1,4 +1,4 @@
-use crate::models::config::AppConfig;
+use crate::config::AppConfig;
 use crate::providers::ProviderRegistry;
 use crate::routing::classify::Router;
 use axum::{
@@ -193,7 +193,7 @@ pub(crate) async fn update_config_json(
     // Deserialise the merged TOML into AppConfig so we can validate and reload.
     let merged_toml_str = toml::to_string_pretty(&config)
         .map_err(|e| RequestError::Internal(anyhow::anyhow!("Failed to serialize config: {e}")))?;
-    let merged_config: crate::models::config::AppConfig = toml::from_str(&merged_toml_str)
+    let merged_config: crate::config::AppConfig = toml::from_str(&merged_toml_str)
         .map_err(|e| RequestError::ParseError(format!("Invalid config after merge: {e}")))?;
 
     // Backup, write, and hot-reload via the shared pipeline.

--- a/src/server/config_guard.rs
+++ b/src/server/config_guard.rs
@@ -113,7 +113,7 @@ pub fn is_key_denied(section: &ConfigSection, key: &str) -> bool {
 /// hot-reload (re-parse + provider rebuild) fails.
 pub async fn persist_and_reload(
     state: &Arc<super::AppState>,
-    config: &crate::models::config::AppConfig,
+    config: &crate::config::AppConfig,
 ) -> Result<(), super::RequestError> {
     let config_path = match &state.config_source {
         crate::cli::ConfigSource::File(p) => p,
@@ -157,7 +157,7 @@ pub async fn persist_and_reload(
 /// Same code path as `server::init` and `preset::build_registry`.
 fn reload_state(
     state: &Arc<super::AppState>,
-    config: crate::models::config::AppConfig,
+    config: crate::config::AppConfig,
     _config_path: &Path,
 ) -> Result<(), super::RequestError> {
     let new_router = crate::routing::classify::Router::new(config.clone());

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -7,213 +7,264 @@ use tracing::info;
 use super::{ReloadableState, RequestError};
 
 /// Resolve and sort provider mappings for a routing decision.
+///
+/// Tries the opt-in tier path first; if it yields no usable provider, falls
+/// back to explicit `[[models]]` routing, then to pass-through inference. The
+/// branch order and per-branch behaviour are identical to the original
+/// single-function implementation.
 pub(crate) fn resolve_provider_mappings(
     inner: &Arc<ReloadableState>,
     headers: &HeaderMap,
     decision: &crate::models::RouteDecision,
 ) -> Result<Vec<crate::cli::ModelMapping>, RequestError> {
-    // Tier-based provider selection (opt-in via [[tiers]] config)
-    if let Some(ref tier) = decision.complexity_tier {
-        let tier_name = tier.to_string();
-        if let Some(tier_cfg) = inner.config.tiers.iter().find(|t| t.name == tier_name) {
-            info!(
-                "📊 Tier '{}' matched — resolving provider mappings",
-                tier_name
-            );
-
-            // Look up [[models]] config once so we can pick actual_model per provider.
-            let model_config = inner.find_model(&decision.model_name);
-
-            let mut priority: u32 = 0;
-            let mappings: Vec<crate::cli::ModelMapping> = tier_cfg
-                .providers
-                .iter()
-                .filter_map(|provider_name| {
-                    // Step 1: prefer explicit actual_model from [[models.mappings]].
-                    if let Some(mc) = model_config {
-                        if let Some(mapping) =
-                            mc.mappings.iter().find(|m| m.provider == *provider_name)
-                        {
-                            info!(
-                                "tier {} -> provider {} -> actual_model {} (from [[models]] mapping)",
-                                tier_name, provider_name, mapping.actual_model
-                            );
-                            priority += 1;
-                            return Some(crate::cli::ModelMapping {
-                                priority,
-                                provider: provider_name.clone(),
-                                actual_model: mapping.actual_model.clone(),
-                                inject_continuation_prompt: mapping.inject_continuation_prompt,
-                            });
-                        }
-                    }
-
-                    // Step 2: provider explicitly lists the model name — use as-is.
-                    let provider_supports = inner
-                        .config
-                        .providers
-                        .iter()
-                        .find(|p| p.name == *provider_name)
-                        .map(|p| {
-                            p.models.iter().any(|m| m == &decision.model_name)
-                                || p.pass_through.unwrap_or(false)
-                        })
-                        .unwrap_or(false);
-
-                    if provider_supports {
-                        info!(
-                            "tier {} -> provider {} -> actual_model {} (provider models list)",
-                            tier_name, provider_name, decision.model_name
-                        );
-                        priority += 1;
-                        return Some(crate::cli::ModelMapping {
-                            priority,
-                            provider: provider_name.clone(),
-                            actual_model: decision.model_name.clone(),
-                            inject_continuation_prompt: false,
-                        });
-                    }
-
-                    // Step 3: no resolution — skip this provider to avoid sending an unknown model name.
-                    info!(
-                        "tier {} -> provider {} SKIP (no resolution for model '{}')",
-                        tier_name, provider_name, decision.model_name
-                    );
-                    None
-                })
-                .collect();
-
-            if !mappings.is_empty() {
-                return Ok(mappings);
-            }
-            // All tier providers were skipped — fall through to [[models]] / pass-through logic.
-            info!(
-                "tier {} — all providers skipped, falling back to [[models]] routing",
-                tier_name
-            );
-        }
+    // Tier-based provider selection (opt-in via [[tiers]] config). A non-empty
+    // result short-circuits; `None` means "fall through" exactly as before.
+    if let Some(mappings) = resolve_tier_mappings(inner, decision) {
+        return Ok(mappings);
     }
 
     if let Some(model_config) = inner.find_model(&decision.model_name) {
-        let forced_provider = headers
-            .get("x-provider")
-            .and_then(|v| v.to_str().ok())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        if let Some(ref provider_name) = forced_provider {
-            info!(
-                "🎯 Using forced provider from X-Provider header: {}",
-                provider_name
-            );
-        }
-
-        let mut sorted = model_config.mappings.clone();
-        if let Some(ref provider_name) = forced_provider {
-            sorted.retain(|m| m.provider == *provider_name);
-            if sorted.is_empty() {
-                return Err(RequestError::RoutingError(format!(
-                    "Provider '{}' not found in mappings for model '{}'",
-                    provider_name, decision.model_name
-                )));
-            }
-        } else {
-            sorted.sort_by_key(|m| m.priority);
-        }
-
-        // GDPR/region filtering: if gdpr=true or region is set, only keep matching providers
-        let gdpr = inner.config.router.gdpr;
-        let required_region = inner.config.router.region.as_deref();
-        if gdpr || required_region.is_some() {
-            let region_filter = required_region.unwrap_or("eu");
-            sorted.retain(|m| {
-                let provider_region = inner
-                    .config
-                    .providers
-                    .iter()
-                    .find(|p| p.name == m.provider)
-                    .and_then(|p| p.region.as_deref())
-                    .unwrap_or("global");
-                provider_region == region_filter || provider_region == "global"
-            });
-            if sorted.is_empty() {
-                return Err(RequestError::RoutingError(format!(
-                    "No providers match region '{}' for model '{}' (GDPR filtering enabled)",
-                    region_filter, decision.model_name
-                )));
-            }
-        }
-
-        Ok(sorted)
+        resolve_explicit_model_mappings(inner, headers, decision, model_config)
     } else {
-        // No explicit [[models]] config — check for pass-through providers
-        let gdpr = inner.config.router.gdpr;
-        let required_region = inner.config.router.region.as_deref();
-        let all_pass_through: Vec<&crate::providers::ProviderConfig> = inner
-            .config
-            .providers
-            .iter()
-            .filter(|p| p.is_enabled() && p.pass_through.unwrap_or(false))
-            .filter(|p| {
-                // GDPR/region filtering for pass-through providers
-                if gdpr || required_region.is_some() {
-                    let region_filter = required_region.unwrap_or("eu");
-                    let provider_region = p.region.as_deref().unwrap_or("global");
-                    provider_region == region_filter || provider_region == "global"
-                } else {
-                    true
+        resolve_pass_through_mappings(inner, decision)
+    }
+}
+
+/// Resolves provider mappings from a matched complexity tier, if any.
+///
+/// Returns `Some(mappings)` only when a tier matched and produced at least one
+/// usable provider; returns `None` to signal the caller should fall through to
+/// `[[models]]` / pass-through routing (no tier, no tier config, or every tier
+/// provider skipped).
+fn resolve_tier_mappings(
+    inner: &Arc<ReloadableState>,
+    decision: &crate::models::RouteDecision,
+) -> Option<Vec<crate::cli::ModelMapping>> {
+    let tier = decision.complexity_tier.as_ref()?;
+    let tier_name = tier.to_string();
+    let tier_cfg = inner.config.tiers.iter().find(|t| t.name == tier_name)?;
+
+    info!(
+        "📊 Tier '{}' matched — resolving provider mappings",
+        tier_name
+    );
+
+    // Look up [[models]] config once so we can pick actual_model per provider.
+    let model_config = inner.find_model(&decision.model_name);
+
+    let mut priority: u32 = 0;
+    let mappings: Vec<crate::cli::ModelMapping> = tier_cfg
+        .providers
+        .iter()
+        .filter_map(|provider_name| {
+            // Step 1: prefer explicit actual_model from [[models.mappings]].
+            if let Some(mc) = model_config {
+                if let Some(mapping) = mc.mappings.iter().find(|m| m.provider == *provider_name) {
+                    info!(
+                        "tier {} -> provider {} -> actual_model {} (from [[models]] mapping)",
+                        tier_name, provider_name, mapping.actual_model
+                    );
+                    priority += 1;
+                    return Some(crate::cli::ModelMapping {
+                        priority,
+                        provider: provider_name.clone(),
+                        actual_model: mapping.actual_model.clone(),
+                        inject_continuation_prompt: mapping.inject_continuation_prompt,
+                    });
                 }
-            })
-            .collect();
-
-        // Smart filtering: prefer providers whose type matches the inferred model family
-        let inferred =
-            crate::routing::classify::inference::infer_provider_type(&decision.model_name);
-        let filtered: Vec<&crate::providers::ProviderConfig> = if let Some(inf) = inferred {
-            let matched: Vec<_> = all_pass_through
-                .iter()
-                .filter(|p| {
-                    p.provider_type == inf
-                        || (inf == "openai" && p.provider_type == "openrouter")
-                        || (inf == "anthropic" && p.provider_type == "openrouter")
-                        || (inf == "gemini" && p.provider_type == "openrouter")
-                })
-                .copied()
-                .collect();
-            if matched.is_empty() {
-                all_pass_through
-            } else {
-                matched
             }
-        } else {
-            all_pass_through
-        };
 
-        let pass_through_mappings: Vec<crate::cli::ModelMapping> = filtered
-            .iter()
-            .enumerate()
-            .map(|(i, p)| crate::cli::ModelMapping {
-                priority: (i as u32) + 1,
-                provider: p.name.clone(),
-                actual_model: decision.model_name.clone(),
-                inject_continuation_prompt: false,
-            })
-            .collect();
+            // Step 2: provider explicitly lists the model name — use as-is.
+            let provider_supports = inner
+                .config
+                .providers
+                .iter()
+                .find(|p| p.name == *provider_name)
+                .map(|p| {
+                    p.models.iter().any(|m| m == &decision.model_name)
+                        || p.pass_through.unwrap_or(false)
+                })
+                .unwrap_or(false);
 
-        if pass_through_mappings.is_empty() {
-            Err(RequestError::RoutingError(format!(
-                "Model '{}' is not configured. Add a [[models]] entry in config.toml or set pass_through = true on a provider.",
-                decision.model_name
-            )))
-        } else {
+            if provider_supports {
+                info!(
+                    "tier {} -> provider {} -> actual_model {} (provider models list)",
+                    tier_name, provider_name, decision.model_name
+                );
+                priority += 1;
+                return Some(crate::cli::ModelMapping {
+                    priority,
+                    provider: provider_name.clone(),
+                    actual_model: decision.model_name.clone(),
+                    inject_continuation_prompt: false,
+                });
+            }
+
+            // Step 3: no resolution — skip this provider to avoid sending an unknown model name.
             info!(
-                "Pass-through routing '{}' to {} provider(s) (inferred: {:?})",
-                decision.model_name,
-                pass_through_mappings.len(),
-                inferred,
+                "tier {} -> provider {} SKIP (no resolution for model '{}')",
+                tier_name, provider_name, decision.model_name
             );
-            Ok(pass_through_mappings)
+            None
+        })
+        .collect();
+
+    if !mappings.is_empty() {
+        return Some(mappings);
+    }
+    // All tier providers were skipped — fall through to [[models]] / pass-through logic.
+    info!(
+        "tier {} — all providers skipped, falling back to [[models]] routing",
+        tier_name
+    );
+    None
+}
+
+/// Resolves mappings for a model declared in `[[models]]`.
+///
+/// Honours the `X-Provider` forced-provider header, otherwise sorts by priority,
+/// then applies GDPR/region filtering.
+///
+/// # Errors
+///
+/// Returns [`RequestError::RoutingError`] if the forced provider is absent from
+/// the model's mappings, or if region filtering leaves no eligible provider.
+fn resolve_explicit_model_mappings(
+    inner: &Arc<ReloadableState>,
+    headers: &HeaderMap,
+    decision: &crate::models::RouteDecision,
+    model_config: &crate::cli::ModelConfig,
+) -> Result<Vec<crate::cli::ModelMapping>, RequestError> {
+    let forced_provider = headers
+        .get("x-provider")
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    if let Some(ref provider_name) = forced_provider {
+        info!(
+            "🎯 Using forced provider from X-Provider header: {}",
+            provider_name
+        );
+    }
+
+    let mut sorted = model_config.mappings.clone();
+    if let Some(ref provider_name) = forced_provider {
+        sorted.retain(|m| m.provider == *provider_name);
+        if sorted.is_empty() {
+            return Err(RequestError::RoutingError(format!(
+                "Provider '{}' not found in mappings for model '{}'",
+                provider_name, decision.model_name
+            )));
         }
+    } else {
+        sorted.sort_by_key(|m| m.priority);
+    }
+
+    // GDPR/region filtering: if gdpr=true or region is set, only keep matching providers
+    let gdpr = inner.config.router.gdpr;
+    let required_region = inner.config.router.region.as_deref();
+    if gdpr || required_region.is_some() {
+        let region_filter = required_region.unwrap_or("eu");
+        sorted.retain(|m| {
+            let provider_region = inner
+                .config
+                .providers
+                .iter()
+                .find(|p| p.name == m.provider)
+                .and_then(|p| p.region.as_deref())
+                .unwrap_or("global");
+            provider_region == region_filter || provider_region == "global"
+        });
+        if sorted.is_empty() {
+            return Err(RequestError::RoutingError(format!(
+                "No providers match region '{}' for model '{}' (GDPR filtering enabled)",
+                region_filter, decision.model_name
+            )));
+        }
+    }
+
+    Ok(sorted)
+}
+
+/// Resolves mappings for an unconfigured model via pass-through providers.
+///
+/// Keeps enabled pass-through providers (after GDPR/region filtering), prefers
+/// those whose type matches the inferred model family, and assigns priorities.
+///
+/// # Errors
+///
+/// Returns [`RequestError::RoutingError`] if no pass-through provider remains.
+fn resolve_pass_through_mappings(
+    inner: &Arc<ReloadableState>,
+    decision: &crate::models::RouteDecision,
+) -> Result<Vec<crate::cli::ModelMapping>, RequestError> {
+    // No explicit [[models]] config — check for pass-through providers
+    let gdpr = inner.config.router.gdpr;
+    let required_region = inner.config.router.region.as_deref();
+    let all_pass_through: Vec<&crate::providers::ProviderConfig> = inner
+        .config
+        .providers
+        .iter()
+        .filter(|p| p.is_enabled() && p.pass_through.unwrap_or(false))
+        .filter(|p| {
+            // GDPR/region filtering for pass-through providers
+            if gdpr || required_region.is_some() {
+                let region_filter = required_region.unwrap_or("eu");
+                let provider_region = p.region.as_deref().unwrap_or("global");
+                provider_region == region_filter || provider_region == "global"
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    // Smart filtering: prefer providers whose type matches the inferred model family
+    let inferred = crate::routing::classify::inference::infer_provider_type(&decision.model_name);
+    let filtered: Vec<&crate::providers::ProviderConfig> = if let Some(inf) = inferred {
+        let matched: Vec<_> = all_pass_through
+            .iter()
+            .filter(|p| {
+                p.provider_type == inf
+                    || (inf == "openai" && p.provider_type == "openrouter")
+                    || (inf == "anthropic" && p.provider_type == "openrouter")
+                    || (inf == "gemini" && p.provider_type == "openrouter")
+            })
+            .copied()
+            .collect();
+        if matched.is_empty() {
+            all_pass_through
+        } else {
+            matched
+        }
+    } else {
+        all_pass_through
+    };
+
+    let pass_through_mappings: Vec<crate::cli::ModelMapping> = filtered
+        .iter()
+        .enumerate()
+        .map(|(i, p)| crate::cli::ModelMapping {
+            priority: (i as u32) + 1,
+            provider: p.name.clone(),
+            actual_model: decision.model_name.clone(),
+            inject_continuation_prompt: false,
+        })
+        .collect();
+
+    if pass_through_mappings.is_empty() {
+        Err(RequestError::RoutingError(format!(
+            "Model '{}' is not configured. Add a [[models]] entry in config.toml or set pass_through = true on a provider.",
+            decision.model_name
+        )))
+    } else {
+        info!(
+            "Pass-through routing '{}' to {} provider(s) (inferred: {:?})",
+            decision.model_name,
+            pass_through_mappings.len(),
+            inferred,
+        );
+        Ok(pass_through_mappings)
     }
 }
 
@@ -304,8 +355,7 @@ mod tests {
 
     /// Builds a minimal [`ReloadableState`] from a TOML snippet.
     fn make_state(toml: &str) -> Arc<ReloadableState> {
-        let config: crate::models::config::AppConfig =
-            toml::from_str(toml).expect("valid test TOML");
+        let config: crate::config::AppConfig = toml::from_str(toml).expect("valid test TOML");
         let router = Router::new(config.clone());
         let registry = Arc::new(ProviderRegistry::new());
         Arc::new(ReloadableState::new(config, router, registry))

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -1,8 +1,8 @@
 use crate::auth::TokenStore;
+use crate::config::AppConfig;
 use crate::features::dlp::session::DlpSessionManager;
 use crate::features::token_pricing::spend::SpendTracker;
 use crate::features::token_pricing::SharedPricingTable;
-use crate::models::config::AppConfig;
 use crate::providers::ProviderRegistry;
 use crate::security::{
     AuditLog, CircuitBreakerRegistry, RateLimitConfig, RateLimiter, ToolSpikeConfig,

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -5,7 +5,7 @@
 //! `rustls-pki-types`.
 
 use super::{oauth_handlers, AppState};
-use crate::models::config::AppConfig;
+use crate::config::AppConfig;
 use axum::{routing::get, Router as AxumRouter};
 use std::sync::Arc;
 use tracing::{error, info, warn};

--- a/src/server/mcp_handlers/config.rs
+++ b/src/server/mcp_handlers/config.rs
@@ -1,6 +1,6 @@
 //! Config-section read/write helpers shared by `grob_configure`, `grob_autotune`, and the wizard tools.
 //!
-//! These helpers operate on an [`AppConfig`](crate::models::config::AppConfig)
+//! These helpers operate on an [`AppConfig`](crate::config::AppConfig)
 //! by value: the caller clones the active config, mutates it via
 //! [`apply_config_update`], then persists and hot-reloads through
 //! [`super::super::config_guard::persist_and_reload`]. The deny-list lives in
@@ -10,7 +10,7 @@ use crate::features::mcp::server::types::ConfigSection;
 
 /// Returns a safe JSON view of the requested config section (no secrets).
 pub(super) fn read_config_section(
-    config: &crate::models::config::AppConfig,
+    config: &crate::config::AppConfig,
     section: &ConfigSection,
 ) -> serde_json::Value {
     match section {
@@ -76,7 +76,7 @@ pub(super) fn read_config_section(
 /// value type does not match the field, or when the section is read-only
 /// (currently `Dlp`).
 pub(super) fn apply_config_update(
-    config: &mut crate::models::config::AppConfig,
+    config: &mut crate::config::AppConfig,
     section: &ConfigSection,
     key: &str,
     value: &serde_json::Value,

--- a/src/server/mcp_handlers/tests.rs
+++ b/src/server/mcp_handlers/tests.rs
@@ -9,7 +9,7 @@ use crate::features::mcp::server::types::{
 use crate::server::config_guard::is_key_denied;
 use crate::server::rpc::types::Role;
 
-fn test_app_config() -> crate::models::config::AppConfig {
+fn test_app_config() -> crate::config::AppConfig {
     let toml_str = r#"
         [router]
         default = "claude-sonnet"

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -52,7 +52,7 @@ pub(crate) fn apply_transparency_headers(
 }
 
 /// Returns true when EU AI Act transparency headers should be added.
-pub(crate) fn should_apply_transparency(config: &crate::models::config::AppConfig) -> bool {
+pub(crate) fn should_apply_transparency(config: &crate::config::AppConfig) -> bool {
     config.compliance.enabled && config.compliance.transparency_headers
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -61,9 +61,9 @@ pub use middleware::{
 };
 
 use crate::auth::TokenStore;
+use crate::config::AppConfig;
 use crate::features::dlp::session::DlpSessionManager;
 use crate::features::token_pricing::SharedPricingTable;
-use crate::models::config::AppConfig;
 use crate::providers::ProviderRegistry;
 use crate::routing::classify::Router;
 use crate::security::{AuditLog, RateLimiter};

--- a/src/server/rpc/config_ns.rs
+++ b/src/server/rpc/config_ns.rs
@@ -2,7 +2,7 @@
 
 use super::auth::{require_role, CallerIdentity};
 use super::types::{rpc_err, Role, StatusResponse, ERR_INTERNAL};
-use crate::models::config::AppConfig;
+use crate::config::AppConfig;
 use crate::providers::ProviderRegistry;
 use crate::routing::classify::Router;
 use crate::server::config_guard::is_section_or_key_denied;
@@ -119,7 +119,7 @@ pub async fn diff(
             .map_err(|e| rpc_err(ERR_INTERNAL, format!("Failed to serialize config: {e}")))?
     };
 
-    let disk = match crate::models::config::AppConfig::from_source(&state.config_source).await {
+    let disk = match crate::config::AppConfig::from_source(&state.config_source).await {
         Ok(cfg) => serde_json::to_value(&cfg).map_err(|e| {
             rpc_err(
                 ERR_INTERNAL,

--- a/src/server/rpc/hit_ns.rs
+++ b/src/server/rpc/hit_ns.rs
@@ -139,7 +139,7 @@ pub async fn set_policy(
 #[cfg(feature = "policies")]
 fn swap_state(
     state: &Arc<AppState>,
-    new_config: crate::models::config::AppConfig,
+    new_config: crate::config::AppConfig,
     caller: &CallerIdentity,
     action: &str,
 ) -> Result<(), ErrorObjectOwned> {

--- a/src/server/rpc/pledge_ns.rs
+++ b/src/server/rpc/pledge_ns.rs
@@ -89,7 +89,7 @@ pub async fn clear(
 /// Pure mutation helper for `set`. Validates the profile name and
 /// either upserts a per-source rule or updates the default profile.
 fn apply_set(
-    config: &mut crate::models::config::AppConfig,
+    config: &mut crate::config::AppConfig,
     profile: &str,
     source: Option<&str>,
 ) -> Result<(), ErrorObjectOwned> {
@@ -138,7 +138,7 @@ fn apply_set(
 
 /// Pure mutation helper for `clear`. Drops all rules and resets the
 /// default profile to the catalogue default (`full`).
-fn apply_clear(config: &mut crate::models::config::AppConfig) {
+fn apply_clear(config: &mut crate::config::AppConfig) {
     config.pledge.rules.clear();
     config.pledge.default_profile = "full".to_string();
 }
@@ -152,7 +152,7 @@ fn is_known_profile(name: &str) -> bool {
 /// it. Same primitive as `config_ns::set` and `tools_ns::*`.
 fn swap_state(
     state: &Arc<AppState>,
-    new_config: crate::models::config::AppConfig,
+    new_config: crate::config::AppConfig,
     caller: &CallerIdentity,
     action: &str,
 ) -> Result<(), ErrorObjectOwned> {
@@ -233,7 +233,7 @@ pub async fn list_profiles(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::config::AppConfig;
+    use crate::config::AppConfig;
     use crate::server::rpc::types::ERR_FORBIDDEN;
 
     fn fixture_config() -> AppConfig {

--- a/src/server/rpc/server_ns.rs
+++ b/src/server/rpc/server_ns.rs
@@ -49,7 +49,7 @@ pub async fn reload_config(
 ) -> Result<StatusResponse, ErrorObjectOwned> {
     require_role(caller, Role::Operator)?;
 
-    use crate::models::config::AppConfig;
+    use crate::config::AppConfig;
     use crate::providers::ProviderRegistry;
     use crate::routing::classify::Router;
     use crate::server::ReloadableState;

--- a/src/server/rpc/tools_ns.rs
+++ b/src/server/rpc/tools_ns.rs
@@ -110,10 +110,7 @@ pub async fn disable(
 /// the new `InjectRule` into the supplied config. Separated from the
 /// async handler so the validation logic is unit-testable without an
 /// `AppState`.
-fn apply_enable(
-    config: &mut crate::models::config::AppConfig,
-    tool: &str,
-) -> Result<(), ErrorObjectOwned> {
+fn apply_enable(config: &mut crate::config::AppConfig, tool: &str) -> Result<(), ErrorObjectOwned> {
     if tool.trim().is_empty() {
         return Err(rpc_err(INVALID_PARAMS_CODE, "tool name cannot be empty"));
     }
@@ -133,7 +130,7 @@ fn apply_enable(
 /// Pure mutation helper for `disable`. Removes any inject rule matching
 /// `tool` from the supplied config. Separated for unit-testability.
 fn apply_disable(
-    config: &mut crate::models::config::AppConfig,
+    config: &mut crate::config::AppConfig,
     tool: &str,
 ) -> Result<(), ErrorObjectOwned> {
     if tool.trim().is_empty() {
@@ -155,7 +152,7 @@ fn apply_disable(
 /// In-memory only — see [`tools/enable`] / [`tools/disable`] for rationale.
 fn swap_state(
     state: &Arc<AppState>,
-    new_config: crate::models::config::AppConfig,
+    new_config: crate::config::AppConfig,
     caller: &CallerIdentity,
     action: &str,
 ) -> Result<(), ErrorObjectOwned> {
@@ -241,7 +238,7 @@ pub async fn catalog(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::config::AppConfig;
+    use crate::config::AppConfig;
     use crate::server::rpc::types::ERR_FORBIDDEN;
 
     /// Minimal AppConfig for tool_layer mutation tests.


### PR DESCRIPTION
## Summary

Structural, **behavior-preserving** cleanup surfaced by a tangle/code audit. Breaks two dependency cycles and splits two god functions. No observable behavior, error messages, routing decisions, or validation outcomes change. All existing tests pass unchanged.

## Cycle cuts

### 1. `features <-> models`
- **Edge removed:** `src/models/config.rs` (the only file in `models` importing `crate::features`) imported `DlpConfig`, `McpConfig`, `PledgeConfig`, `TapConfig`, and `PolicyConfig`, while those feature modules import core types (`CanonicalRequest`, `ContentBlock`, ...) from `crate::models` — forming `models -> features -> models`.
- **Fix:** moved the `models::config` module to a new **top-level `crate::config`** leaf (via `git mv`, history preserved) that sits *above* both `models` and `features`, mirroring the existing `crate::pricing` anti-cycle pattern. `models` no longer imports `features` at all.
- All `crate::models::config::*` paths updated to `crate::config::*` (21 files). `crate::cli` keeps re-exporting `AppConfig` so `cli::AppConfig` call sites (incl. tests) are untouched.
- **Verified gone:** `grep -rn "crate::features" src/models/` -> empty; no code edge from `models`/`features` back to `crate::config` (only doc-comment links).

### 2. `auth <-> providers`
- **Edge removed:** `src/auth/auto_flow.rs:14` `use crate::providers::{AuthType, ProviderConfig};` — those two types are merely *re-exported* by `providers` from their canonical home `crate::cli::config::providers`, and `providers` itself depends on `auth` (TokenStore / OAuth) — forming `auth -> providers -> auth`.
- **Fix:** one-line change to import from `crate::cli` (the canonical home; `auth -> cli::config` is the sanctioned direction documented in `auth/README.md`).
- **Verified gone:** `grep -rn "crate::providers" src/auth/` -> empty.

## God-function splits

### 3. `AppConfig::validate` (~154 LOC, ~48 branches)
Split into eight private per-section validators: `validate_model_mappings`, `validate_provider_auth`, `validate_router_regexes`, `warn_unknown_router_models`, `validate_acme`, `validate_auth_mode`, `validate_fan_out`, `validate_tiers`. The fixed call order preserves the original first-error short-circuit semantics; the shared `provider_names`/`model_names` HashSets are built once and passed by reference (allocation-equivalent).

### 4. `server::helpers::resolve_provider_mappings` (~209 LOC, ~36 branches, hot dispatch path)
Split into three private helpers — `resolve_tier_mappings` (returns `Option`, `None` = fall through), `resolve_explicit_model_mappings`, `resolve_pass_through_mappings`. Identical branch order, logging, error variants, and clones; **no new allocations** on the hot path. The public `resolve_provider_mappings` signature is unchanged and the existing tests exercise it end-to-end.

## Behavior preserved

**All 1178 lib unit tests + 266 integration tests pass unchanged.** No test logic was modified — the only test-file edits are mechanical import-path renames (`crate::models::config::AppConfig` -> `crate::config::AppConfig`) forced by the module move.

## Gates (all green locally)

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --no-default-features --features dlp,oauth,tap,compliance,mcp,watch,policies,socket-opts,dirs -- -D warnings`
- `cargo test --lib` (1178 passed) and `cargo test --test lib` (266 passed)
- `RUSTDOCFLAGS='-W missing-docs' cargo doc --no-deps` — no missing-docs (and one stale intra-doc link fixed)

## Reviewer notes

- This is **review-first**: auto-merge intentionally not enabled.
- A pre-existing `cli <-> config` re-export coupling (config imports cli types; cli re-exports `AppConfig`) is **out of scope** and left as-is — breaking it would require touching ~50 sites including tests. It is not one of the two audited cycles and predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
