### PR TITLE
fix(security): raise tool-spike defaults for agentic clients

### DIFF
--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -234,9 +234,13 @@ Detects per-session tool-call spikes so a misbehaving agent cannot exhaust provi
 
 ```toml
 [security]
-tool_spike_warn_per_min = 100     # log + metric above this (default: 100)
-tool_spike_block_per_min = 500    # return HTTP 429 above this (default: 500)
+tool_spike_warn_per_min = 500     # log + metric above this (default: 500)
+tool_spike_block_per_min = 2000   # return HTTP 429 above this (default: 2000)
 ```
+
+> Counting includes both `tool_use` and the `tool_result` echoed back, so one
+> tool round-trip scores ~2. The defaults are sized for agentic clients (Claude
+> Code, multi-skill runs); lower them for stricter quota protection.
 
 ### Behavior
 

--- a/src/cli/config/security.rs
+++ b/src/cli/config/security.rs
@@ -67,14 +67,14 @@ pub struct SecurityConfig {
     /// keyed on a non-anonymous tenant id.
     #[serde(default)]
     pub strict_tenant: bool,
-    /// Tool-call spike: warn threshold per session per minute (default 100).
+    /// Tool-call spike: warn threshold per session per minute (default 500).
     ///
     /// Crossing this rolling 60s count logs a warning and emits a
     /// metric without rejecting the request. Set to `0` to disable
     /// warnings.
     #[serde(default = "default_tool_spike_warn_per_min")]
     pub tool_spike_warn_per_min: u32,
-    /// Tool-call spike: block threshold per session per minute (default 500).
+    /// Tool-call spike: block threshold per session per minute (default 2000).
     ///
     /// Crossing this rolling 60s count returns HTTP 429, writes a
     /// signed audit entry, and emits a metric. Set to `0` to disable
@@ -147,17 +147,21 @@ fn default_scoring_decay_rate() -> f64 {
     0.001
 }
 
-// NOTE: 100 tool calls/min/session is roughly the upper bound for a busy
-// build run (Claude Code reading ~2 files/sec while exploring a tree).
-// Above this we want a paper trail but still let the request through.
+// NOTE: The detector counts both `tool_use` blocks and the `tool_result`
+// blocks echoed back, so a single tool round-trip scores ~2. Agentic clients
+// (Claude Code, multi-skill orchestrations like `/cli-cycle`) legitimately burst
+// to several hundred tool events/min, so the warn level is the early signal for
+// that band — a paper trail without rejecting the request.
 fn default_tool_spike_warn_per_min() -> u32 {
-    100
+    500
 }
 
-// NOTE: 500 tool calls/min/session is firmly anomalous — >8/sec sustained,
-// which only a runaway loop produces. Blocks dispatch and audit-logs.
+// NOTE: 2000 tool events/min/session (~33/sec counting both directions, i.e.
+// ~16 round-trips/sec) is firmly anomalous — only a runaway loop sustains it,
+// while heavy-but-legitimate agentic runs stay below it. Blocks and audit-logs.
+// (The previous 500 throttled real multi-skill workloads with HTTP 429.)
 fn default_tool_spike_block_per_min() -> u32 {
-    500
+    2000
 }
 
 /// EU AI Act compliance configuration

--- a/src/security/tool_spike.rs
+++ b/src/security/tool_spike.rs
@@ -53,8 +53,8 @@ pub struct ToolSpikeConfig {
 impl Default for ToolSpikeConfig {
     fn default() -> Self {
         Self {
-            warn_per_min: 100,
-            block_per_min: 500,
+            warn_per_min: 500,
+            block_per_min: 2000,
         }
     }
 }


### PR DESCRIPTION
## Problem

The tool-spike detector counts both `tool_use` blocks **and** the `tool_result` blocks echoed back, so one tool round-trip scores ~2. With defaults at `warn=100` / `block=500` per session per minute, a legitimate heavy agentic run — a Claude Code multi-skill orchestration like `/cli-cycle` — bursts past the block level and gets **HTTP 429'd mid-flight**.

Observed live (gpt-5.5 via Codex OAuth running `/cli-cycle`): **91 tool-spike blocks in one session-minute**, stalling the run. The old code comment assumed ">8/sec sustained only a runaway loop produces" — no longer true for multi-agent orchestration.

## Fix

Raise the defaults to `warn=500` / `block=2000` (~16 round-trips/sec at the block level): still firmly anomalous for a runaway loop, but no longer throttling real agentic traffic.

- `src/cli/config/security.rs` — default fns + doc, with a note that counting is bidirectional.
- `src/security/tool_spike.rs` — `Default` impl.
- `docs/reference/security.md` — documented defaults + counting note.

Operators wanting stricter quota protection can lower them in `[security]`. Setting both to `0` still disables the detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)