### PR TITLE
chore: release v0.36.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.52](https://github.com/azerozero/grob/compare/v0.36.51...v0.36.52) - 2026-05-31
+
+### Fixed
+
+- *(cli)* pass --config before the start subcommand when daemonizing
+
+### Other
+
+- ignore local personal grob config (grob-openai.toml)
+
 ## [0.36.51](https://github.com/azerozero/grob/compare/v0.36.50...v0.36.51) - 2026-05-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.51"
+version = "0.36.52"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.51"
+version = "0.36.52"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.51 -> 0.36.52

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.52](https://github.com/azerozero/grob/compare/v0.36.51...v0.36.52) - 2026-05-31

### Fixed

- *(cli)* pass --config before the start subcommand when daemonizing

### Other

- ignore local personal grob config (grob-openai.toml)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).