### PR TITLE
chore: release v0.36.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.48](https://github.com/azerozero/grob/compare/v0.36.47...v0.36.48) - 2026-05-28
+
+### Other
+
+- break features↔models & auth↔providers cycles, split two god functions
+- fix claude-code-router fork leftovers
+- Merge pull request #350 from azerozero/revive/dispatch-retry-reload
+- Merge pull request #351 from azerozero/revive/tool-spike-anomaly
+
 ## [0.36.47](https://github.com/azerozero/grob/compare/v0.36.46...v0.36.47) - 2026-05-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.47"
+version = "0.36.48"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.47"
+version = "0.36.48"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.47 -> 0.36.48

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.48](https://github.com/azerozero/grob/compare/v0.36.47...v0.36.48) - 2026-05-28

### Other

- break features↔models & auth↔providers cycles, split two god functions
- fix claude-code-router fork leftovers
- Merge pull request #350 from azerozero/revive/dispatch-retry-reload
- Merge pull request #351 from azerozero/revive/tool-spike-anomaly
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).