### PR TITLE
docs: fix nav orphans, residual fork drift, and CONTRACTS drift

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -30,7 +30,7 @@
 - On success: returns `DispatchResult` (Streaming, Complete, or FanOut)
 - On failure: returns `AppError` with a specific error variant
 - DLP events are emitted for every DLP action taken
-- Spend is recorded after successful provider response
+- Spend is recorded after a successful provider response. For **complete** responses this happens inline after the provider returns; for **streaming** responses the `SpendStream` wrapper records on stream termination (see `SpendStream::poll_next` below). Both paths record against the same tenant and routed model name.
 
 **Boundary behavior:**
 - No providers available: returns `AppError` (after exhausting all fallbacks)
@@ -154,27 +154,31 @@
 - INV-2 (Non-blocking): Budget check reads current spend but does not record or modify anything.
 - INV-3 (Threshold semantics): The check uses `>=` (greater-than-or-equal), meaning the exact limit value is already considered exceeded.
 - INV-4 (Zero global bypass): A `global_limit` of `0.0` means no global limit (skipped, not "zero budget").
+- INV-5 (Tenant isolation): `check_tenant_budget(tenant, ...)` evaluates the supplied limits against the **tenant-local** spend cache (`load_spend(Some(tenant))`), not the global counter. One tenant exceeding its quota cannot block another. `tenant == None` falls back to [`DEFAULT_TENANT`](crate::storage::DEFAULT_TENANT) so legacy single-tenant callers still go through the per-tenant path.
 
 **Preconditions:**
 - Spend data is loaded and reflects the current month
 
 **Postconditions:**
 - On `Ok(())`: no limit exceeded
-- On `Err(BudgetError)`: message identifies which limit (model/provider/global) was hit
+- On `Err(BudgetError)`: message identifies which limit (model/provider/global) was hit; for `check_tenant_budget`, the message names the offending tenant
 
 **Boundary behavior:**
 - `model_limit` is `None`: model budget check is skipped
 - `provider_limit` is `None`: provider budget check is skipped
 - `global_limit` is `0.0`: global budget check is skipped
 - New month: spend data auto-resets before check (via `reset_if_new_month`)
+- `check_tenant_budget` with no `GrobStore` (test/CLI mode): falls back to the global `check_budget` path with `tenant_limit` used as the global limit
 
 **Known drifts:**
-- (none recorded yet)
+- 2026-05 (intentional, multi-tenant isolation): `record_tenant` no longer accumulates tenant-tagged spend into the **global** counter. Previously a per-tenant overspend tripped the global budget for every other tenant. The event still lands in the global JSONL journal as a tenant-tagged copy (so exports keep working), but the global `$` total and per-tenant budget checks are now isolated. Global `check_budget` therefore reflects only untagged (`None`/default-tenant) spend.
 
 **Red flags to detect:**
 - Check order changed (e.g., global before model)
 - `>` used instead of `>=` (off-by-one at boundary)
 - `global_limit == 0.0` treated as "zero budget" instead of "no limit"
+- Tenant spend leaking back into the global counter (regression of the multi-tenant isolation drift)
+- `check_tenant_budget` reading global spend instead of `load_spend(Some(tenant))`
 
 ---
 
@@ -374,3 +378,39 @@
 - Probe spawned with `BlockingClient` or on the dispatch runtime — must stay on tokio, timeout isolated.
 - `JoinHandle::abort()` missing from `Drop` — registry reload would leak tasks.
 - `HealthStatus` retrieved via mutex on the hot path — must stay `AtomicBool`.
