### PR TITLE
ci: add shellcheck gate, fix SC2168, drop empty scaffolds

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,74 @@
+# ShellCheck gate: static analysis for the repo's shell scripts.
+#
+# Lints every tracked `*.sh` script (top-level, scripts/**, tests/e2e/**)
+# with `shellcheck -x` so `source`d files are followed. Runs on push to main
+# and on PRs that touch shell scripts or this workflow, catching shell bugs
+# (e.g. `local` outside a function, SC2168) before they reach main.
+#
+# Severity is pinned to `warning`: this still flags every genuine bug
+# (errors + warnings such as SC2168/SC2164/SC2034) while not failing on
+# `info`-level style notes for the intentional, deliberate word-splitting
+# idioms used throughout the e2e harness (e.g. `$GROB`, `$CURL_PID`).
+
+name: ShellCheck
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.sh"
+      - ".github/workflows/shellcheck.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**.sh"
+      - ".github/workflows/shellcheck.yml"
+
+concurrency:
+  group: shellcheck-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v6
+      - name: Run shellcheck
+        run: |
+          set -euo pipefail
+          # ubuntu-latest ships shellcheck preinstalled; print the version so
+          # the log records exactly which ruleset produced the result.
+          shellcheck --version
+
+          # Collect the scoped scripts: scripts/**, tests/e2e/**, and any
+          # top-level *.sh. `! -path './*/*'` pins the third alternative to
+          # the repo root so it does not pull in scripts owned by other trees
+          # (e.g. demo/). -print0/-d '' keeps paths with spaces intact.
+          mapfile -d '' -t scripts < <(
+            find . \
+              -type d -name target -prune -o \
+              -type f -name '*.sh' \
+              \( -path './scripts/*' \
+                 -o -path './tests/e2e/*' \
+                 -o \( -path './*.sh' ! -path './*/*' \) \) \
+              -print0
+          )
+
+          if [ "${#scripts[@]}" -eq 0 ]; then
+            echo "::error::No shell scripts found — check the find globs."
+            exit 1
+          fi
+
+          printf 'Linting %d shell script(s):\n' "${#scripts[@]}"
+          printf '  %s\n' "${scripts[@]}"
+
+          # -x follows `source`/`.` directives; --severity=warning fails on
+          # errors and warnings but not info/style notes.
+          shellcheck -x --severity=warning "${scripts[@]}"

--- a/scripts/mutation-pr.sh
+++ b/scripts/mutation-pr.sh
@@ -24,7 +24,8 @@
 
 set -euo pipefail
 
-readonly SCRIPT_NAME="$(basename "$0")"
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
 readonly BASE_REF="${1:-origin/main}"
 readonly TIMEOUT_SECONDS="${MUTATION_TIMEOUT_SECONDS:-1500}"
 readonly PER_MUTANT_TIMEOUT="${MUTATION_PER_MUTANT_TIMEOUT:-120}"

--- a/tests/e2e/pict/generate.sh
+++ b/tests/e2e/pict/generate.sh
@@ -198,7 +198,6 @@ while IFS=$'\t' read -r auth provider dlp policy format payload; do
         echo "HTTP ${status}"
 
         # Assertions
-        local asserts
         asserts=$(build_asserts "$status" "$auth" "$provider" "$dlp" "$format" "$payload")
         if [[ -n "$asserts" ]]; then
             echo "[Asserts]"

