### PR TITLE
chore: release v0.36.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.51](https://github.com/azerozero/grob/compare/v0.36.50...v0.36.51) - 2026-05-30
+
+### Fixed
+
+- *(openai)* stream ChatGPT Codex (OAuth) via the Responses API
+- *(openai)* parse Codex responses from output_item.done events
+
+### Other
+
+- *(examples)* add ChatGPT Codex OAuth config example
+- *(mutants)* exclude the `delete !` mutant in build_encrypted_content
+
 ## [0.36.50](https://github.com/azerozero/grob/compare/v0.36.49...v0.36.50) - 2026-05-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.50"
+version = "0.36.51"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.50"
+version = "0.36.51"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.50 -> 0.36.51

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.51](https://github.com/azerozero/grob/compare/v0.36.50...v0.36.51) - 2026-05-30

### Fixed

- *(openai)* stream ChatGPT Codex (OAuth) via the Responses API
- *(openai)* parse Codex responses from output_item.done events

### Other

- *(examples)* add ChatGPT Codex OAuth config example
- *(mutants)* exclude the `delete !` mutant in build_encrypted_content
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).