+
+---
+
+## SpendStream::poll_next() (streaming spend accounting)
+
+**Module:** `src/server/dispatch/spend_stream.rs`
+**Intention:** Passthrough wrapper around a provider SSE byte stream that observes events, captures provider-reported usage, and records persistent spend on stream termination. Closes the historical gap where streaming responses recorded **no** persistent spend (only ephemeral Prometheus metrics), so budget enforcement now covers streamed requests the same as complete ones.
+
+**Invariants:**
+- INV-1 (Byte transparency): Each chunk is forwarded unchanged in the same poll. Time-to-first-byte and inter-chunk timing are identical to the un-wrapped stream; the wrapper never buffers, reorders, or rewrites bytes.
+- INV-2 (Record once, on termination): Spend is recorded exactly once, when the underlying stream ends (or errors). Mid-stream chunks never commit spend.
+- INV-3 (Token source priority): Provider-reported usage is authoritative (`message_start.message.usage.input_tokens`, `message_delta.usage.output_tokens`). The estimate-mode fallback (pre-captured input estimate + ~4-chars/token output estimate from accumulated `text_delta`) is used only when the provider omits usage **and** token counting is in `Estimate` mode.
+- INV-4 (Tenant + model parity): Spend is recorded against the same tenant (`SpendStreamContext::tenant_id`) and routed model name as the non-streaming path, so per-tenant isolation (see `check_budget` INV-5) holds for streamed requests.
+- INV-5 (Off-hot-path commit): Cost computation, the spend mutex, and the JSONL append run in a detached spawned task on termination, so the final client poll returns without waiting on disk I/O.
+
+**Preconditions:**
+- Wrapper owns an `Arc<AppState>` and `String` clones (it outlives the request handler; it must not borrow the transient `DispatchContext`).
+- `SpendStreamContext` carries provider, model_name, actual_model, route_type, tenant_id, is_subscription, and the input estimate.
+
+**Postconditions:**
+- The wrapped stream yields the identical sequence of `Bytes`/errors as the inner stream.
+- On termination, spend is recorded via the shared `record_spend` path (tenant-isolated) unless billed amount is `$0`.
+
+**Boundary behavior:**
+- OAuth/subscription provider (`is_subscription == true`): billed as `$0` (subscription cost model).
+- `api` mode with no provider usage: nothing is recorded — matching non-streaming, where `$0` usage bills `$0`.
+- Stream errors mid-flight: spend for usage observed so far is still recorded on termination.
+
+**Known drifts:**
+- 2026-05 (intentional, streaming spend accounting): streaming responses now commit spend to the monthly JSONL journal. Previously `send_message_stream` only emitted ephemeral Prometheus metrics and committed nothing, so streamed traffic was invisible to budget enforcement.
+
+**Red flags to detect:**
+- Chunk buffered/parsed with `serde_json` on every poll instead of a cheap `memchr::memmem` substring scan (only usage-bearing events should be JSON-parsed).
+- Spend recorded per-chunk instead of once on termination (double-billing).
+- Terminal recording run inline on the poll path instead of a detached task (TTFB / tail-latency regression).
+- Streaming spend recorded against the global counter instead of the request's tenant (regression of tenant isolation).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,34 @@ When the scope of a change involves a new architectural decision, add
 an ADR in `docs/decisions/NNNN-short-title.md` using
 `docs/decisions/0000-template.md`.
 
+## Drift Surveillance
+
+[`CONTRACTS.md`](CONTRACTS.md) records the **intended behavior** of
+critical functions and APIs — invariants, pre/postconditions, boundary
+behavior, and known drifts. It is the reference against which an
+autophagy scan compares the code to catch **silent semantic drift**:
+changes that compile and pass tests but quietly violate the original
+intention.
+
+When your change alters the behavior of a contracted item, you must keep
+`CONTRACTS.md` in lockstep:
+
+- **Intentional behavior change** — update the relevant contract section
+  (invariants, postconditions, boundary behavior) so it describes the
+  new intended behavior, and add a dated entry under **Known drifts**
+  explaining what changed and why. The drift entry is the audit trail;
+  do not silently overwrite an invariant.
+- **Bug fix** — do **not** edit `CONTRACTS.md` to match a bug. The
+  contract is the source of truth; fix the code so it matches the
+  contract instead.
+- **New contracted surface** — if you add a function or API critical
+  enough to be audited (routing, dispatch, spend, DLP, storage), add a
+  new contract section following the existing format.
+
+Reviewers should reject a PR that changes contracted behavior without a
+corresponding `CONTRACTS.md` update. If you are unsure whether an item is
+contracted, search `CONTRACTS.md` for its name before merging.
+
 ## Reporting bugs
 
 File bugs at <https://github.com/azerozero/grob/issues/new>. Include

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,11 @@ Start here: **[Documentation Index](index.md)**
 - [How to Contribute](how-to/contribute.md) -- Development workflow, code style, CI
 - [Provider Setup](how-to/providers.md) -- Per-provider configuration
 - [OAuth Setup](how-to/oauth-setup.md) -- OAuth for Anthropic Pro/Max and Gemini Pro
