### PR TITLE
fix(reload): don't gate config reload on live provider health (E2E regression)

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -251,11 +251,17 @@
 **Module:** `src/server/config_api.rs`
 **Intention:** Hot-reload the server configuration by atomically swapping the reloadable state (config, router, provider registry) without restarting the server. In-flight requests continue using the old snapshot.
 
+**Applies to both reload surfaces:** the HTTP `POST /api/config/reload`
+handler (`config_api::reload_config`) and the JSON-RPC
+`grob/server/reload_config` method (`rpc::server_ns::reload_config`). Both
+enforce the same contract.
+
 **Invariants:**
 - INV-1 (Atomicity): The swap from old to new state is a single write-lock assignment. No intermediate state is visible to readers.
 - INV-2 (Non-reloadable preservation): Token store, grob store, event bus, and other persistent state are NOT replaced. Only `ReloadableState` changes.
 - INV-3 (Error safety): If config parsing or provider initialization fails, the old config remains active. No partial reload.
 - INV-4 (Snapshot isolation): Requests that started before the reload continue using the old `Arc<ReloadableState>` snapshot (reference counting).
+- INV-5 (Structural-reject only): Reload rejects a candidate **only** for *structural* breakage — a parse error, an `AppConfig::validate()` failure (model mapping → unknown provider, missing provider auth, invalid router regex), or a provider-registry build failure. It does **NOT** gate the swap on *live* provider health. A structurally-valid config is always swapped in even if a live `validate_config` probe would fail, because a provider being momentarily unreachable must not block a config swap.
 
 **Preconditions:**
 - Server is running with valid initial config
@@ -263,21 +269,23 @@
 
 **Postconditions:**
 - On success: new config is active for all subsequent requests
-- On failure: old config remains active, error response returned
-- Background validation task is spawned after successful reload
+- On structural failure: old config remains active, 4xx error response returned
+- A detached, fire-and-forget live-health probe task (`spawn_health_probe`) is spawned **after** the successful swap. It only logs warnings on unhealthy mappings; it never reverts the reload.
 
 **Boundary behavior:**
-- Config file missing: returns error, old config preserved
-- Provider initialization fails: returns error, old config preserved
+- Config file missing / parse error: returns error, old config preserved
+- Provider initialization (registry build) fails: returns error, old config preserved
+- Provider reachable but a live probe fails: reload still succeeds (200); a warning is logged by the detached probe
 - Concurrent reload requests: serialized by write lock
 
 **Known drifts:**
-- (none recorded yet)
+- 2026-05: PR #350 introduced a live-health gate (awaited `validate_config` + `reject_if_validation_broken`) that returned HTTP 422 / a JSON-RPC error when any router model lacked a healthy *live* mapping. This conflated structural validity with live health, turning the E2E reload tests red (mock pod can't pass the probe). Reverted to structural-reject + detached log-only probe to satisfy INV-5.
 
 **Red flags to detect:**
 - Any persistent state (token_store, grob_store) being replaced during reload
 - Partial state update (e.g., router updated but registry not)
 - Missing error handling that allows partial reload
+- An **awaited** live-health probe (`validate_config`) gating the swap, or any reload rejection keyed on `any_ok()` / live mapping health (violates INV-5)
 
 ---
 

--- a/src/server/config_api.rs
+++ b/src/server/config_api.rs
@@ -209,11 +209,15 @@ pub(crate) async fn update_config_json(
 
 /// Reload configuration without restarting the server.
 ///
-/// The handler **awaits** validation against the candidate provider registry
-/// before swapping the live config. If any router model has no healthy
-/// provider the reload is rejected with a 4xx and the in-flight `inner`
-/// snapshot is left untouched, so requests never observe a half-validated
-/// config and a misconfigured reload cannot briefly serve traffic.
+/// Rejects only **structurally** invalid candidates: a parse error, an
+/// `AppConfig::validate()` failure (model mapping references an unknown
+/// provider, missing provider auth, bad router regex), or a provider-registry
+/// build failure surface as a 4xx and leave the live `inner` snapshot
+/// untouched. A structurally-valid candidate is always swapped in — the reload
+/// is **not** gated on live provider health, because a provider being
+/// momentarily unreachable must not block a config swap. Health is still
+/// observed: `validate_config`'s live probes run in a detached task that only
+/// logs warnings on unhealthy mappings.
 pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Response {
     use axum::http::StatusCode;
 
@@ -265,42 +269,32 @@ pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Respons
         }
     };
 
