### PR TITLE
feat(openai): control Codex reasoning effort (auto-map + config override)

### DIFF
--- a/src/cli/config/providers.rs
+++ b/src/cli/config/providers.rs
@@ -86,6 +86,12 @@ pub struct ProviderConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pass_through: Option<bool>,
 
+    /// Forces a Codex reasoning effort (`"minimal"`, `"low"`, `"medium"`,
+    /// `"high"`) for this provider, overriding the per-request auto-mapping.
+    /// Only affects the OpenAI Responses (Codex) path. Lower effort cuts latency.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+
     /// Path to PEM client certificate for mTLS.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_cert: Option<String>,

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -24,6 +24,7 @@ pub(crate) struct ProviderBase {
     pub api_timeout: Duration,
     pub pass_through: bool,
     pub key_pool: Option<Arc<KeyPool>>,
+    pub reasoning_effort: Option<String>,
 }
 
 impl ProviderBase {
@@ -43,6 +44,7 @@ impl ProviderBase {
             api_timeout: params.api_timeout,
             pass_through: params.pass_through,
             key_pool: params.key_pool,
+            reasoning_effort: params.reasoning_effort,
         }
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -222,6 +222,8 @@ pub struct ProviderParams {
     pub tls_ca: Option<reqwest::Certificate>,
     /// Optional multi-account key pool for API key rotation.
     pub key_pool: Option<std::sync::Arc<key_pool::KeyPool>>,
+    /// Forced Codex reasoning effort, overriding per-request auto-mapping.
+    pub reasoning_effort: Option<String>,
 }
 
 // Re-export config types that were moved to cli::config to break the

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -64,7 +64,7 @@ pub mod test_api {
         request: &CanonicalRequest,
         instructions: &str,
     ) -> Result<serde_json::Value, String> {
-        let resp_req = transform::transform_to_responses_request(request, instructions)
+        let resp_req = transform::transform_to_responses_request(request, instructions, None)
             .map_err(|e| e.to_string())?;
         serde_json::to_value(&resp_req).map_err(|e| e.to_string())
     }
@@ -199,8 +199,11 @@ impl OpenAIProvider {
         auth_value: &str,
         base_url: &str,
     ) -> Result<ProviderResponse, ProviderError> {
-        let responses_request =
-            transform::transform_to_responses_request(request, CODEX_INSTRUCTIONS)?;
+        let responses_request = transform::transform_to_responses_request(
+            request,
+            CODEX_INSTRUCTIONS,
+            self.base.reasoning_effort.as_deref(),
+        )?;
 
         let endpoint = if self.base.is_oauth() {
             "/codex/responses"
@@ -383,8 +386,11 @@ impl LlmProvider for OpenAIProvider {
                 endpoint,
                 request.model
             );
-            let responses_request =
-                transform::transform_to_responses_request(&request, CODEX_INSTRUCTIONS)?;
+            let responses_request = transform::transform_to_responses_request(
+                &request,
+                CODEX_INSTRUCTIONS,
+                self.base.reasoning_effort.as_deref(),
+            )?;
             let body = serde_json::to_value(&responses_request)
                 .map_err(ProviderError::SerializationError)?;
             (format!("{}{}", base_url, endpoint), body)

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -582,6 +582,7 @@ with its required arguments.";
 pub(crate) fn transform_to_responses_request(
     request: &CanonicalRequest,
     codex_instructions: &str,
+    forced_effort: Option<&str>,
 ) -> Result<OpenAIResponsesRequest, ProviderError> {
     let tools = transform_responses_tools(request);
 
@@ -633,7 +634,42 @@ pub(crate) fn transform_to_responses_request(
         tool_choice: tools.as_ref().and(transform_responses_tool_choice(request)),
         parallel_tool_calls: tools.as_ref().map(|_| true),
         tools,
+        reasoning: resolve_reasoning_effort(request, forced_effort)
+            .map(|effort| serde_json::json!({ "effort": effort })),
     })
+}
+
+/// Resolves the Codex reasoning effort for a request.
+///
+/// Precedence: a provider-config `forced_effort` wins, then an explicit
+/// `reasoning_effort` request extension (e.g. from a Codex CLI client),
+/// otherwise the effort is auto-mapped from the request's extended-thinking
+/// setting so simple turns stay fast while deliberate thinking turns get more
+/// reasoning. Returns `None` for unrecognised effort strings, leaving the
+/// backend default in place.
+fn resolve_reasoning_effort(request: &CanonicalRequest, forced: Option<&str>) -> Option<String> {
+    let candidate = forced
+        .map(str::to_string)
+        .or_else(|| request.extensions.reasoning_effort.clone())
+        .unwrap_or_else(|| auto_map_thinking_effort(request));
+    // Guard against typos slipping through to the backend.
+    matches!(candidate.as_str(), "minimal" | "low" | "medium" | "high").then_some(candidate)
+}
+
+/// Maps Anthropic extended-thinking config to a Codex reasoning-effort tier.
+///
+/// No thinking (or `disabled`) maps to `low` for snappy responses; enabled
+/// thinking scales with the token budget — a large budget signals the client
+/// wants deeper reasoning.
+fn auto_map_thinking_effort(request: &CanonicalRequest) -> String {
+    match request.thinking.as_ref() {
+        Some(t) if t.r#type == "enabled" => match t.budget_tokens {
+            Some(budget) if budget >= 16_000 => "high",
+            Some(_) | None => "medium",
+        },
+        _ => "low",
+    }
+    .to_string()
 }
 
 /// Expands a message's content blocks into Responses items, preserving order.
@@ -806,7 +842,7 @@ mod tests {
             },
         ];
 