+- [OAuth Testing](how-to/oauth-testing.md) -- Verify and debug OAuth flows
+- [Manage Secrets](how-to/manage-secrets.md) -- Manage upstream provider secrets
+- [Auto-tune Routing](how-to/auto-tune-routing.md) -- Tune routing with trace analysis
+- [Configure the SimHash Cache](how-to/configure-simhash-cache.md) -- Fuzzy response cache setup
+- [Use grob_hint](how-to/use-grob-hint.md) -- Override request complexity per call
 - [Troubleshooting](how-to/troubleshooting.md) -- Common errors and fixes
 
 ## Reference (information-oriented)
@@ -22,6 +27,8 @@ Start here: **[Documentation Index](index.md)**
 - [CLI Reference](reference/cli.md) -- All commands and flags
 - [Error Reference](reference/errors.md) -- HTTP status codes and error types
 - [OpenAI Compatibility](reference/openai-compatibility.md) -- `/v1/chat/completions` endpoint
+- [HIT Risk Scoring](reference/hit-scoring.md) -- Human-in-the-loop risk scoring details
+- [DLP Indirect Injection Detection](reference/dlp-indirect-injection.md) -- Indirect prompt injection coverage
 - [OpenAPI Specification](openapi.yaml) -- Full API in OpenAPI 3.0
 
 ## Explanation (understanding-oriented)

--- a/docs/explanation/design-principles.md
+++ b/docs/explanation/design-principles.md
@@ -29,7 +29,7 @@ Our goal is to minimize the complexity developers face when using multiple AI pr
 ### Value first, cost later
 **Get users productive first, expose advanced settings later.**
 
-- Presets (`grob preset apply medium`) give a working setup in one command.
+- Presets (`grob preset apply perf`) give a working setup in one command.
 - Manual config editing is for fine-tuning, not for getting started.
 - Required vs optional fields are clearly distinguished in config comments.
 
@@ -60,7 +60,7 @@ Our goal is to minimize the complexity developers face when using multiple AI pr
 
 ### Action-oriented CLI output
 - Good: `grob start`, `grob status`, `grob spend`
-- Good: Error messages that suggest a fix: `"No providers configured. Run 'grob preset apply medium' to get started."`
+- Good: Error messages that suggest a fix: `"No providers configured. Run 'grob preset apply perf' to get started."`
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,13 @@ Grob accepts requests in both Anthropic and OpenAI API formats, normalizes them,
 | [0016](decisions/0016-decision-tokens-transparent-routing.md) | Decision tokens, transparent routing |
 | [0017](decisions/0017-sokolsky-log-backend.md) | Sokolsky log backend |
 | [0018](decisions/0018-nature-inspired-routing.md) | Nature-inspired routing (RE-1a/RE-1b) |