-    // 4. Validate the candidate config BEFORE swapping. Awaiting here is
-    //    intentional — if validation fails we must surface the error and keep
-    //    the live snapshot intact, so in-flight requests never observe a
-    //    half-validated config.
-    info!("🔍 Validating reloaded config...");
-    let validation = crate::preset::validate_config(&new_config, &new_registry).await;
-    crate::preset::log_validation_results(&validation);
-
-    if let Some(rejection) = reject_if_validation_broken(&validation) {
-        error!(
-            "Configuration reload rejected: validation failed for {}",
-            rejection.detail
-        );
-        return (
-            StatusCode::UNPROCESSABLE_ENTITY,
-            Json(serde_json::json!({
-                "status": "error",
-                "message": format!(
-                    "Validation failed — config not reloaded. Models with no healthy provider: {}",
-                    rejection.detail,
-                ),
-                "broken_models": rejection.broken_models,
-            })),
-        )
-            .into_response();
-    }
-
-    // 5. Create new reloadable state and atomically swap (write lock held for
+    // 4. Create new reloadable state and atomically swap (write lock held for
     //    microseconds). In-flight requests continue on the old snapshot because
     //    they hold an `Arc<ReloadableState>` taken before the swap.
-    let new_inner = Arc::new(ReloadableState::new(new_config, new_router, new_registry));
+    //
+    //    The candidate is already structurally valid here: `from_source`
+    //    re-parsed it and ran `AppConfig::validate()` (model→provider mappings,
+    //    provider auth, router regexes), and `from_configs_with_models`
+    //    confirmed the registry builds. We do NOT gate the swap on live
+    //    provider health — a momentarily unreachable provider must not block a
+    //    config reload.
+    let new_inner = Arc::new(ReloadableState::new(
+        new_config.clone(),
+        new_router,
+        new_registry.clone(),
+    ));
 
     let active = state
         .active_requests
         .load(std::sync::atomic::Ordering::Relaxed);
     *state.inner.write().unwrap_or_else(|e| e.into_inner()) = new_inner;
