### PR TITLE
fix(spend): don't panic on per-tenant journal open failure

### DIFF
--- a/src/features/token_pricing/spend.rs
+++ b/src/features/token_pricing/spend.rs
@@ -153,9 +153,10 @@ impl SpendTracker {
             // intentionally do not include tenant-tagged spend.
             self.data = store.load_spend(None);
         } else {
-            // No store available (test/CLI mode): track the tenant amount
-            // locally so future per-tenant budget checks behave correctly.
-            // Global counters are intentionally untouched.
+            // No store available (test/CLI mode): only month-reset bookkeeping
+            // runs here. Per-tenant amounts are intentionally NOT tracked in
+            // this mode — the store-backed path (production) is the source of
+            // truth for per-tenant budgets; global counters stay untouched.
             self.reset_if_new_month();
         }
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -240,21 +240,40 @@ impl GrobStore {
                 .tenant_journals
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
-            let journal_entry = tj.entry(safe_tenant.clone()).or_insert_with(|| {
-                let dir = self.base_dir.join("spend").join(&safe_tenant);
-                journal::SpendJournal::open_in(&dir)
-                    .unwrap_or_else(|e| panic!("open per-tenant spend journal: {e}"))
-            });
-            let tenant_event = journal::SpendEvent {
-                ts,
-                kind: "spend".to_string(),
-                provider: provider.to_string(),
-                model: model.to_string(),
-                cost_usd: amount,
-                tenant: Some(t.to_string()),
+            // Open the per-tenant journal lazily. A disk-full / permission error
+            // must NOT crash the spend path: log and skip the per-tenant append.
+            // The global journal above already holds a tenant-tagged copy of this
+            // event, so per-tenant spend remains recoverable.
+            use std::collections::hash_map::Entry;
+            let journal_entry = match tj.entry(safe_tenant.clone()) {
+                Entry::Occupied(occupied) => Some(occupied.into_mut()),
+                Entry::Vacant(vacant) => {
+                    let dir = self.base_dir.join("spend").join(&safe_tenant);
+                    match journal::SpendJournal::open_in(&dir) {
+                        Ok(journal) => Some(vacant.insert(journal)),
+                        Err(e) => {
+                            tracing::error!(
+                                tenant = %safe_tenant,
+                                "failed to open per-tenant spend journal; skipping per-tenant \
+                                 append (global journal retains a tagged copy): {e}"
+                            );
+                            None
+                        }
+                    }
+                }
             };
-            if let Err(e) = journal_entry.append(&tenant_event) {
-                tracing::warn!("failed to append per-tenant spend event: {e}");
+            if let Some(journal_entry) = journal_entry {
+                let tenant_event = journal::SpendEvent {
+                    ts,
+                    kind: "spend".to_string(),
+                    provider: provider.to_string(),
+                    model: model.to_string(),
+                    cost_usd: amount,
+                    tenant: Some(t.to_string()),
+                };
+                if let Err(e) = journal_entry.append(&tenant_event) {
+                    tracing::warn!("failed to append per-tenant spend event: {e}");
+                }
             }
         }
 


### PR DESCRIPTION
Final tail item. A disk-full / permission error while opening a per-tenant spend journal (`spend/<tenant>/<month>.jsonl`) crashed the whole spend path via `panic!`. Now degrades: logs an error and skips the per-tenant append (the global journal already holds a tenant-tagged copy, so per-tenant spend stays recoverable). Uses the `Entry` API so the fsync bookkeeping after it still runs.

Also corrects a misleading comment in `record_tenant`'s no-store branch (claimed local tenant tracking it doesn't do).

> Note: the audit's cosmetic "split `storage/mod.rs` (841 LOC)" item is **deferred** — the agent's attempt was a broken half-refactor; not worth shipping broken for a maintainability nicety.

clippy `-D warnings` + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)