+| [0019](decisions/0019-ema-stigmergy-endpoint-scoring.md) | EMA stigmergy — adaptive endpoint health scoring (proposed) |
+| [0020](decisions/0020-hedged-requests.md) | Hedged requests — tail-latency reduction (proposed) |
+| [0022](decisions/0022-declarative-endpoints-policies-schema.md) | Declarative `[[endpoints]]` and `[[policies]]` routing schema (proposed) |
+| [0023](decisions/0023-preset-naming-and-composition.md) | Preset naming and composition strategy (proposed) |
+| [0024](decisions/0024-preset-as-compliance-template.md) | Preset-as-compliance-template (proposed) |
+| [0025](decisions/0025-rpc-mutation-transactionality.md) | RPC mutation transactionality and in-flight visibility (proposed) |
+| [0026](decisions/0026-model-name-canonicalization-policy.md) | Model name canonicalization policy (proposed) |
 
 ### Examples
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -160,8 +160,8 @@ Manage configuration presets.
 ```bash
 grob preset list
 grob preset info perf
-grob preset apply medium --reload
-grob preset apply medium --dry-run          # Preview without writing
+grob preset apply eu-pro --reload
+grob preset apply eu-pro --dry-run          # Preview without writing
 grob preset export my-setup
 grob preset export my-setup --env qa        # Saves as my-setup.qa.toml
 grob preset install https://github.com/org/presets.git
@@ -256,7 +256,7 @@ Push a local preset to a remote grob instance. Loads the preset, fetches the rem
 
 ```bash
 grob preset push perf --target https://grob-qa.example.com
-grob preset push medium --target https://grob-prod.example.com --yes
+grob preset push eu-max --target https://grob-prod.example.com --yes
 ```
 
 ### `grob preset pull`
@@ -336,7 +336,7 @@ Compare local config against a preset or remote config. Defaults to comparing ag
 
 ```bash
 grob config-diff                  # Compare against active preset
-grob config-diff medium           # Compare against a specific preset
+grob config-diff eu-pro           # Compare against a specific preset
 ```
 
 Reports section-level differences for `[router]`, `[[providers]]`, and `[[models]]`.

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -79,7 +79,7 @@ A provider has accumulated 5+ consecutive failures. Grob skips it for 30 seconds
 
 ### `Failed to parse config` (startup)
 
-The TOML config file has a syntax error. Run `grob doctor` for validation details, or start fresh with `grob preset apply medium`.
+The TOML config file has a syntax error. Run `grob doctor` for validation details, or start fresh with `grob preset apply perf`.
 
 ## Provider-specific errors
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -6,11 +6,11 @@ Grob ships with 7 built-in presets. Apply with `grob preset apply <name>`.
 
 | Preset | Description | Providers |
 |--------|-------------|-----------|
-| `perf` | Performance max | Anthropic + OpenAI + Gemini, top-tier models |
-| `medium` | Best quality/price | Anthropic thinking + OpenRouter defaults |
-| `local` | Private, zero API cost for defaults | Ollama local + Anthropic thinking |
-| `cheap` | Budget max ($0-5/month) | GLM-5 + DeepSeek + Gemini Flash |
-| `fast` | Premium quality, no limit | Opus + GPT-5.2 + Gemini Pro |
+| `perf` | Pure Anthropic OAuth (Pro/Max) — auto-map `claude-*` to native | Anthropic (OAuth) |
+| `ultra-cheap` | EUR0-2/month — stacked free tiers | Groq + Cerebras + Z.ai + OpenRouter `:free` |
+| `eu-eco` | Strict-EU sovereign, budget — ~75% SWE-V | Scaleway FR + Nebius eu-north1 |
+| `eu-pro` | Strict-EU sovereign, balanced — ~82% SWE-V | Hermes-4-405B + Qwen3.5-397B |
+| `eu-max` | Strict-EU sovereign, premium — ~85% SWE-V | preemptive 397B/405B everywhere |
 | `gdpr` | EU-only GDPR compliant | Mistral, Scaleway, OVH (region=eu) |
 | `eu-ai-act` | EU AI Act compliant | EU providers + transparency headers + risk classification |
 
@@ -19,8 +19,8 @@ Grob ships with 7 built-in presets. Apply with `grob preset apply <name>`.
 ```bash
 grob preset list                  # List all presets (built-in + installed)
 grob preset info perf             # Show providers, models, env vars, router config
