### PR TITLE
fix(openai): make ChatGPT Codex (OAuth) work for streaming and non-streaming

### DIFF
--- a/docs/examples/chatgpt-codex-oauth.toml
+++ b/docs/examples/chatgpt-codex-oauth.toml
@@ -1,0 +1,71 @@
+# ChatGPT Codex OAuth Configuration Example
+#
+# Routes grob at OpenAI Codex using a ChatGPT Plus/Pro subscription via OAuth —
+# no API key and no pay-as-you-go credits required. grob authenticates with your
+# ChatGPT login and calls the Codex backend (`chatgpt.com/backend-api`) that the
+# subscription covers.
+#
+# Setup:
+#   1. grob -c chatgpt-codex-oauth.toml connect openai-codex   # one-time browser login
+#   2. grob -c chatgpt-codex-oauth.toml start
+#
+# Models exposed to a Plus account via Codex OAuth:
+#   gpt-5.5        newest frontier model — OpenAI's recommended default
+#   gpt-5.4        flagship reasoning + coding
+#   gpt-5.4-mini   fast / sub-agent tier
+#   gpt-5.3-codex  dedicated agentic-coding model (strongest on SWE-bench)
+# `gpt-5.3-codex-spark` requires ChatGPT Pro. There is no `gpt-5.5-codex`
+# (GPT-5.5 in Codex is just `gpt-5.5`).
+
+[server]
+host = "127.0.0.1"
+port = 13456
+log_level = "info"
+
+[server.timeouts]
+api_timeout_ms = 600000
+connect_timeout_ms = 10000
+
+# OAuth provider — authenticates with ChatGPT instead of an API key.
+# `base_url` is ignored under OAuth: grob targets the ChatGPT Codex backend.
+[[providers]]
+name = "chatgpt-codex"
+provider_type = "openai"
+auth_type = "oauth"           # Use OAuth instead of api_key.
+oauth_provider = "openai-codex"  # Token key in the TokenStore (set by `grob connect`).
+enabled = true
+models = []                   # Models are declared in the [[models]] blocks below.
+
+# Default dev model: gpt-5.5 (OpenAI's recommended Codex default).
+# To prefer the dedicated coding model, set `default = "codex"` under [router].
+[[models]]
+name = "dev"
+
+[[models.mappings]]
+provider = "chatgpt-codex"
+actual_model = "gpt-5.5"
+priority = 1
+
+# Dedicated agentic-coding model.
+[[models]]
+name = "codex"
+
+[[models.mappings]]
+provider = "chatgpt-codex"
+actual_model = "gpt-5.3-codex"
+priority = 1
+
+# Fast / background tier.
+[[models]]
+name = "fast"
+
+[[models.mappings]]
+provider = "chatgpt-codex"
+actual_model = "gpt-5.4-mini"
+priority = 1
+
+[router]
+default = "dev"
+think = "codex"
+background = "fast"
+websearch = "dev"

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ Grob accepts requests in both Anthropic and OpenAI API formats, normalizes them,
 |-------|------|
 | Default config | [`examples/default.toml`](examples/default.toml) |
 | Anthropic Claude Max via OAuth | [`examples/claude-max-oauth.toml`](examples/claude-max-oauth.toml) |