+
+    // 5. Spawn a detached live-health probe purely as a signal. It sends a
+    //    minimal request to each router mapping and logs warnings on unhealthy
+    //    ones, mirroring the `validate_on_start` task in `server::init`. It runs
+    //    after the swap and never blocks or reverts the reload.
+    spawn_health_probe(new_config, new_registry);
 
     if active > 0 {
         info!(
@@ -319,147 +313,34 @@ pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Respons
     .into_response()
 }
 
-/// Internal carrier for a validation rejection — feeds the 4xx response body.
+/// Spawns a detached live-health probe over a reloaded config's router models.
 ///
-/// Extracted so the rejection logic can be unit-tested without standing up an
-/// [`AppState`] or a full router.
-struct ValidationRejection {
-    detail: String,
-    broken_models: Vec<serde_json::Value>,
-}
+/// Sends a minimal request to every router mapping and logs warnings on
+/// unhealthy ones. Runs as a fire-and-forget [`tokio::spawn`] **after** the
+/// atomic swap, so it provides a health signal without ever blocking or
+/// reverting the reload — a provider being momentarily unreachable does not
+/// fail the swap. Mirrors the `validate_on_start` task in [`super::init`].
+pub(crate) fn spawn_health_probe(config: AppConfig, registry: Arc<ProviderRegistry>) {
+    tokio::spawn(async move {
+        info!("🔍 Probing reloaded config provider health...");
+        let results = crate::preset::validate_config(&config, &registry).await;
+        crate::preset::log_validation_results(&results);
 
-/// Returns `Some(rejection)` when a router model has zero healthy providers.
-///
-/// Reports the first failing router model(s) so the reload handler can
-/// short-circuit and leave the live config untouched, upholding the
-/// "in-flight requests keep using the old snapshot" invariant. Returns `None`
-/// when every router model has at least one healthy mapping (or none are
-/// declared, preserving the soft contract for minimal configs).
-fn reject_if_validation_broken(
-    validation: &[crate::preset::ModelValidation],
-) -> Option<ValidationRejection> {
-    let broken: Vec<&crate::preset::ModelValidation> =
-        validation.iter().filter(|m| !m.any_ok()).collect();
-    if broken.is_empty() {
-        return None;
-    }
-    let detail = broken
-        .iter()
-        .map(|m| format!("{} [{}]", m.model_name, m.role))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let broken_models = broken
-        .iter()
-        .map(|m| {
-            serde_json::json!({
-                "model": m.model_name,
-                "role": m.role,
-            })
-        })
-        .collect();
-    Some(ValidationRejection {
-        detail,
-        broken_models,
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::preset::{MappingResult, ModelValidation};
-
-    fn ok_mapping() -> MappingResult {
-        MappingResult {
-            priority: 1,
-            provider: "p".into(),
-            actual_model: "m".into(),
-            ok: true,
-            detail: "OK (12ms)".into(),
+        let total = results.len();
+        let healthy = results.iter().filter(|r| r.any_ok()).count();
+        if healthy == total {
+            info!("✅ Reload health probe: {healthy}/{total} models healthy");
+        } else {
+            let unhealthy = results
+                .iter()
+                .filter(|r| !r.any_ok())
+                .map(|r| format!("{} [{}]", r.model_name, r.role))
+                .collect::<Vec<_>>()
+                .join(", ");
+            warn!(
+                "⚠️ Reload health probe: {healthy}/{total} models healthy — \
+                 no healthy provider for: {unhealthy} (config still reloaded)"
+            );
         }
-    }
-
-    fn broken_mapping(detail: &str) -> MappingResult {
-        MappingResult {
-            priority: 1,
-            provider: "p".into(),
-            actual_model: "m".into(),
-            ok: false,
-            detail: detail.into(),
-        }
-    }
-
-    #[test]
-    fn empty_validation_passes() {
-        // No router models declared → nothing to validate → no rejection.
-        // Preserves the prior "soft" reload contract for minimal configs.
-        assert!(reject_if_validation_broken(&[]).is_none());
-    }
-
-    #[test]
-    fn all_ok_validation_passes() {
-        let results = vec![ModelValidation {
-            model_name: "default".into(),
-            role: "default".into(),
-            mappings: vec![ok_mapping()],
-        }];
-        assert!(reject_if_validation_broken(&results).is_none());
-    }
-
-    #[test]
-    fn at_least_one_healthy_mapping_passes() {
-        // any_ok() — a single healthy mapping is enough; a fallback being
-        // rate-limited at reload time should not block the reload.
-        let results = vec![ModelValidation {
-            model_name: "default".into(),
-            role: "default".into(),
-            mappings: vec![ok_mapping(), broken_mapping("429 - rate limited")],
-        }];
-        assert!(reject_if_validation_broken(&results).is_none());
-    }
-
-    #[test]
-    fn rejects_when_any_router_model_has_zero_healthy_mappings() {
-        // Regression guard for the race this fix targets: a config where a
-        // router slot points at a model with no working provider must NOT be
-        // swapped in.
-        let results = vec![
-            ModelValidation {
-                model_name: "default".into(),
-                role: "default".into(),
-                mappings: vec![ok_mapping()],
-            },
-            ModelValidation {
-                model_name: "missing-think-model".into(),
-                role: "think".into(),
-                mappings: vec![broken_mapping("Model not found in [[models]]")],
-            },
-        ];
-        let rejection = reject_if_validation_broken(&results)
-            .expect("expected rejection for the broken router model");
-        assert!(rejection.detail.contains("missing-think-model [think]"));
-        assert_eq!(rejection.broken_models.len(), 1);
-        assert_eq!(rejection.broken_models[0]["model"], "missing-think-model");
-        assert_eq!(rejection.broken_models[0]["role"], "think");
-    }
-
-    #[test]
-    fn rejects_with_multiple_broken_models_in_detail() {
-        let results = vec![
-            ModelValidation {
-                model_name: "default".into(),
-                role: "default".into(),
-                mappings: vec![broken_mapping("connection refused")],
-            },
-            ModelValidation {
-                model_name: "think".into(),
-                role: "think".into(),
-                mappings: vec![broken_mapping("connection refused")],
-            },
-        ];
-        let rejection =
-            reject_if_validation_broken(&results).expect("expected rejection for broken models");
-        assert!(rejection.detail.contains("default [default]"));
-        assert!(rejection.detail.contains("think [think]"));
-        assert_eq!(rejection.broken_models.len(), 2);
-    }
+    });
 }

--- a/src/server/rpc/server_ns.rs
+++ b/src/server/rpc/server_ns.rs
@@ -39,9 +39,11 @@ pub async fn status(
 
 /// Triggers an atomic configuration reload.
 ///
-/// Awaits validation against the candidate registry **before** swapping the
-/// live snapshot. A failure surfaces as a JSON-RPC error and the in-flight
-/// `inner` snapshot stays untouched — the same contract the HTTP
+/// Rejects only **structurally** invalid candidates (parse error,
+/// `AppConfig::validate()` failure, or provider-registry build failure) as a
+/// JSON-RPC error, leaving the in-flight `inner` snapshot untouched. A
+/// structurally-valid candidate is always swapped in — the reload is **not**
+/// gated on live provider health. The same contract the HTTP
 /// `/api/config/reload` endpoint enforces.
 pub async fn reload_config(
     state: &Arc<AppState>,
@@ -80,33 +82,26 @@ pub async fn reload_config(
     .map(Arc::new)
     .map_err(|e| rpc_err(ERR_INTERNAL, format!("Failed to init providers: {e}")))?;
 
-    // Awaited validation BEFORE the swap so a misconfigured reload cannot
-    // briefly serve traffic. In-flight requests continue on the old snapshot
-    // via their cached `Arc<ReloadableState>`.
-    let validation = crate::preset::validate_config(&new_config, &new_registry).await;
-    crate::preset::log_validation_results(&validation);
-    let broken: Vec<&crate::preset::ModelValidation> =
-        validation.iter().filter(|m| !m.any_ok()).collect();
-    if !broken.is_empty() {
-        let detail = broken
-            .iter()
-            .map(|m| format!("{} [{}]", m.model_name, m.role))
-            .collect::<Vec<_>>()
-            .join(", ");
-        return Err(rpc_err(
-            ERR_INTERNAL,
-            format!(
-                "Validation failed — config not reloaded. Models with no healthy provider: {detail}"
-            ),
-        ));
-    }
-
-    let new_inner = Arc::new(ReloadableState::new(new_config, new_router, new_registry));
+    // The candidate is already structurally valid: `from_source` re-parsed it
+    // and ran `AppConfig::validate()`, and `from_configs_with_models` confirmed
+    // the registry builds. We do NOT gate the swap on live provider health — a
+    // momentarily unreachable provider must not block a config reload.
+    // In-flight requests continue on the old snapshot via their cached
+    // `Arc<ReloadableState>`.
+    let new_inner = Arc::new(ReloadableState::new(
+        new_config.clone(),
+        new_router,
+        new_registry.clone(),
+    ));
 
     let active = state
         .active_requests
         .load(std::sync::atomic::Ordering::Relaxed);
     *state.inner.write().unwrap_or_else(|e| e.into_inner()) = new_inner;
+
+    // Detached live-health probe as a signal only: logs warnings on unhealthy
+    // router mappings after the swap, never blocking or reverting the reload.
+    crate::server::config_api::spawn_health_probe(new_config, new_registry);
 
     Ok(StatusResponse {
         status: "ok".into(),


### PR DESCRIPTION
## The regression

PR #350 made the config-reload endpoints gate the atomic swap on **live provider health**. Both reload surfaces began awaiting `crate::preset::validate_config(&new_config, &new_registry)` — which sends a `max_tokens=1` "Say OK" probe to **every** provider mapping — and then rejected the reload when any router model lacked a healthy *live* mapping:

- HTTP `POST /api/config/reload` (`config_api::reload_config`) returned **422 UNPROCESSABLE_ENTITY**.
- JSON-RPC `grob/server/reload_config` (`rpc::server_ns::reload_config`) returned a JSON-RPC error.

In the mock E2E pod the live probe never passes, so reload returned 422/error instead of 200, turning the E2E CI red:

- `tests/e2e/tests/happy/06-config-reload.hurl`
- `tests/e2e/tests/happy/15-config-reload-idempotent.hurl`

Both assert **HTTP 200**. The baseline (pre-#350) CI was green.

## Root issue

Reload conflated **structural validity** (config parses; router slots reference existing `[[models]]`; provider auth present — already enforced by `AppConfig` deserialization + `AppConfig::validate()` inside `AppConfig::from_source`) with **live provider health** (`validate_config`'s network probes). A config swap must not be blocked because a provider is momentarily unreachable.

## The fix

Removed the live-health gate from the reload swap on **both** endpoints. Reload now rejects only **structurally** broken configs:

- a parse error,
- an `AppConfig::validate()` failure (model mapping → unknown provider, missing provider auth, invalid router regex),
- a provider-registry build failure.

These already surface as a 4xx earlier in the pipeline (via `AppConfig::from_source` at step 1 and `ProviderRegistry::from_configs_with_models`). A structurally-valid config is always swapped in even if a live probe would fail.

The health *signal* is preserved without blocking: a shared `config_api::spawn_health_probe(config, registry)` helper runs `validate_config` in a detached `tokio::spawn` **after** the atomic swap and only logs warnings on unhealthy mappings — mirroring the pre-#350 `validate_on_start` task in `server::init`.

### Changes
- `src/server/config_api.rs`: dropped the awaited `validate_config` + `reject_if_validation_broken` gate; swap first, then `spawn_health_probe`. Removed `reject_if_validation_broken`, the `ValidationRejection` carrier, and their now-obsolete unit tests.
- `src/server/rpc/server_ns.rs`: same change, delegating to the shared `spawn_health_probe`.
- `CONTRACTS.md`: added **INV-5 (Structural-reject only)** to the `reload_config` contract, recorded the #350 drift, and noted both reload surfaces share the contract.

### Why the E2E reload tests now pass
`POST /api/config/reload` on a structurally-valid config performs the parse + `validate()` + registry build (all succeed in the mock pod), atomically swaps, and returns **200** — the live probe is detached and never affects the status code. So `06-config-reload.hurl` and `15-config-reload-idempotent.hurl` see HTTP 200 again.

### Genuine structural-rejection guarantee is preserved
A config with an unknown provider reference, missing provider auth, or a bad router regex still fails `AppConfig::validate()` and returns a 4xx, leaving the live snapshot untouched (INV-3).

## Gates (all green locally)
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --no-default-features --features dlp,oauth,tap,compliance,mcp,watch,policies,socket-opts,dirs -- -D warnings`
- `cargo test --lib` (1188 passed) and `cargo test --test lib` (267 passed)
- `RUSTDOCFLAGS='-W missing-docs' cargo doc --no-deps` — no new missing-docs warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)