-grob preset apply medium          # Apply preset (backs up current config to .toml.backup)
-grob preset apply medium --reload # Apply and hot-reload the running server
+grob preset apply eu-pro          # Apply preset (backs up current config to .toml.backup)
+grob preset apply eu-pro --reload # Apply and hot-reload the running server
 grob preset export my-custom      # Export current config as a reusable preset
 grob preset install https://github.com/org/presets.git  # Install from git repo
 grob preset sync                  # Sync presets from configured remote
@@ -180,7 +180,7 @@ The running server can reload configuration without restart:
 curl -X POST http://localhost:13456/api/config/reload
 
 # Via preset apply
-grob preset apply medium --reload
+grob preset apply eu-pro --reload
 ```
 
 Hot-reload atomically swaps the router, provider registry, and model index. In-flight requests continue on the old snapshot.


### PR DESCRIPTION
## Summary

Documentation-only cleanup from a quality audit. Three independent fixes, all confined to `docs/`, `CONTRACTS.md`, and `CONTRIBUTING.md`. No code changes.

## Fix 1 — Orphan docs not in nav

- **`docs/index.md`**: the ADR table stopped at 0018. Added entries for every ADR that exists beyond it: **0019, 0020, 0022, 0023, 0024, 0025, 0026** (each labelled with its status, all currently `proposed`). ADR-0021 does not exist on disk, so it was intentionally skipped — flagging the numbering gap.
- **`docs/README.md`**: linked the orphan pages that existed under `docs/how-to/` and `docs/reference/` but were absent from every nav surface:
  - How-tos: `oauth-testing`, `manage-secrets`, `auto-tune-routing`, `configure-simhash-cache`, `use-grob-hint`
  - References: `hit-scoring`, `dlp-indirect-injection`

## Fix 2 — Residual fork drift

Aligned docs to the SSOTs (`presets/` for preset names, `src/pricing.rs` for model names). Changed docs only.

- Replaced ghost presets (`medium`, `cheap`, `local`, `fast`) with the real set — `perf`, `ultra-cheap`, `gdpr`, `eu-ai-act`, `eu-eco`, `eu-pro`, `eu-max` — in `reference/operations.md`, `reference/cli.md`, `reference/errors.md`, and `explanation/design-principles.md`.
- Dropped stale model names (`GLM-5`, `GPT-5.2`, `Gemini Flash/Pro`) from the operations preset table; rewrote the table descriptions to match the preset headers.
- Left the legitimate bench `--payload medium` size in `cli.md` untouched (not a preset).

## Fix 3 — CONTRACTS.md drift + Drift Surveillance

Two intentional behavior changes had landed without updating the contracts:

- **Per-tenant spend isolation**: added invariant INV-5 to the `check_budget` contract (tenant budgets evaluated against the tenant-local cache; `None` maps to `DEFAULT_TENANT`) and a dated **Known drifts** entry recording that the global counter no longer accumulates tenant-tagged spend.
- **Streaming spend accounting**: added a new `SpendStream::poll_next()` contract (byte transparency, record-once-on-termination, token-source priority, tenant parity, off-hot-path commit) and updated the `dispatch` postcondition to cover the streaming path.
- **`CONTRIBUTING.md`**: added a **Drift Surveillance** section telling contributors to keep `CONTRACTS.md` in lockstep on intentional behavior changes (and to fix the code, not the contract, for bugs).

## Verification

- All 14 newly added relative links resolve to existing files (verified by `ls` and by the pre-commit `lychee` offline link check, which passed).
- `markdownlint-cli2` is not installed in this environment and `npx` install is sandboxed, so it could not be run; changes were reviewed manually against the repo `.markdownlint.json` (MD013 disabled, table structure preserved, no new H1s, trailing newlines intact).
- Commit contains exactly the 8 docs files — no `src/` or `tests/` leakage.

## Note

This is a **review-first** PR — auto-merge intentionally NOT enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