+| ChatGPT Codex via OAuth (Plus/Pro) | [`examples/chatgpt-codex-oauth.toml`](examples/chatgpt-codex-oauth.toml) |
 | DeepSeek-only setup | [`examples/deepseek.toml`](examples/deepseek.toml) |
 | Multi-provider mix with fallbacks | [`examples/mixed.toml`](examples/mixed.toml) |
 | Model declaration patterns | [`examples/models.toml`](examples/models.toml) |

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -350,16 +350,29 @@ impl LlmProvider for OpenAIProvider {
         let base_url = self.effective_base_url();
         let is_codex = Self::is_codex_model(&request.model);
 
-        let (url, request_body) = if is_codex {
+        // The ChatGPT backend (OAuth) and any Codex model speak the Responses
+        // API, which streams typed events; everything else uses Chat Completions.
+        // Mirrors the endpoint choice in the non-streaming `send_message`.
+        let use_responses = self.base.is_oauth() || is_codex;
+
+        let (url, request_body) = if use_responses {
+            // OAuth serves the stream under `/codex/responses`; the public API
+            // uses `/responses`. Mirrors the non-streaming `send_responses_api`.
+            let endpoint = if self.base.is_oauth() {
+                "/codex/responses"
+            } else {
+                "/responses"
+            };
             tracing::debug!(
-                "Using /v1/responses endpoint for Codex model (streaming): {}",
+                "Using {} endpoint for Responses-API stream: {}",
+                endpoint,
                 request.model
             );
             let responses_request =
                 transform::transform_to_responses_request(&request, CODEX_INSTRUCTIONS)?;
             let body = serde_json::to_value(&responses_request)
                 .map_err(ProviderError::SerializationError)?;
-            (format!("{}/responses", base_url), body)
+            (format!("{}{}", base_url, endpoint), body)
         } else {
             let openai_request = transform::transform_request(&request)?;
             let body =
@@ -377,7 +390,7 @@ impl LlmProvider for OpenAIProvider {
 
         if self.base.is_oauth() {
             req_builder =
-                Self::apply_oauth_headers(req_builder, &auth_value, is_codex, &self.base.name);
+                Self::apply_oauth_headers(req_builder, &auth_value, use_responses, &self.base.name);
         }
 
         req_builder = self.base.apply_headers(req_builder);
@@ -404,14 +417,22 @@ impl LlmProvider for OpenAIProvider {
         let sse_stream = SseStream::new(response.bytes_stream());
         let provider_name = self.base.name.clone();
         let model_name = request.model.clone();
+        let model_for_events = request.model.clone();
 
         let transformed_stream = sse_stream
             .then(move |result| {
                 let message_id = message_id.clone();
                 let state = state.clone();
                 let provider_name = provider_name.clone();
+                let model_for_events = model_for_events.clone();
                 async move {
                     match result {
+                        Ok(sse_event) if use_responses => process_codex_sse_event(
+                            &sse_event.data,
+                            &state,
+                            &message_id,
+                            &model_for_events,
+                        ),
                         Ok(sse_event) => {
                             process_sse_event(&sse_event.data, &state, &message_id, &provider_name)
                         }
@@ -468,6 +489,35 @@ impl LlmProvider for OpenAIProvider {
             .as_ref()
             .is_some_and(|pool| pool.rotate_on_error())
     }
+}
+
+/// Transform one Responses-API SSE event into Anthropic SSE.
+///
+/// Wraps [`streaming::transform_codex_event_to_anthropic_sse`] with the same
+/// guards as [`process_sse_event`]: skip once the stream has ended and ignore
+/// keepalive / `[DONE]` lines.
+fn process_codex_sse_event(
+    data: &str,
+    state: &std::sync::Arc<std::sync::Mutex<StreamTransformState>>,
+    message_id: &str,
+    model: &str,
+) -> Result<Bytes, ProviderError> {
+    if state.lock().unwrap_or_else(|e| e.into_inner()).stream_ended {
+        return Ok(Bytes::new());
+    }
+
+    let trimmed = data.trim();
+    if trimmed.is_empty() || trimmed == "[DONE]" {
+        return Ok(Bytes::new());
+    }
+
+    let sse_output = streaming::transform_codex_event_to_anthropic_sse(
+        data,
+        message_id,
+        model,
+        &mut state.lock().unwrap_or_else(|e| e.into_inner()),
+    );
+    Ok(Bytes::from(sse_output))
 }
 
 /// Transform a single OpenAI SSE event into Anthropic SSE format.

--- a/src/providers/openai/streaming.rs
+++ b/src/providers/openai/streaming.rs
@@ -286,3 +286,189 @@ fn emit_stream_end(
         output_tokens
     );
 }
+
+/// Ensures the Anthropic `message_start` event is emitted exactly once.
+fn ensure_message_started(
+    output: &mut String,
+    state: &mut StreamTransformState,
+    message_id: &str,
+    model: &str,
+) {
+    if !state.message_started {
+        emit_message_start(output, message_id, model);
+        state.message_started = true;
+    }
+}
+
+/// Transform a single ChatGPT/Codex Responses-API SSE event to Anthropic SSE.
+///
+/// The Responses API streams typed events (`response.output_text.delta`,
+/// `response.reasoning_summary_text.delta`, `response.completed`, …) instead of
+/// Chat-Completions `choices[].delta` chunks. Text deltas map to a `text` block,
+/// reasoning summary deltas to a `thinking` block, and `response.completed`
+/// closes the message. Events without an Anthropic equivalent yield an empty
+/// string (filtered out downstream).
+pub(crate) fn transform_codex_event_to_anthropic_sse(
+    data: &str,
+    message_id: &str,
+    model: &str,
+    state: &mut StreamTransformState,
+) -> String {
+    let mut output = String::new();
+
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(data) else {
+        return output;
+    };
+    let event_type = json
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+
+    match event_type {
+        "response.created" => ensure_message_started(&mut output, state, message_id, model),
+        ty if ty.ends_with("output_text.delta") => {
+            ensure_message_started(&mut output, state, message_id, model);
+            if let Some(delta) = json.get("delta").and_then(|v| v.as_str()) {
+                if !delta.is_empty() {
+                    emit_text_delta(&mut output, state, delta);
+                }
+            }
+        }
+        ty if ty.contains("reasoning") && ty.ends_with(".delta") => {
+            ensure_message_started(&mut output, state, message_id, model);
+            if let Some(delta) = json.get("delta").and_then(|v| v.as_str()) {
+                if !delta.is_empty() {
+                    emit_reasoning_delta(&mut output, state, delta);
+                }
+            }
+        }
+        "response.completed" | "response.incomplete" | "response.failed" => {
+            ensure_message_started(&mut output, state, message_id, model);
+            emit_codex_stream_end(&mut output, state, &json);
+        }
+        _ => {}
+    }
+
+    output
+}
+
+/// Closes any open content blocks and emits `message_delta` + `message_stop`
+/// for a terminal Responses-API event (`response.completed` / `.incomplete`).
+fn emit_codex_stream_end(
+    output: &mut String,
+    state: &mut StreamTransformState,
+    json: &serde_json::Value,
+) {
+    if state.stream_ended {
+        return;
+    }
+    state.stream_ended = true;
+
+    close_open_blocks(output, state);
+    for block_index in state.tool_blocks.values() {
+        emit_block_stop(output, *block_index);
+    }
+
+    let response = json.get("response");
+    let status = response
+        .and_then(|r| r.get("status"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("completed");
+    let stop_reason = if state.had_tool_calls {
+        "tool_use"
+    } else if status == "incomplete" {
+        "max_tokens"
+    } else {
+        "end_turn"
+    };
+
+    let usage = response.and_then(|r| r.get("usage"));
+    let input_tokens = usage
+        .and_then(|u| u.get("input_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let output_tokens = usage
+        .and_then(|u| u.get("output_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let message_delta = serde_json::json!({
+        "type": "message_delta",
+        "delta": { "stop_reason": stop_reason, "stop_sequence": null },
+        "usage": { "input_tokens": input_tokens, "output_tokens": output_tokens }
+    });
+    output.push_str(&format!(
+        "event: message_delta\ndata: {}\n\n",
+        message_delta
+    ));
+    output.push_str(&format!(
+        "event: message_stop\ndata: {}\n\n",
+        serde_json::json!({ "type": "message_stop" })
+    ));
+}
+
+#[cfg(test)]
+mod codex_stream_tests {
+    use super::transform_codex_event_to_anthropic_sse as transform;
+    use crate::providers::openai::types::StreamTransformState;
+
+    fn run(events: &[&str]) -> String {
+        let mut state = StreamTransformState::default();
+        let mut out = String::new();
+        for event in events {
+            out.push_str(&transform(event, "msg_test", "gpt-5.5", &mut state));
+        }
+        out
+    }
+
+    #[test]
+    fn emits_message_start_then_incremental_text_then_stop() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_text.delta","delta":"Hel"}"#,
+            r#"{"type":"response.output_text.delta","delta":"lo"}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+        assert!(out.contains("event: message_start"));
+        assert!(out.contains("event: content_block_start"));
+        assert!(out.contains("text_delta"));
+        assert!(out.contains(r#""text":"Hel""#));
+        assert!(out.contains(r#""text":"lo""#));
+        assert!(out.contains("end_turn"));
+        assert_eq!(out.matches("event: message_stop").count(), 1);
+        assert_eq!(out.matches("event: message_start").count(), 1);
+    }
+
+    #[test]
+    fn maps_reasoning_delta_to_thinking_block() {
+        let out = run(&[
+            r#"{"type":"response.reasoning_summary_text.delta","delta":"weighing"}"#,
+            r#"{"type":"response.output_text.delta","delta":"answer"}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+        assert!(out.contains("thinking_delta"));
+        assert!(out.contains(r#""thinking":"weighing""#));
+        assert!(out.contains(r#""text":"answer""#));
+        // The thinking block is closed before the text block opens.
+        assert!(out.contains("event: content_block_stop"));
+    }
+
+    #[test]
+    fn incomplete_status_maps_to_max_tokens() {
+        let out = run(&[
+            r#"{"type":"response.output_text.delta","delta":"x"}"#,
+            r#"{"type":"response.incomplete","response":{"status":"incomplete"}}"#,
+        ]);
+        assert!(out.contains("max_tokens"));
+    }
+
+    #[test]
+    fn unknown_events_and_garbage_are_ignored() {
+        let out = run(&[
+            "not json",
+            r#"{"type":"response.in_progress"}"#,
+            r#"{"type":"response.output_item.added","item":{"type":"message"}}"#,
+        ]);
+        assert!(out.is_empty());
+    }
+}

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -435,41 +435,60 @@ pub(crate) fn transform_response(response: OpenAIResponse) -> ProviderResponse {
 
 /// Parse SSE response from ChatGPT Codex and extract content blocks.
 ///
-/// Finds the `response.completed` event and extracts reasoning + message output.
+/// The ChatGPT backend (`backend-api/codex`) delivers each finished block in a
+/// `response.output_item.done` event and leaves `response.completed.output`
+/// empty, whereas the standard Responses API populates `output[]` in the
+/// `response.completed` event. Both layouts are handled: per-item events win,
+/// with the completed-event output as a fallback.
 pub(crate) fn parse_sse_response(sse_text: &str) -> Result<Vec<ContentBlock>, ProviderError> {
     let lines: Vec<&str> = sse_text.lines().collect();
 
+    let mut item_blocks: Vec<ContentBlock> = Vec::new();
+    let mut completed_blocks: Vec<ContentBlock> = Vec::new();
+
     for (i, line) in lines.iter().enumerate() {
-        if !line.starts_with("event: response.completed") {
+        let Some(event) = line.strip_prefix("event: ").map(str::trim) else {
+            continue;
+        };
+        if event != "response.output_item.done" && event != "response.completed" {
             continue;
         }
 
-        let Some(data_line) = lines.get(i + 1) else {
-            continue;
-        };
-        let Some(json_str) = data_line.strip_prefix("data: ") else {
+        // The SSE `data:` payload sits on the line immediately after `event:`.
+        let Some(json_str) = lines.get(i + 1).and_then(|l| l.strip_prefix("data: ")) else {
             continue;
         };
         let Ok(json) = serde_json::from_str::<serde_json::Value>(json_str) else {
             continue;
         };
 
-        let Some(output) = json
-            .get("response")
-            .and_then(|r| r.get("output"))
-            .and_then(|v| v.as_array())
-        else {
-            continue;
-        };
-
-        let content_blocks: Vec<ContentBlock> = output
-            .iter()
-            .filter_map(extract_codex_output_block)
-            .collect();
-
-        if !content_blocks.is_empty() {
-            return Ok(content_blocks);
+        match event {
+            "response.output_item.done" => {
+                if let Some(block) = json.get("item").and_then(extract_codex_output_block) {
+                    item_blocks.push(block);
+                }
+            }
+            "response.completed" => {
+                if let Some(output) = json
+                    .get("response")
+                    .and_then(|r| r.get("output"))
+                    .and_then(|v| v.as_array())
+                {
+                    completed_blocks.extend(output.iter().filter_map(extract_codex_output_block));
+                }
+            }
+            _ => {}
         }
+    }
+
+    let content_blocks = if item_blocks.is_empty() {
+        completed_blocks
+    } else {
+        item_blocks
+    };
+
+    if !content_blocks.is_empty() {
+        return Ok(content_blocks);
     }
 
     Err(ProviderError::ApiError {
@@ -481,8 +500,11 @@ pub(crate) fn parse_sse_response(sse_text: &str) -> Result<Vec<ContentBlock>, Pr
 /// Maps a Codex `output[]` item (`reasoning` or `message`) to the corresponding Anthropic thinking or text block.
 fn extract_codex_output_block(item: &serde_json::Value) -> Option<ContentBlock> {
     let output_type = item.get("type").and_then(|v| v.as_str())?;
+    // `message` items carry text under `content[]`; `reasoning` items carry it
+    // under `summary[]`. Accept whichever is present.
     let text = item
         .get("content")
+        .or_else(|| item.get("summary"))
         .and_then(|v| v.as_array())
         .and_then(|arr| arr.first())
         .and_then(|first| first.get("text"))
@@ -720,5 +742,62 @@ mod tests {
         assert_eq!(tool_calls[0].id, "call_1");
         assert_eq!(tool_calls[0].function.name, "weather");
         assert_eq!(tool_calls[0].function.arguments, r#"{"city":"Paris"}"#);
+    }
+
+    #[test]
+    fn parse_sse_uses_output_item_done_when_completed_output_empty() {
+        // The ChatGPT backend (`backend-api/codex`) carries the message in a
+        // `response.output_item.done` event and leaves `completed.output` null.
+        let sse = concat!(
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"hi there\"}]}}\n",
+            "\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"output\":null}}\n",
+        );
+
+        let blocks = parse_sse_response(sse).expect("should extract content");
+        assert_eq!(blocks.len(), 1);
+        let value = serde_json::to_value(&blocks[0]).expect("serialize block");
+        assert_eq!(value["type"], "text");
+        assert_eq!(value["text"], "hi there");
+    }
+
+    #[test]
+    fn parse_sse_falls_back_to_completed_output_for_standard_api() {
+        // The public Responses API populates `output[]` in `response.completed`
+        // and emits no per-item done events.
+        let sse = concat!(
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"final\"}]}]}}\n",
+        );
+
+        let blocks = parse_sse_response(sse).expect("should extract content");
+        assert_eq!(blocks.len(), 1);
+        let value = serde_json::to_value(&blocks[0]).expect("serialize block");
+        assert_eq!(value["text"], "final");
+    }
+
+    #[test]
+    fn parse_sse_maps_reasoning_summary_to_thinking() {
+        let sse = concat!(
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"weighing options\"}]}}\n",
+            "\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"answer\"}]}}\n",
+        );
+
+        let blocks = parse_sse_response(sse).expect("should extract content");
+        assert_eq!(blocks.len(), 2);
+        let thinking = serde_json::to_value(&blocks[0]).expect("serialize block");
+        assert_eq!(thinking["type"], "thinking");
+        assert_eq!(thinking["thinking"], "weighing options");
+    }
+
+    #[test]
+    fn parse_sse_errors_when_no_content() {
+        let sse = "event: response.created\ndata: {\"type\":\"response.created\"}\n";
+        assert!(parse_sse_response(sse).is_err());
     }
 }


### PR DESCRIPTION
## Problem

Routing grob at the ChatGPT Plus/Pro **Codex OAuth** backend (`oauth_provider = "openai-codex"`) failed for every request with:

```
500 - Failed to parse SSE response: no content found
```

and streaming clients got `404 Not Found` (then a misleading `400 - The '<model>' model is not supported`).

Root causes (the ChatGPT backend behaves differently from the public Responses API):

1. **Non-streaming parser** — `chatgpt.com/backend-api/codex/responses` returns `response.completed` with `output: null`; the actual content ships in `response.output_item.done` events. `parse_sse_response` only read `completed.output[]`, so it never found content.
2. **Streaming endpoint** — `send_message_stream` picked the endpoint from `is_codex_model()` alone, so non-codex models (e.g. `gpt-5.5`) hit `/chat/completions`, which **does not exist** on the ChatGPT backend (404).
3. **Streaming transform** — the backend streams Responses-API SSE, but the only stream transform was for Chat-Completions chunks (`choices[].delta`), so it couldn't parse a single event.

## Fix

- **Parser** (`transform.rs`): read `response.output_item.done` events, falling back to `response.completed.output[]` for the public Responses API. Map a reasoning item's `summary[]` to a thinking block.
- **Endpoint** (`mod.rs`): route `is_oauth() || is_codex` to `/codex/responses`, mirroring the non-streaming `send_message`; pass that flag to `apply_oauth_headers`.
- **Incremental streaming** (`streaming.rs`): new `transform_codex_event_to_anthropic_sse` mapping `response.output_text.delta` → `text_delta`, reasoning-summary deltas → `thinking_delta`, and `response.completed`/`incomplete` → `message_delta` + `message_stop`. True token-by-token streaming.

## Verified against a live ChatGPT Plus account

| model | non-stream | stream |
|---|---|---|
| `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` | ✅ | ✅ incremental |
| `gpt-5.3-codex` | ✅ | ✅ incremental |

Example: "count 1→10" streamed as 26 progressive `text_delta` events; a code prompt streamed 73; valid single `message_start`/`message_stop` framing.

## Tests

8 new unit tests (4 parser layouts incl. reasoning + the no-content error; 4 streaming-transform cases incl. reasoning→thinking and `incomplete`→`max_tokens`). `cargo fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)