--- a/tests/e2e/tests/audit/A10-batch-signing.sh
+++ b/tests/e2e/tests/audit/A10-batch-signing.sh
@@ -4,7 +4,7 @@
 # For now, just verify that entries have the signature field.
 AUDIT_DIR="${1:?usage: $0 <audit_dir>}"
 RSSI_KEY="crypto/rssi.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 
 for f in "$AUDIT_DIR"/*; do
   decrypted=$(age -d -i "$RSSI_KEY" "$f" 2>/dev/null) || { echo "FAIL: cannot decrypt $f"; exit 1; }

--- a/tests/e2e/tests/audit/A11-tamper-detection.sh
+++ b/tests/e2e/tests/audit/A11-tamper-detection.sh
@@ -3,11 +3,13 @@
 # This is a negative test — tampering should be detectable.
 AUDIT_DIR="${1:?usage: $0 <audit_dir>}"
 RSSI_KEY="crypto/rssi.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 
 # Decrypt all entries into a temp JSONL file.
+# Bash expands globs in lexical (LC_COLLATE) order, so this matches the
+# previous `ls | sort` behaviour without the word-splitting fragility.
 PLAINTEXT=$(mktemp)
-for f in $(ls "$AUDIT_DIR"/* | sort); do
+for f in "$AUDIT_DIR"/*; do
   age -d -i "$RSSI_KEY" "$f" 2>/dev/null >> "$PLAINTEXT" || { echo "FAIL: cannot decrypt $f"; exit 1; }
   echo >> "$PLAINTEXT"
 done

--- a/tests/e2e/tests/audit/A2-signature-valid.sh
+++ b/tests/e2e/tests/audit/A2-signature-valid.sh
@@ -3,7 +3,7 @@
 # After decryption with rssi key, check that the entry has a valid signature field
 AUDIT_DIR="${1:?}"
 RSSI_KEY="crypto/rssi.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 for f in "$AUDIT_DIR"/*; do
   decrypted=$(age -d -i "$RSSI_KEY" "$f" 2>/dev/null) || { echo "FAIL: cannot decrypt $f"; exit 1; }
   sig=$(echo "$decrypted" | jq -r '.signature // empty' 2>/dev/null)

--- a/tests/e2e/tests/audit/A3-decrypt-rssi.sh
+++ b/tests/e2e/tests/audit/A3-decrypt-rssi.sh
@@ -2,7 +2,7 @@
 # A3: RSSI key can decrypt and produce valid JSON
 AUDIT_DIR="${1:?}"
 RSSI_KEY="crypto/rssi.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 for f in "$AUDIT_DIR"/*; do
   decrypted=$(age -d -i "$RSSI_KEY" "$f" 2>/dev/null) || { echo "FAIL: cannot decrypt $f with RSSI key"; exit 1; }
   echo "$decrypted" | jq . > /dev/null 2>&1 || { echo "FAIL: decrypted $f is not valid JSON"; exit 1; }

--- a/tests/e2e/tests/audit/A4-decrypt-dpo.sh
+++ b/tests/e2e/tests/audit/A4-decrypt-dpo.sh
@@ -2,7 +2,7 @@
 # A4: DPO key can decrypt and produce valid JSON
 AUDIT_DIR="${1:?}"
 DPO_KEY="crypto/dpo.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 for f in "$AUDIT_DIR"/*; do
   decrypted=$(age -d -i "$DPO_KEY" "$f" 2>/dev/null) || { echo "FAIL: cannot decrypt $f with DPO key"; exit 1; }
   echo "$decrypted" | jq . > /dev/null 2>&1 || { echo "FAIL: decrypted $f is not valid JSON"; exit 1; }

--- a/tests/e2e/tests/audit/A5-decrypt-intruder-fails.sh
+++ b/tests/e2e/tests/audit/A5-decrypt-intruder-fails.sh
@@ -2,7 +2,7 @@
 # A5: Intruder key must NOT decrypt any audit entry
 AUDIT_DIR="${1:?}"
 INTRUDER_KEY="crypto/intruder.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 for f in "$AUDIT_DIR"/*; do
   if age -d -i "$INTRUDER_KEY" "$f" > /dev/null 2>&1; then
     echo "FAIL: intruder decrypted $f — this should not be possible"

--- a/tests/e2e/tests/audit/A6-entry-has-model.sh
+++ b/tests/e2e/tests/audit/A6-entry-has-model.sh
@@ -2,7 +2,7 @@
 # A6: Decrypted entry must contain model name (EU AI Act Art. 12)
 AUDIT_DIR="${1:?}"
 RSSI_KEY="crypto/rssi.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 for f in "$AUDIT_DIR"/*; do
   model=$(age -d -i "$RSSI_KEY" "$f" | jq -r '.model // .model_name // empty' 2>/dev/null)
   [ -n "$model" ] || { echo "FAIL: no model field in $f"; exit 1; }

--- a/tests/e2e/tests/audit/A7-entry-has-tokens.sh
+++ b/tests/e2e/tests/audit/A7-entry-has-tokens.sh
@@ -2,7 +2,7 @@
 # A7: Decrypted entry must contain token counts (EU AI Act Art. 12)
 AUDIT_DIR="${1:?}"
 RSSI_KEY="crypto/rssi.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 for f in "$AUDIT_DIR"/*; do
   tokens=$(age -d -i "$RSSI_KEY" "$f" | jq -r '.token_counts // .usage // empty' 2>/dev/null)
   [ -n "$tokens" ] || { echo "FAIL: no token_counts/usage field in $f"; exit 1; }

--- a/tests/e2e/tests/audit/A8-entry-has-tenant.sh
+++ b/tests/e2e/tests/audit/A8-entry-has-tenant.sh
@@ -2,7 +2,7 @@
 # A8: Decrypted entry must contain tenant from JWT claims
 AUDIT_DIR="${1:?}"
 RSSI_KEY="crypto/rssi.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 for f in "$AUDIT_DIR"/*; do
   tenant=$(age -d -i "$RSSI_KEY" "$f" | jq -r '.tenant // .tenant_id // empty' 2>/dev/null)
   [ -n "$tenant" ] || { echo "FAIL: no tenant field in $f"; exit 1; }

--- a/tests/e2e/tests/audit/A9-chain-integrity.sh
+++ b/tests/e2e/tests/audit/A9-chain-integrity.sh
@@ -5,11 +5,13 @@
 # empty previous_hash.
 AUDIT_DIR="${1:?usage: $0 <audit_dir>}"
 RSSI_KEY="crypto/rssi.key"
-cd "$(dirname "$0")/../.."
+cd "$(dirname "$0")/../.." || exit 1
 
 # Decrypt all entries and sort by event_id or filename order.
+# Bash expands globs in lexical (LC_COLLATE) order, so this matches the
+# previous `ls | sort` behaviour without the word-splitting fragility.
 entries=()
-for f in $(ls "$AUDIT_DIR"/* | sort); do
+for f in "$AUDIT_DIR"/*; do
   decrypted=$(age -d -i "$RSSI_KEY" "$f" 2>/dev/null) || { echo "FAIL: cannot decrypt $f"; exit 1; }
   entries+=("$decrypted")
 done

--- a/tests/e2e/tests/audit/run-audit-tests.sh
+++ b/tests/e2e/tests/audit/run-audit-tests.sh
@@ -9,7 +9,7 @@ JWT=$(cat auth/tokens/jwt-hospital-eu.txt)
 rm -rf "$AUDIT_DIR" && mkdir -p "$AUDIT_DIR"
 
 echo "Generating audit entries..."
-for i in $(seq 1 3); do
+for _ in $(seq 1 3); do
   curl -sf -X POST "http://${HOST}/v1/chat/completions" \
     -H "Authorization: Bearer ${JWT}" \
     -H "Content-Type: application/json" \

--- a/tests/e2e/tests/compliance/C0-risk-webhook.sh
+++ b/tests/e2e/tests/compliance/C0-risk-webhook.sh
@@ -11,5 +11,7 @@ cd "$E2E_ROOT"
 HOST="${HOST:-127.0.0.1:13456}"
 JWT="${JWT:-$(cat auth/tokens/jwt-default.txt 2>/dev/null || echo "")}"
 
-resp=$(curl -sf "http://$HOST/health")
+# `-sf` + `set -e` make this fail loudly if the health endpoint is down;
+# the body is intentionally discarded (only the exit status matters).
+curl -sf "http://$HOST/health" >/dev/null
 echo "PASS: C0 — compliance features loaded (health ok)"

--- a/tests/e2e/tests/wizard/run-wizard-tests.sh
+++ b/tests/e2e/tests/wizard/run-wizard-tests.sh
@@ -11,7 +11,6 @@ set -euo pipefail
 #   ./run-wizard-tests.sh              # run all wizard tests
 #   ./run-wizard-tests.sh W1           # run a single test
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GROB="${GROB_BIN:-cargo run --quiet --}"
 TEST_HOME=$(mktemp -d)
 GROB_HOME="${TEST_HOME}/.grob"


### PR DESCRIPTION
## Summary

CI/shell hardening: introduces a ShellCheck gate for the repo's shell scripts and fixes every genuine finding it surfaces on the current tree. Scope is limited to shell scripts and `.github/workflows/`; no Rust or docs touched.

## Items

### 1. Real shell bug — SC2168 in `tests/e2e/pict/generate.sh`
`local asserts` was used inside a top-level `while ... done` loop, not inside a function. `local` is only valid in a function, so under `set -euo pipefail` this aborts the script at runtime. Removed the `local` keyword — every other variable in the same loop body is already a plain (non-local) script-scope variable, so this is the consistent fix.

### 2. New ShellCheck CI gate — `.github/workflows/shellcheck.yml`
A small dedicated workflow that runs `shellcheck -x --severity=warning` over the scoped scripts:

- **Scope:** `scripts/**/*.sh`, `tests/e2e/**/*.sh`, top-level `*.sh` (41 scripts). `demo/` is intentionally excluded to stay in lane.
- **`-x`** so `source`/`.` directives are followed.
- **`--severity=warning`** — sensible scoping that flags every genuine bug (errors + warnings, including the SC2168 class) while not failing on `info`-level notes for the harness's deliberate word-splitting idioms (`$GROB`, `$CURL_PID`, `$fn`).
- Matches repo workflow conventions: `step-security/harden-runner@v2` (audit egress), `concurrency` group with `cancel-in-progress`, `permissions: read-all`, `actions/checkout@v6`, `ubuntu-latest`, `timeout-minutes`.

To make the gate pass on the current tree, the following genuine warning-level findings were fixed:

- **SC2164** (`cd` without guard, no `set -e`): audit scripts `A2`–`A11` ran `cd "$(dirname "$0")/../.."` unguarded — a failed `cd` would silently run the rest in the wrong directory. Added `|| exit 1`.
- **SC2045/SC2046** (`ls` in a loop + word-splitting): `A9` and `A11` iterated `$(ls "$DIR"/* | sort)`. Replaced with a plain glob — bash already expands globs in lexical (`LC_COLLATE`) order, so behaviour is preserved without the fragility.
- **SC2034** (unused variable): `C0-risk-webhook.sh` assigned an unused `resp`. Now runs curl for its exit status only and discards the body.

### 3. Empty Hurl scaffold dirs — none to remove
The audit flagged `tests/e2e/tests/{wizard,fanout,compliance,audit}/` as empty placeholders, but in the current tree they are **not** empty — they contain the active shell test suites (`run-wizard-tests.sh`, `F0-fanout-fastest.sh`, `C0-risk-webhook.sh`, the full `A0`–`A13` audit suite). There are no empty directories anywhere under `tests/e2e`, so nothing was removed (removing them would delete real test coverage).

## Verification

- `shellcheck` execution was blocked by the sandbox in the authoring environment, so findings were determined by careful per-script analysis of all 41 scoped scripts (severity levels reasoned per ShellCheck wiki). The CI gate itself is the live verification.
- New workflow YAML validated by the repo's `check-yaml` pre-commit hook (passed).
- Find expression for the gate's scope verified to resolve to exactly the intended 41 scripts (scripts/** + tests/e2e/**, `demo/` excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)