### PR TITLE
feat(openai): make ChatGPT Codex tool-calling work end-to-end

### DIFF
--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -1,6 +1,7 @@
 //! OpenAI provider implementation.
 
 mod streaming;
+mod tool_salvage;
 mod transform;
 pub(crate) mod types;
 
@@ -245,13 +246,27 @@ impl OpenAIProvider {
 
         let content_blocks = transform::parse_sse_response(&response_text)?;
 
+        // A function_call in the output means the model wants to use a tool.
+        let stop_reason = if content_blocks.iter().any(|b| {
+            matches!(
+                b,
+                crate::providers::ContentBlock::Known(
+                    crate::providers::KnownContentBlock::ToolUse { .. }
+                )
+            )
+        }) {
+            "tool_use"
+        } else {
+            "end_turn"
+        };
+
         Ok(ProviderResponse {
             id: "sse-response".to_string(),
             r#type: "message".to_string(),
             role: "assistant".to_string(),
             content: content_blocks,
             model: request.model.clone(),
-            stop_reason: Some("end_turn".to_string()),
+            stop_reason: Some(stop_reason.to_string()),
             stop_sequence: None,
             usage: Usage {
                 input_tokens: 0,

--- a/src/providers/openai/streaming.rs
+++ b/src/providers/openai/streaming.rs
@@ -1,3 +1,4 @@
+use super::tool_salvage::{drain_buffer, salvage_complete, SalvageEvent, SalvagedToolCall};
 use super::types::{OpenAIStreamChunk, StreamTransformState};
 
 /// Transform an OpenAI streaming chunk to Anthropic SSE format.
@@ -32,7 +33,7 @@ pub(crate) fn transform_openai_chunk_to_anthropic_sse(
 
         if let Some(text) = choice.delta.content.as_ref() {
             if !text.is_empty() {
-                emit_text_delta(&mut output, state, text);
+                push_text(&mut output, state, text);
             }
         }
 
@@ -141,6 +142,96 @@ fn emit_text_delta(output: &mut String, state: &mut StreamTransformState, text: 
     output.push_str(&format!("event: content_block_delta\ndata: {}\n\n", delta));
 }
 
+/// Buffers assistant text and emits complete text / salvaged tool-call events.
+///
+/// Routing text through the salvage scanner lets a `<tool_call>` block that the
+/// model leaked into plain content be recovered as a real `tool_use` block. A
+/// trailing fragment that might continue a split marker stays in
+/// `state.text_buffer` until the next delta. See
+/// [`crate::providers::openai::tool_salvage`].
+fn push_text(output: &mut String, state: &mut StreamTransformState, text: &str) {
+    state.text_buffer.push_str(text);
+    let events = drain_buffer(&mut state.text_buffer);
+    apply_salvage_events(output, state, events);
+}
+
+/// Flushes any buffered text at stream end, treating an unterminated marker as text.
+fn flush_text_buffer(output: &mut String, state: &mut StreamTransformState) {
+    if state.text_buffer.is_empty() {
+        return;
+    }
+    let remaining = std::mem::take(&mut state.text_buffer);
+    let events = salvage_complete(&remaining);
+    apply_salvage_events(output, state, events);
+}
+
+/// Emits the SSE for an ordered list of salvage events.
+fn apply_salvage_events(
+    output: &mut String,
+    state: &mut StreamTransformState,
+    events: Vec<SalvageEvent>,
+) {
+    for event in events {
+        match event {
+            SalvageEvent::Text(text) => emit_text_delta(output, state, &text),
+            SalvageEvent::ToolCall(call) => emit_salvaged_tool_use(output, state, &call),
+        }
+    }
+}
+
+/// Emits a complete `tool_use` content block for a tool call recovered from text.
+///
+/// Unlike [`emit_tool_call_deltas`], the salvaged call is fully known up front,
+/// so the block is opened, filled, and closed in one shot. Setting
+/// `had_tool_calls` forces `stop_reason="tool_use"` so the client runs the tool.
+fn emit_salvaged_tool_use(
+    output: &mut String,
+    state: &mut StreamTransformState,
+    call: &SalvagedToolCall,
+) {
+    close_open_blocks(output, state);
+
+    let block_index = state.next_block_index;
+    state.next_block_index += 1;
+    state.salvaged_tool_count += 1;
+    state.had_tool_calls = true;
+    let tool_id = format!("toolu_salvaged_{}", state.salvaged_tool_count);
+
+    tracing::info!(
+        "Salvaged leaked tool call '{}' as tool_use block {} (id {})",
+        call.name,
+        block_index,
+        tool_id
+    );
+
+    let block_start = serde_json::json!({
+        "type": "content_block_start",
+        "index": block_index,
+        "content_block": {
+            "type": "tool_use",
+            "id": tool_id,
+            "name": call.name,
+            "input": {}
+        }
+    });
+    output.push_str(&format!(
+        "event: content_block_start\ndata: {}\n\n",
+        block_start
+    ));
+
+    let input_delta = serde_json::json!({
+        "type": "content_block_delta",
+        "index": block_index,
+        "delta": { "type": "input_json_delta", "partial_json": call.input.to_string() }
+    });
+    output.push_str(&format!(
+        "event: content_block_delta\ndata: {}\n\n",
+        input_delta
+    ));
+
+    emit_block_stop(output, block_index);
+}
+
 fn emit_tool_call_deltas(
     output: &mut String,
     state: &mut StreamTransformState,
@@ -229,6 +320,108 @@ fn emit_tool_call_deltas(
     }
 }
 
+/// Opens an Anthropic `tool_use` block for a streaming Codex `function_call` item.
+///
+/// Codex streams a structured tool call as `output_item.added` (the call shell),
+/// then `function_call_arguments.delta` chunks, then `output_item.done`. The
+/// block is keyed by the Responses `output_index` so argument deltas correlate.
+fn emit_responses_fc_start(
+    output: &mut String,
+    state: &mut StreamTransformState,
+    json: &serde_json::Value,
+    item: &serde_json::Value,
+) {
+    let output_index = json
+        .get("output_index")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if state.responses_fc_blocks.contains_key(&output_index) {
+        return;
+    }
+
+    close_open_blocks(output, state);
+
+    let call_id = item
+        .get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("call_0");
+    let name = item
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    let block_index = state.next_block_index;
+    state.next_block_index += 1;
+    state.responses_fc_blocks.insert(output_index, block_index);
+    state.had_tool_calls = true;
+
+    let block_start = serde_json::json!({
+        "type": "content_block_start",
+        "index": block_index,
+        "content_block": { "type": "tool_use", "id": call_id, "name": name, "input": {} }
+    });
+    output.push_str(&format!(
+        "event: content_block_start\ndata: {}\n\n",
+        block_start
+    ));
+
+    // `output_item.added` sometimes already carries the full arguments.
+    if let Some(args) = item.get("arguments").and_then(|v| v.as_str()) {
+        if !args.is_empty() {
+            emit_responses_fc_input(output, block_index, args);
+        }
+    }
+}
+
+/// Emits an `input_json_delta` for a streaming Codex function-call argument chunk.
+fn emit_responses_fc_args(
+    output: &mut String,
+    state: &mut StreamTransformState,
+    json: &serde_json::Value,
+    delta: &str,
+) {
+    let output_index = json
+        .get("output_index")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if let Some(&block_index) = state.responses_fc_blocks.get(&output_index) {
+        emit_responses_fc_input(output, block_index, delta);
+    }
+}
+
+/// Closes a streaming Codex function-call block on `output_item.done`.
+///
+/// If the `added`/`delta` events were never seen (a fully-buffered call), the
+/// block is opened and filled from the complete item before closing.
+fn emit_responses_fc_done(
+    output: &mut String,
+    state: &mut StreamTransformState,
+    json: &serde_json::Value,
+    item: &serde_json::Value,
+) {
+    let output_index = json
+        .get("output_index")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if !state.responses_fc_blocks.contains_key(&output_index) {
+        emit_responses_fc_start(output, state, json, item);
+    }
+    if let Some(block_index) = state.responses_fc_blocks.remove(&output_index) {
+        emit_block_stop(output, block_index);
+    }
+}
+
+/// Emits a tool-use `input_json_delta` carrying a partial arguments string.
+fn emit_responses_fc_input(output: &mut String, block_index: u32, partial_json: &str) {
+    let delta = serde_json::json!({
+        "type": "content_block_delta",
+        "index": block_index,
+        "delta": { "type": "input_json_delta", "partial_json": partial_json }
+    });
+    output.push_str(&format!("event: content_block_delta\ndata: {}\n\n", delta));
+}
+
 fn emit_stream_end(
     output: &mut String,
     state: &mut StreamTransformState,
@@ -236,6 +429,7 @@ fn emit_stream_end(
     reason: &str,
 ) {
     state.stream_ended = true;
+    flush_text_buffer(output, state);
 
     if state.thinking_block_open {
         emit_block_stop(output, state.thinking_block_index);
@@ -330,7 +524,7 @@ pub(crate) fn transform_codex_event_to_anthropic_sse(
             ensure_message_started(&mut output, state, message_id, model);
             if let Some(delta) = json.get("delta").and_then(|v| v.as_str()) {
                 if !delta.is_empty() {
-                    emit_text_delta(&mut output, state, delta);
+                    push_text(&mut output, state, delta);
                 }
             }
         }
@@ -339,6 +533,26 @@ pub(crate) fn transform_codex_event_to_anthropic_sse(
             if let Some(delta) = json.get("delta").and_then(|v| v.as_str()) {
                 if !delta.is_empty() {
                     emit_reasoning_delta(&mut output, state, delta);
+                }
+            }
+        }
+        "response.output_item.added" => {
+            if let Some(item) = json.get("item") {
+                if item.get("type").and_then(|t| t.as_str()) == Some("function_call") {
+                    ensure_message_started(&mut output, state, message_id, model);
+                    emit_responses_fc_start(&mut output, state, &json, item);
+                }
+            }
+        }
+        ty if ty.ends_with("function_call_arguments.delta") => {
+            if let Some(delta) = json.get("delta").and_then(|v| v.as_str()) {
+                emit_responses_fc_args(&mut output, state, &json, delta);
+            }
+        }
+        "response.output_item.done" => {
+            if let Some(item) = json.get("item") {
+                if item.get("type").and_then(|t| t.as_str()) == Some("function_call") {
+                    emit_responses_fc_done(&mut output, state, &json, item);
                 }
             }
         }
@@ -363,9 +577,14 @@ fn emit_codex_stream_end(
         return;
     }
     state.stream_ended = true;
+    flush_text_buffer(output, state);
 
     close_open_blocks(output, state);
     for block_index in state.tool_blocks.values() {
+        emit_block_stop(output, *block_index);
+    }
+    // Close any function-call blocks whose `output_item.done` never arrived.
+    for block_index in state.responses_fc_blocks.values() {
         emit_block_stop(output, *block_index);
     }
 
@@ -460,6 +679,55 @@ mod codex_stream_tests {
             r#"{"type":"response.incomplete","response":{"status":"incomplete"}}"#,
         ]);
         assert!(out.contains("max_tokens"));
+    }
+
+    #[test]
+    fn leaked_tool_call_in_text_is_salvaged_as_tool_use() {
+        // The tool_call marker and JSON are split across deltas to exercise the
+        // streaming buffer.
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_text.delta","delta":"sure, running <tool_"}"#,
+            r#"{"type":"response.output_text.delta","delta":"call>{\"name\":\"Bash\","}"#,
+            r#"{"type":"response.output_text.delta","delta":"\"arguments\":{\"command\":\"ls\"}}</tool_call>"}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        // The pre-marker text is still forwarded.
+        assert!(out.contains(r#""text":"sure, running ""#));
+        // A tool_use block is opened with the recovered name.
+        assert!(out.contains(r#""type":"tool_use""#));
+        assert!(out.contains(r#""name":"Bash""#));
+        // Its input arrives as an input_json_delta.
+        assert!(out.contains("input_json_delta"));
+        assert!(out.contains(r#"command\":\"ls"#));
+        // The leaked marker itself must not leak through as text.
+        assert!(!out.contains("tool_call>"));
+        // Salvaging forces stop_reason=tool_use so the client runs the tool.
+        assert!(out.contains(r#""stop_reason":"tool_use""#));
+    }
+
+    #[test]
+    fn structured_function_call_streams_as_tool_use() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_abc","name":"Bash","arguments":""}}"#,
+            r#"{"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"command\":\""}"#,
+            r#"{"type":"response.function_call_arguments.delta","output_index":0,"delta":"ls\"}"}"#,
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","call_id":"call_abc","name":"Bash","arguments":"{\"command\":\"ls\"}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        // A single tool_use block opened with the call's id and name.
+        assert_eq!(out.matches(r#""type":"tool_use""#).count(), 1);
+        assert!(out.contains(r#""id":"call_abc""#));
+        assert!(out.contains(r#""name":"Bash""#));
+        // Arguments arrive incrementally as input_json_delta, not text.
+        assert!(out.contains("input_json_delta"));
+        assert!(!out.contains("text_delta"));
+        // The block is closed and the turn ends with tool_use.
+        assert!(out.contains("event: content_block_stop"));
+        assert!(out.contains(r#""stop_reason":"tool_use""#));
     }
 
     #[test]

--- a/src/providers/openai/tool_salvage.rs
+++ b/src/providers/openai/tool_salvage.rs
@@ -1,0 +1,365 @@
+//! Salvage of leaked tool calls from OpenAI/Codex model output.
+//!
+//! Some OpenAI-family models — notably ChatGPT Codex (gpt-5.x) behind the
+//! Responses API — occasionally emit a tool invocation as **plain text** inside
+//! the assistant content instead of through the structured tool-call channel,
+//! e.g. the streamed text contains:
+//!
+//! ```text
+//! <tool_call>
+//! {"name": "Bash", "arguments": {"command": "ls"}}
+//! </tool_call>
+//! ```
+//!
+//! When that happens the downstream Anthropic-API client (Claude Code, etc.)
+//! sees only narrative text, never runs the tool, and the model stalls
+//! believing it has no tools. This module detects those leaked blocks and lets
+//! the streaming/non-streaming transforms re-emit them as real Anthropic
+//! `tool_use` content blocks — the same recovery LiteLLM and claude-code-router
+//! perform.
+//!
+//! The scan is provider-output-shaped, not client-shaped, so it works for any
+//! Anthropic-API client regardless of which model name was requested.
+
+/// Opening marker of a leaked tool call.
+const OPEN: &str = "<tool_call>";
+/// Closing marker of a leaked tool call.
+const CLOSE: &str = "</tool_call>";
+/// Tool name assigned to nameless shell-style leaks (the Codex `shell` format).
+const SHELL_TOOL_NAME: &str = "Bash";
+
+/// One item produced while scanning model text for leaked tool calls.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum SalvageEvent {
+    /// A run of plain text safe to forward to the client verbatim.
+    Text(String),
+    /// A recovered tool call to re-emit as an Anthropic `tool_use` block.
+    ToolCall(SalvagedToolCall),
+}
+
+/// A tool call recovered from leaked `<tool_call>` text.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SalvagedToolCall {
+    /// Anthropic `tool_use` name.
+    pub name: String,
+    /// Anthropic `tool_use` input object.
+    pub input: serde_json::Value,
+}
+
+/// Drains a streaming text buffer, returning complete text/tool-call events.
+///
+/// Consumes everything that can be safely classified and leaves the rest in
+/// `buffer` for the next delta. Specifically it retains: (a) an open
+/// `<tool_call>` whose closing marker has not arrived yet, and (b) a trailing
+/// fragment that could be the start of a split `<tool_call>` marker. This makes
+/// the scan robust to markers split across `output_text.delta` fragments.
+pub(crate) fn drain_buffer(buffer: &mut String) -> Vec<SalvageEvent> {
+    let mut events = Vec::new();
+
+    loop {
+        if let Some(open_idx) = buffer.find(OPEN) {
+            if open_idx > 0 {
+                push_text(&mut events, buffer[..open_idx].to_string());
+            }
+
+            let after_open = open_idx + OPEN.len();
+            if let Some(rel_close) = buffer[after_open..].find(CLOSE) {
+                let inner = &buffer[after_open..after_open + rel_close];
+                match parse_tool_call(inner) {
+                    Some(call) => events.push(SalvageEvent::ToolCall(call)),
+                    // Unparseable block: preserve it verbatim rather than drop it.
+                    None => push_text(&mut events, format!("{OPEN}{inner}{CLOSE}")),
+                }
+                let consumed = after_open + rel_close + CLOSE.len();
+                *buffer = buffer[consumed..].to_string();
+                continue;
+            }
+
+            // Open marker without a close yet — wait for more deltas.
+            *buffer = buffer[open_idx..].to_string();
+            return events;
+        }
+
+        // No open marker. Hold back any suffix that could begin one.
+        let keep = partial_open_suffix_len(buffer);
+        let flush_to = buffer.len() - keep;
+        if flush_to > 0 {
+            push_text(&mut events, buffer[..flush_to].to_string());
+        }
+        *buffer = buffer[flush_to..].to_string();
+        return events;
+    }
+}
+
+/// Scans a complete (non-streamed) text body for leaked tool calls.
+///
+/// Returns the text split into ordered text and tool-call events. When no
+/// marker is present the whole body is returned as a single [`SalvageEvent::Text`].
+pub(crate) fn salvage_complete(text: &str) -> Vec<SalvageEvent> {
+    if !text.contains(OPEN) {
+        return vec![SalvageEvent::Text(text.to_string())];
+    }
+    let mut buffer = text.to_string();
+    let mut events = drain_buffer(&mut buffer);
+    // A complete body cannot grow further, so any retained tail (an unterminated
+    // marker or split-marker fragment) is just text.
+    if !buffer.is_empty() {
+        push_text(&mut events, buffer);
+    }
+    events
+}
+
+/// Appends text to `events`, coalescing with a trailing text event if present.
+fn push_text(events: &mut Vec<SalvageEvent>, text: String) {
+    if text.is_empty() {
+        return;
+    }
+    if let Some(SalvageEvent::Text(last)) = events.last_mut() {
+        last.push_str(&text);
+    } else {
+        events.push(SalvageEvent::Text(text));
+    }
+}
+
+/// Returns the longest suffix length of `buffer` that is a strict prefix of [`OPEN`].
+///
+/// Used to hold back a trailing fragment like `"<too"` that might continue into
+/// a full `<tool_call>` marker on the next delta. Markers are ASCII, so the
+/// returned length always lands on a UTF-8 char boundary.
+fn partial_open_suffix_len(buffer: &str) -> usize {
+    let open = OPEN.as_bytes();
+    let buf = buffer.as_bytes();
+    let max = open.len().min(buf.len());
+    (1..max)
+        .rev()
+        .find(|&k| buf[buf.len() - k..] == open[..k])
+        .unwrap_or(0)
+}
+
+/// Parses the JSON inside a `<tool_call>` block into a [`SalvagedToolCall`].
+///
+/// Recognises two shapes:
+/// - Canonical function call: `{"name": "X", "arguments": {…}}` (also accepts
+///   `parameters`, and `arguments` as a JSON-encoded string).
+/// - Nameless Codex shell call: `{"cmd"|"command": …, "workdir"?: …}` → mapped
+///   to the [`SHELL_TOOL_NAME`] tool with a single `command` string.
+///
+/// Returns `None` when the inner text is not JSON or carries no usable call, so
+/// the caller can fall back to forwarding it as plain text.
+fn parse_tool_call(inner: &str) -> Option<SalvagedToolCall> {
+    let value: serde_json::Value = serde_json::from_str(inner.trim()).ok()?;
+    let obj = value.as_object()?;
+
+    if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
+        if !name.is_empty() {
+            let input = normalize_arguments(obj.get("arguments").or_else(|| obj.get("parameters")));
+            return Some(SalvagedToolCall {
+                name: name.to_string(),
+                input,
+            });
+        }
+    }
+
+    // Codex emits its native shell call without a `name`; map it to Bash so the
+    // client can still run it.
+    if let Some(cmd) = obj.get("cmd").or_else(|| obj.get("command")) {
+        if let Some(command) = shell_command_string(cmd) {
+            let full = match obj.get("workdir").and_then(|w| w.as_str()) {
+                Some(dir) if !dir.is_empty() => format!("cd {} && {}", shell_quote(dir), command),
+                _ => command,
+            };
+            return Some(SalvagedToolCall {
+                name: SHELL_TOOL_NAME.to_string(),
+                input: serde_json::json!({ "command": full }),
+            });
+        }
+    }
+
+    None
+}
+
+/// Normalizes a leaked `arguments`/`parameters` field into an input object.
+fn normalize_arguments(value: Option<&serde_json::Value>) -> serde_json::Value {
+    match value {
+        // Some models double-encode arguments as a JSON string.
+        Some(serde_json::Value::String(s)) => {
+            serde_json::from_str(s).unwrap_or_else(|_| serde_json::json!({}))
+        }
+        Some(other) => other.clone(),
+        None => serde_json::json!({}),
+    }
+}
+
+/// Flattens a Codex `cmd`/`command` value into a single shell command string.
+///
+/// `["bash", "-lc", "<script>"]` and `["sh", "-c", "<script>"]` collapse to the
+/// script itself; other arrays are space-joined; a bare string passes through.
+fn shell_command_string(cmd: &serde_json::Value) -> Option<String> {
+    match cmd {
+        serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+        serde_json::Value::Array(arr) => {
+            let parts: Vec<&str> = arr.iter().filter_map(|x| x.as_str()).collect();
+            if parts.is_empty() {
+                return None;
+            }
+            let is_shell_wrapper = parts.len() >= 3
+                && matches!(parts[0], "bash" | "sh" | "zsh")
+                && matches!(parts[1], "-c" | "-lc" | "-ic");
+            if is_shell_wrapper {
+                Some(parts[parts.len() - 1].to_string())
+            } else {
+                Some(parts.join(" "))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Single-quotes a string for safe interpolation into a shell command.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drain_once(text: &str) -> Vec<SalvageEvent> {
+        let mut buf = text.to_string();
+        drain_buffer(&mut buf)
+    }
+
+    #[test]
+    fn plain_text_passes_through() {
+        assert_eq!(
+            salvage_complete("just some text"),
+            vec![SalvageEvent::Text("just some text".to_string())]
+        );
+    }
+
+    #[test]
+    fn canonical_tool_call_is_salvaged() {
+        let events = salvage_complete(
+            r#"before <tool_call>{"name":"Bash","arguments":{"command":"ls"}}</tool_call> after"#,
+        );
+        assert_eq!(
+            events,
+            vec![
+                SalvageEvent::Text("before ".to_string()),
+                SalvageEvent::ToolCall(SalvagedToolCall {
+                    name: "Bash".to_string(),
+                    input: serde_json::json!({ "command": "ls" }),
+                }),
+                SalvageEvent::Text(" after".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn arguments_as_json_string_are_decoded() {
+        let events = salvage_complete(
+            r#"<tool_call>{"name":"Read","arguments":"{\"path\":\"/tmp/x\"}"}</tool_call>"#,
+        );
+        assert_eq!(
+            events,
+            vec![SalvageEvent::ToolCall(SalvagedToolCall {
+                name: "Read".to_string(),
+                input: serde_json::json!({ "path": "/tmp/x" }),
+            })]
+        );
+    }
+
+    #[test]
+    fn nameless_codex_shell_call_maps_to_bash() {
+        let events = salvage_complete(
+            r#"<tool_call>{"cmd":["bash","-lc","pwd && ls"],"workdir":"/repo"}</tool_call>"#,
+        );
+        assert_eq!(
+            events,
+            vec![SalvageEvent::ToolCall(SalvagedToolCall {
+                name: "Bash".to_string(),
+                input: serde_json::json!({ "command": "cd '/repo' && pwd && ls" }),
+            })]
+        );
+    }
+
+    #[test]
+    fn marker_split_across_deltas_is_buffered() {
+        // Simulate three streamed fragments that split the open marker and JSON.
+        let mut buf = String::new();
+        let mut all = Vec::new();
+
+        buf.push_str("hello <too");
+        all.extend(drain_buffer(&mut buf));
+        // The partial marker must be held back, only "hello " flushed.
+        assert_eq!(all, vec![SalvageEvent::Text("hello ".to_string())]);
+
+        buf.push_str(r#"l_call>{"name":"Bash","#);
+        all.extend(drain_buffer(&mut buf));
+        // Open seen but not closed yet — nothing new emitted.
+        assert_eq!(all, vec![SalvageEvent::Text("hello ".to_string())]);
+
+        buf.push_str(r#""arguments":{"command":"ls"}}</tool_call>done"#);
+        all.extend(drain_buffer(&mut buf));
+        assert_eq!(
+            all,
+            vec![
+                SalvageEvent::Text("hello ".to_string()),
+                SalvageEvent::ToolCall(SalvagedToolCall {
+                    name: "Bash".to_string(),
+                    input: serde_json::json!({ "command": "ls" }),
+                }),
+                SalvageEvent::Text("done".to_string()),
+            ]
+        );
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn unparseable_block_is_kept_as_text() {
+        let events = drain_once("<tool_call>not json</tool_call>");
+        assert_eq!(
+            events,
+            vec![SalvageEvent::Text(
+                "<tool_call>not json</tool_call>".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn unterminated_marker_is_retained_in_buffer() {
+        let mut buf = r#"text <tool_call>{"name":"Bash""#.to_string();
+        let events = drain_buffer(&mut buf);
+        assert_eq!(events, vec![SalvageEvent::Text("text ".to_string())]);
+        assert_eq!(buf, r#"<tool_call>{"name":"Bash""#);
+    }
+
+    #[test]
+    fn multibyte_text_before_partial_marker_is_safe() {
+        // Ensure suffix retention does not split a multibyte char.
+        let mut buf = "café <".to_string();
+        let events = drain_buffer(&mut buf);
+        assert_eq!(events, vec![SalvageEvent::Text("café ".to_string())]);
+        assert_eq!(buf, "<");
+    }
+
+    #[test]
+    fn fenced_codex_leak_is_recovered() {
+        // The exact shape observed from gpt-5.5: a markdown bash fence wrapping a
+        // nameless shell tool_call.
+        let leak = "```bash\npwd\n<tool_call>\n{\"cmd\":[\"bash\",\"-lc\",\"pwd && git log\"],\"workdir\":\"/Users/ludwig/workspace/reti\"}\n</tool_call>\n```";
+        let events = salvage_complete(leak);
+        let tool = events
+            .iter()
+            .find_map(|e| match e {
+                SalvageEvent::ToolCall(c) => Some(c),
+                _ => None,
+            })
+            .expect("a tool call should be recovered");
+        assert_eq!(tool.name, "Bash");
+        assert_eq!(
+            tool.input,
+            serde_json::json!({ "command": "cd '/Users/ludwig/workspace/reti' && pwd && git log" })
+        );
+    }
+}

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -364,6 +364,7 @@ pub(crate) fn transform_response(response: OpenAIResponse) -> ProviderResponse {
     };
 
     let mut content_blocks = Vec::new();
+    let mut salvaged_tool_count = 0u32;
 
     // Add reasoning as thinking block
     if let Some(reasoning) = choice.message.reasoning {
@@ -391,8 +392,28 @@ pub(crate) fn transform_response(response: OpenAIResponse) -> ProviderResponse {
         None => String::new(),
     };
 
+    // Scan the text for tool calls the model leaked as plain content (Codex
+    // sometimes does this) and re-emit them as structured tool_use blocks.
+    let mut salvaged_tool = false;
     if !text.is_empty() {
-        content_blocks.push(ContentBlock::text(text, None));
+        for event in super::tool_salvage::salvage_complete(&text) {
+            match event {
+                super::tool_salvage::SalvageEvent::Text(t) => {
+                    if !t.is_empty() {
+                        content_blocks.push(ContentBlock::text(t, None));
+                    }
+                }
+                super::tool_salvage::SalvageEvent::ToolCall(call) => {
+                    salvaged_tool = true;
+                    salvaged_tool_count += 1;
+                    content_blocks.push(ContentBlock::tool_use(
+                        format!("toolu_salvaged_{salvaged_tool_count}"),
+                        call.name,
+                        call.input,
+                    ));
+                }
+            }
+        }
     }
 
     // Transform tool_calls to tool_use content blocks
@@ -408,8 +429,10 @@ pub(crate) fn transform_response(response: OpenAIResponse) -> ProviderResponse {
         }
     }
 
-    // Map OpenAI finish_reason to Anthropic stop_reason
+    // Map OpenAI finish_reason to Anthropic stop_reason. A salvaged tool call
+    // overrides a plain "stop" so the client runs the recovered tool.
     let stop_reason = choice.finish_reason.map(|reason| match reason.as_str() {
+        "stop" if salvaged_tool => "tool_use".to_string(),
         "stop" => "end_turn".to_string(),
         "length" => "max_tokens".to_string(),
         "tool_calls" => "tool_use".to_string(),
@@ -497,9 +520,31 @@ pub(crate) fn parse_sse_response(sse_text: &str) -> Result<Vec<ContentBlock>, Pr
     })
 }
 
-/// Maps a Codex `output[]` item (`reasoning` or `message`) to the corresponding Anthropic thinking or text block.
+/// Maps a Codex `output[]` item to the corresponding Anthropic content block.
+///
+/// Handles `function_call` (→ `tool_use`), `reasoning` (→ `thinking`), and
+/// `message` (→ `text`) items; anything else yields `None`.
 fn extract_codex_output_block(item: &serde_json::Value) -> Option<ContentBlock> {
     let output_type = item.get("type").and_then(|v| v.as_str())?;
+
+    if output_type == "function_call" {
+        let name = item.get("name").and_then(|v| v.as_str())?;
+        let call_id = item
+            .get("call_id")
+            .or_else(|| item.get("id"))
+            .and_then(|v| v.as_str())?;
+        let input = item
+            .get("arguments")
+            .and_then(|v| v.as_str())
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_else(|| serde_json::json!({}));
+        return Some(ContentBlock::tool_use(
+            call_id.to_string(),
+            name.to_string(),
+            input,
+        ));
+    }
+
     // `message` items carry text under `content[]`; `reasoning` items carry it
     // under `summary[]`. Accept whichever is present.
     let text = item
@@ -519,52 +564,175 @@ fn extract_codex_output_block(item: &serde_json::Value) -> Option<ContentBlock> 
     }
 }
 
+/// Instructions used when the client forwards its own tools.
+///
+/// The full Codex CLI prompt describes built-in `shell`/`apply_patch`/`update_plan`
+/// tools that do not exist when a client like Claude Code provides its own tool
+/// set — that mismatch makes the model invent tool calls (often leaked as text).
+/// This minimal preamble keeps the backend-expected "Codex" identity but defers
+/// all tool behavior to the request's tools and the client's own system prompt.
+const CODEX_TOOL_INSTRUCTIONS: &str = "You are Codex, based on GPT-5, operating as a coding agent. \
+The harness provides its own system prompt and a set of tools in this request. Use ONLY those \
+provided tools through the function-calling interface to take actions — do not assume any built-in \
+`shell`, `apply_patch`, or `update_plan` tool exists, and never emit a tool call as plain text or \
+inside a code block. When you need to run a command, read, or edit, call the matching provided tool \
+with its required arguments.";
+
 /// Transform Anthropic request to OpenAI Responses API format.
 pub(crate) fn transform_to_responses_request(
     request: &CanonicalRequest,
     codex_instructions: &str,
 ) -> Result<OpenAIResponsesRequest, ProviderError> {
-    let instructions = codex_instructions.to_string();
-    let mut messages = Vec::new();
+    let tools = transform_responses_tools(request);
 
-    // Add system message as user message (Codex doesn't have separate system role)
+    // Forwarding tools and the Codex CLI prompt at once makes the model call
+    // non-existent built-in tools, so swap to a tool-deferring preamble.
+    let instructions = if tools.is_some() {
+        CODEX_TOOL_INSTRUCTIONS.to_string()
+    } else {
+        codex_instructions.to_string()
+    };
+
+    let mut items = Vec::new();
+
+    // Codex has no separate system role; hoist the system prompt to a user item.
     if let Some(ref system) = request.system {
-        messages.push(OpenAIResponsesMessage {
+        items.push(OpenAIResponsesItem::Message {
             role: "user".to_string(),
             content: Some(system.to_text()),
         });
     }
 
     for msg in &request.messages {
-        let content = match &msg.content {
-            MessageContent::Text(text) => text.clone(),
-            MessageContent::Blocks(blocks) => {
-                let text = blocks
-                    .iter()
-                    .filter_map(|block| block.as_text().map(|s| s.to_string()))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                if text.is_empty() {
-                    String::new()
-                } else {
-                    text
-                }
-            }
+        // The ChatGPT Codex backend rejects `system`-role items ("System messages
+        // are not allowed") — system guidance belongs in `instructions`. Fold any
+        // system-role message (e.g. Claude Code `<system-reminder>` turns) into a
+        // user item so its content survives.
+        let role = if msg.role == "system" {
+            "user"
+        } else {
+            msg.role.as_str()
         };
-
-        messages.push(OpenAIResponsesMessage {
-            role: msg.role.clone(),
-            content: Some(content),
-        });
+        match &msg.content {
+            MessageContent::Text(text) => items.push(OpenAIResponsesItem::Message {
+                role: role.to_string(),
+                content: Some(text.clone()),
+            }),
+            MessageContent::Blocks(blocks) => {
+                push_blocks_as_items(&mut items, role, blocks)?;
+            }
+        }
     }
 
     Ok(OpenAIResponsesRequest {
         model: request.model.clone(),
-        input: OpenAIResponsesInput::Messages(messages),
+        input: OpenAIResponsesInput::Items(items),
         instructions,
         store: false,
         stream: true,
+        tool_choice: tools.as_ref().and(transform_responses_tool_choice(request)),
+        parallel_tool_calls: tools.as_ref().map(|_| true),
+        tools,
     })
+}
+
+/// Expands a message's content blocks into Responses items, preserving order.
+///
+/// Text and image blocks collapse into `message` items; `tool_use` blocks become
+/// `function_call` items and `tool_result` blocks become `function_call_output`
+/// items, keyed by the shared Anthropic tool-use id so the round-trip stays
+/// correlated. Thinking blocks are dropped.
+fn push_blocks_as_items(
+    items: &mut Vec<OpenAIResponsesItem>,
+    role: &str,
+    blocks: &[ContentBlock],
+) -> Result<(), ProviderError> {
+    let mut text = String::new();
+
+    for block in blocks {
+        match block {
+            ContentBlock::Known(KnownContentBlock::Text { text: t, .. }) => {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(t);
+            }
+            ContentBlock::Known(KnownContentBlock::ToolUse { id, name, input }) => {
+                flush_text_item(items, role, &mut text);
+                let arguments = serialize_tool_input(input, name)?;
+                items.push(OpenAIResponsesItem::FunctionCall {
+                    call_id: id.clone(),
+                    name: name.clone(),
+                    arguments,
+                });
+            }
+            ContentBlock::Known(KnownContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            }) => {
+                flush_text_item(items, role, &mut text);
+                items.push(OpenAIResponsesItem::FunctionCallOutput {
+                    call_id: tool_use_id.clone(),
+                    output: content.to_string(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    flush_text_item(items, role, &mut text);
+    Ok(())
+}
+
+/// Pushes accumulated text as a `message` item and clears the buffer.
+fn flush_text_item(items: &mut Vec<OpenAIResponsesItem>, role: &str, text: &mut String) {
+    if !text.is_empty() {
+        items.push(OpenAIResponsesItem::Message {
+            role: role.to_string(),
+            content: Some(std::mem::take(text)),
+        });
+    }
+}
+
+/// Transforms Anthropic tool definitions into Responses-API (flattened) tools.
+fn transform_responses_tools(request: &CanonicalRequest) -> Option<Vec<serde_json::Value>> {
+    let tools: Vec<serde_json::Value> = request
+        .tools
+        .as_ref()?
+        .iter()
+        .filter_map(|tool| {
+            let name = tool.name.as_ref()?;
+            let mut entry = serde_json::json!({
+                "type": "function",
+                "name": name,
+                "parameters": tool
+                    .input_schema
+                    .clone()
+                    .unwrap_or_else(|| serde_json::json!({ "type": "object", "properties": {} })),
+            });
+            if let Some(description) = &tool.description {
+                entry["description"] = serde_json::Value::String(description.clone());
+            }
+            Some(entry)
+        })
+        .collect();
+
+    (!tools.is_empty()).then_some(tools)
+}
+
+/// Transforms Anthropic `tool_choice` into the Responses-API shape.
+fn transform_responses_tool_choice(request: &CanonicalRequest) -> Option<serde_json::Value> {
+    let tc = request.tool_choice.as_ref()?;
+    match tc.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+        "auto" => Some(serde_json::json!("auto")),
+        "any" => Some(serde_json::json!("required")),
+        "tool" => {
+            let name = tc.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            Some(serde_json::json!({ "type": "function", "name": name }))
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -592,6 +760,111 @@ mod tests {
             tool_choice: None,
             extensions: Default::default(),
         }
+    }
+
+    #[test]
+    fn responses_request_forwards_tools_and_tool_history() {
+        use crate::models::{Message, Tool, ToolResultContent};
+
+        let mut request = base_request();
+        request.model = "gpt-5.5".to_string();
+        request.tools = Some(vec![Tool {
+            r#type: Some("function".to_string()),
+            name: Some("Bash".to_string()),
+            description: Some("Run a shell command".to_string()),
+            input_schema: Some(serde_json::json!({
+                "type": "object",
+                "properties": { "command": { "type": "string" } }
+            })),
+        }]);
+        request.messages = vec![
+            Message {
+                role: "user".to_string(),
+                content: MessageContent::Text("list files".to_string()),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::text("Running ls".to_string(), None),
+                    ContentBlock::tool_use(
+                        "toolu_1".to_string(),
+                        "Bash".to_string(),
+                        serde_json::json!({ "command": "ls" }),
+                    ),
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: MessageContent::Blocks(vec![ContentBlock::Known(
+                    KnownContentBlock::ToolResult {
+                        tool_use_id: "toolu_1".to_string(),
+                        content: ToolResultContent::Text("file1\nfile2".to_string()),
+                        is_error: false,
+                        cache_control: None,
+                    },
+                )]),
+            },
+        ];
+
+        let req = transform_to_responses_request(&request, "FULL CODEX PROMPT").unwrap();
+        let json = serde_json::to_value(&req).unwrap();
+
+        // Tools are forwarded in the flattened Responses shape.
+        assert_eq!(json["tools"][0]["type"], "function");
+        assert_eq!(json["tools"][0]["name"], "Bash");
+        assert!(json["tools"][0]["parameters"]["properties"]["command"].is_object());
+        assert_eq!(json["parallel_tool_calls"], true);
+
+        // The full Codex prompt is swapped for the tool-deferring preamble.
+        let instructions = json["instructions"].as_str().unwrap();
+        assert!(instructions.contains("provided tools"));
+        assert!(!instructions.contains("FULL CODEX PROMPT"));
+
+        // History carries the tool call and its output, correlated by id.
+        let input = json["input"].as_array().unwrap();
+        assert!(input.iter().any(|i| i["type"] == "function_call"
+            && i["call_id"] == "toolu_1"
+            && i["name"] == "Bash"));
+        assert!(input.iter().any(|i| i["type"] == "function_call_output"
+            && i["call_id"] == "toolu_1"
+            && i["output"] == "file1\nfile2"));
+        // The assistant's narration survives as a message item before the call.
+        assert!(input
+            .iter()
+            .any(|i| i["type"] == "message" && i["role"] == "assistant"));
+    }
+
+    #[test]
+    fn responses_request_folds_system_role_into_user() {
+        use crate::models::Message;
+
+        let mut request = base_request();
+        request.system = None;
+        request.messages = vec![Message {
+            role: "system".to_string(),
+            content: MessageContent::Text("be terse".to_string()),
+        }];
+
+        let req = transform_to_responses_request(&request, "FULL").unwrap();
+        let json = serde_json::to_value(&req).unwrap();
+        let input = json["input"].as_array().unwrap();
+
+        // No system-role items survive (the Codex backend rejects them)...
+        assert!(input.iter().all(|i| i["role"] != "system"));
+        // ...but the content is preserved as a user item.
+        assert!(input
+            .iter()
+            .any(|i| i["role"] == "user" && i["content"] == "be terse"));
+    }
+
+    #[test]
+    fn responses_request_without_tools_keeps_full_instructions() {
+        let mut request = base_request();
+        request.system = None;
+        let req = transform_to_responses_request(&request, "FULL CODEX PROMPT").unwrap();
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["instructions"], "FULL CODEX PROMPT");
+        assert!(json.get("tools").is_none() || json["tools"].is_null());
     }
 
     #[test]

--- a/src/providers/openai/types.rs
+++ b/src/providers/openai/types.rs
@@ -62,22 +62,48 @@ pub(crate) struct OpenAIResponsesRequest {
     pub store: bool,
     /// Enable streaming responses
     pub stream: bool,
+    /// Tool definitions in Responses-API (flattened `function`) shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<serde_json::Value>>,
+    /// Tool selection strategy (`"auto"`, `"required"`, or a named function).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<serde_json::Value>,
+    /// Whether the model may emit several tool calls in one turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parallel_tool_calls: Option<bool>,
 }
 
-/// Input for Responses API can be string or array of messages
-// Both variants used by serde serialization depending on context
+/// Input for Responses API is an array of typed items.
+// Single-variant untagged enum so it serializes as a bare JSON array.
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub(crate) enum OpenAIResponsesInput {
-    Messages(Vec<OpenAIResponsesMessage>),
+    Items(Vec<OpenAIResponsesItem>),
 }
 
-/// Message format for Responses API
+/// One item in a Responses API `input[]` array.
+///
+/// Alongside plain `message` items, the ChatGPT Codex backend accepts the
+/// `function_call` / `function_call_output` items that carry tool-use history
+/// so multi-turn agent loops survive the Anthropic ⇄ Responses translation.
 #[derive(Debug, Serialize)]
-pub(crate) struct OpenAIResponsesMessage {
-    pub role: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum OpenAIResponsesItem {
+    /// A conversational message; `content` is plain text.
+    Message {
+        role: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        content: Option<String>,
+    },
+    /// An assistant tool call replayed from history.
+    FunctionCall {
+        call_id: String,
+        name: String,
+        /// JSON-encoded arguments string.
+        arguments: String,
+    },
+    /// The output of a tool call, fed back to the model.
+    FunctionCallOutput { call_id: String, output: String },
 }
 
 /// Content can be string or array of content parts
@@ -253,4 +279,17 @@ pub(crate) struct StreamTransformState {
     pub stream_ended: bool,
     /// Did this response include any tool calls? (for correct stop_reason)
     pub had_tool_calls: bool,
+    /// Pending assistant text awaiting a leaked-tool-call scan.
+    ///
+    /// Text deltas are buffered here so a `<tool_call>` marker split across
+    /// streamed fragments can still be detected before the text is forwarded.
+    /// See [`crate::providers::openai::tool_salvage`].
+    pub text_buffer: String,
+    /// Count of tool calls salvaged from leaked text, used to mint unique ids.
+    pub salvaged_tool_count: u32,
+    /// Responses-API function-call output index → Anthropic content block index.
+    ///
+    /// Tracks structured Codex `function_call` items as they stream so argument
+    /// deltas land on the right `tool_use` block.
+    pub responses_fc_blocks: std::collections::HashMap<u64, u32>,
 }

--- a/tests/enterprise/translation_test.rs
+++ b/tests/enterprise/translation_test.rs
@@ -790,9 +790,9 @@ fn anthropic_to_responses_input_array_format() {
 
 #[test]
 fn anthropic_to_responses_with_tools_array() {
-    // The Responses API uses a flat tools schema (no nested "function" wrapper).
-    // The provider-side outbound translator currently does not attach tools to
-    // the Codex request body — verify this contract so any change is loud.
+    // The Responses API uses a flat tools schema (no nested "function" wrapper):
+    // each tool is {type:"function", name, description, parameters}. The outbound
+    // translator forwards the request's tools so Codex can call them.
     let mut req = base_canonical("gpt-5.3-codex");
     req.tools = Some(vec![Tool {
         r#type: Some("function".to_string()),
@@ -803,13 +803,25 @@ fn anthropic_to_responses_with_tools_array() {
     req.messages = vec![user_text("What's there?")];
 
     let out = anthropic_to_responses_request(&req, "X").expect("transform succeeds");
-    // This is a contract pin: today the outbound Responses request omits tools,
-    // so changing that is a feature requiring an explicit test update.
+
+    let tools = out["tools"]
+        .as_array()
+        .expect("Codex outbound must forward the request's tools as an array");
+    assert_eq!(tools.len(), 1);
+    // Flat schema: name/description/parameters at the top level, never nested
+    // under a "function" key (that is the Chat Completions shape).
+    assert_eq!(tools[0]["type"], json!("function"));
+    assert_eq!(tools[0]["name"], json!("ls"));
+    assert_eq!(tools[0]["description"], json!("List files"));
+    assert!(tools[0]["parameters"].is_object());
     assert!(
-        out.get("tools").is_none() || out["tools"].is_null(),
-        "Codex outbound currently does not forward tools; if that changes, update this test. Got: {}",
-        out
+        tools[0].get("function").is_none(),
+        "Responses tools must be flat (no nested 'function' wrapper): {}",
+        tools[0]
     );
+    // Forwarding tools swaps the full Codex CLI prompt for the tool-deferring
+    // preamble, so the passed-in instructions are intentionally overridden.
+    assert_ne!(out["instructions"], json!("X"));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The ChatGPT Codex (gpt-5.x via OAuth) Responses backend was **text-only**. `transform_to_responses_request` forwarded no tools and extracted only text from each message, dropping `tool_use`/`tool_result` blocks. So any agentic client (Claude Code, etc.) routed to gpt-5.5 had no usable tools:

- the model gave up ("aucun outil shell exposé"), or
- it leaked an invented tool call as plain text (`<tool_call>{"cmd":["bash","-lc",...],"workdir":...}`), driven by the Codex CLI system prompt that describes built-in `shell`/`apply_patch` tools that don't exist here,
- and even a *correct* structured `function_call` was discarded, because the streaming transform only handled `output_text.delta`/reasoning/completed events.

## Fix — full tool-calling for the Responses backend

**Request:**
- Forward request tools as flattened Responses `function` definitions, plus `tool_choice` and `parallel_tool_calls`.
- Replay history through typed input items: assistant `tool_use` → `function_call`, user `tool_result` → `function_call_output`, correlated by the shared id so multi-turn loops survive the round-trip.
- Swap the Codex CLI prompt for a minimal **tool-deferring preamble** when tools are forwarded, so the model uses the provided tools instead of the non-existent built-ins.
- Fold disallowed `system`-role items into user items (the backend rejects *"System messages are not allowed"*).

**Response:**
- Translate streaming `function_call` events (`output_item.added` / `function_call_arguments.delta` / `output_item.done`) into Anthropic `tool_use` blocks (`content_block_start` + `input_json_delta` + `content_block_stop`), keyed by `output_index`.
- Handle structured `function_call` items in the non-streaming parse, and set `stop_reason = tool_use`.

**Fallback net — `tool_salvage`:**
- When a model still leaks a `<tool_call>` block as text, recover it into a real `tool_use` block. Streaming-buffer aware (markers split across deltas), handles the canonical `{name, arguments}` shape and the nameless Codex `shell` shape (→ `Bash`).

## Tests

- `providers::openai` unit tests: 33 pass. New coverage for tools+history round-trip, system-role folding, streaming structured function calls, and the salvage scanner (split markers, multibyte safety, fenced Codex leak).
- Full lib suite green (1230 tests).

## Verified live

gpt-5.5 via ChatGPT Codex OAuth now runs real Bash/Read tool loops in Claude Code, including the multi-step `/cli-cycle` skill:

```
⏺ Bash(pwd && ls)
  ⎿  /Users/ludwig/workspace/reti
     AGENTS.md ... +26 lines
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)