-        let req = transform_to_responses_request(&request, "FULL CODEX PROMPT").unwrap();
+        let req = transform_to_responses_request(&request, "FULL CODEX PROMPT", None).unwrap();
         let json = serde_json::to_value(&req).unwrap();
 
         // Tools are forwarded in the flattened Responses shape.
@@ -845,7 +881,7 @@ mod tests {
             content: MessageContent::Text("be terse".to_string()),
         }];
 
-        let req = transform_to_responses_request(&request, "FULL").unwrap();
+        let req = transform_to_responses_request(&request, "FULL", None).unwrap();
         let json = serde_json::to_value(&req).unwrap();
         let input = json["input"].as_array().unwrap();
 
@@ -858,10 +894,55 @@ mod tests {
     }
 
     #[test]
+    fn reasoning_effort_auto_maps_and_respects_overrides() {
+        use crate::models::ThinkingConfig;
+
+        let effort = |req: &CanonicalRequest, forced: Option<&str>| {
+            serde_json::to_value(transform_to_responses_request(req, "X", forced).unwrap()).unwrap()
+                ["reasoning"]["effort"]
+                .clone()
+        };
+
+        let mut req = base_request();
+        req.system = None;
+
+        // No thinking → low (snappy).
+        assert_eq!(effort(&req, None), serde_json::json!("low"));
+
+        // Thinking enabled with a large budget → high.
+        req.thinking = Some(ThinkingConfig {
+            r#type: "enabled".to_string(),
+            budget_tokens: Some(20_000),
+        });
+        assert_eq!(effort(&req, None), serde_json::json!("high"));
+
+        // Smaller budget → medium.
+        req.thinking = Some(ThinkingConfig {
+            r#type: "enabled".to_string(),
+            budget_tokens: Some(4_000),
+        });
+        assert_eq!(effort(&req, None), serde_json::json!("medium"));
+
+        // Provider-forced effort overrides the auto-mapping.
+        assert_eq!(effort(&req, Some("minimal")), serde_json::json!("minimal"));
+
+        // A request extension forces effort when no provider override is set.
+        req.thinking = None;
+        req.extensions.reasoning_effort = Some("high".to_string());
+        assert_eq!(effort(&req, None), serde_json::json!("high"));
+
+        // An unrecognised effort is dropped (backend default kept).
+        req.extensions.reasoning_effort = Some("turbo".to_string());
+        let out =
+            serde_json::to_value(transform_to_responses_request(&req, "X", None).unwrap()).unwrap();
+        assert!(out.get("reasoning").is_none() || out["reasoning"].is_null());
+    }
+
+    #[test]
     fn responses_request_without_tools_keeps_full_instructions() {
         let mut request = base_request();
         request.system = None;
-        let req = transform_to_responses_request(&request, "FULL CODEX PROMPT").unwrap();
+        let req = transform_to_responses_request(&request, "FULL CODEX PROMPT", None).unwrap();
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["instructions"], "FULL CODEX PROMPT");
         assert!(json.get("tools").is_none() || json["tools"].is_null());

--- a/src/providers/openai/types.rs
+++ b/src/providers/openai/types.rs
@@ -71,6 +71,9 @@ pub(crate) struct OpenAIResponsesRequest {
     /// Whether the model may emit several tool calls in one turn.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parallel_tool_calls: Option<bool>,
+    /// Reasoning controls, e.g. `{"effort": "low"}`. Lower effort cuts latency.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<serde_json::Value>,
 }
 
 /// Input for Responses API is an array of typed items.

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -172,6 +172,7 @@ impl ProviderRegistry {
             tls_identity,
             tls_ca,
             key_pool,
+            reasoning_effort: config.reasoning_effort.clone(),
         }
     }
 
@@ -619,6 +620,7 @@ mod tests {
                 tls_key: None,
                 tls_ca: None,
                 pool: None,
+                reasoning_effort: None,
                 circuit_breaker: None,
 
                 health_check: None,
@@ -643,6 +645,7 @@ mod tests {
                 tls_key: None,
                 tls_ca: None,
                 pool: None,
+                reasoning_effort: None,
                 circuit_breaker: None,
 
                 health_check: None,
@@ -756,6 +759,7 @@ mod tests {
             tls_key: None,
             tls_ca: None,
             pool: None,
+            reasoning_effort: None,
             circuit_breaker: None,
             health_check: None,
             max_retries: None,

--- a/src/server/budget.rs
+++ b/src/server/budget.rs
@@ -584,6 +584,7 @@ mod tests {
             tls_key: None,
             tls_ca: None,
             pool: None,
+            reasoning_effort: None,
             circuit_breaker: None,
             health_check: None,
             max_retries,

--- a/src/storage/secrets.rs
+++ b/src/storage/secrets.rs
@@ -309,6 +309,7 @@ mod tests {
             tls_key: None,
             tls_ca: None,
             pool: None,
+            reasoning_effort: None,
             circuit_breaker: None,
             health_check: None,
             max_retries: None,

--- a/tests/helpers/fixtures.rs
+++ b/tests/helpers/fixtures.rs
@@ -123,6 +123,7 @@ pub fn base_provider_config(name: &str) -> grob::providers::ProviderConfig {
         tls_key: None,
         tls_ca: None,
         pool: None,
+        reasoning_effort: None,
         circuit_breaker: None,
 
         health_check: None,

--- a/tests/unit/provider_test.rs
+++ b/tests/unit/provider_test.rs
@@ -29,6 +29,7 @@ mod tests {
             tls_key: None,
             tls_ca: None,
             pool: None,
+            reasoning_effort: None,
             circuit_breaker: None,
 
             health_check: None,
@@ -60,6 +61,7 @@ mod tests {
             tls_key: None,
             tls_ca: None,
             pool: None,
+            reasoning_effort: None,
             circuit_breaker: None,
 
             health_check: None,


### PR DESCRIPTION
## Problem

The Responses (Codex) path never set a reasoning effort, so gpt-5.x ran at its default high effort — the dominant source of latency (time-to-first-token up to ~14s observed in agentic runs).

## Fix

Resolve an effort per request, with precedence:
1. provider config `reasoning_effort` (operator-forced, new `[[providers]]` field),
2. an explicit `reasoning_effort` request extension (e.g. Codex CLI clients),
3. **auto-mapped from Anthropic extended-thinking** (the default): no thinking → `low` (snappy), enabled → `medium`, enabled with a large budget (≥16k tokens) → `high`.

Unrecognised efforts are dropped, leaving the backend default in place. Adds a `reasoning_effort` field plumbed through `ProviderConfig → ProviderParams → ProviderBase`.

## Tests

`reasoning_effort_auto_maps_and_respects_overrides` covers all tiers + both override sources + the invalid-effort drop. Full suite green (1524 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)