### PR TITLE
chore: release v0.36.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.54](https://github.com/azerozero/grob/compare/v0.36.53...v0.36.54) - 2026-05-31
+
+### Added
+
+- *(openai)* control Codex reasoning effort (auto-map + config override)
+- *(openai)* make ChatGPT Codex tool-calling work end-to-end
+
+### Other
+
+- *(openai)* update Codex tools contract pin to expect forwarded tools
+
 ## [0.36.53](https://github.com/azerozero/grob/compare/v0.36.52...v0.36.53) - 2026-05-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.53"
+version = "0.36.54"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.53"
+version = "0.36.54"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.53 -> 0.36.54

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.54](https://github.com/azerozero/grob/compare/v0.36.53...v0.36.54) - 2026-05-31

### Added

- *(openai)* control Codex reasoning effort (auto-map + config override)
- *(openai)* make ChatGPT Codex tool-calling work end-to-end

### Other

- *(openai)* update Codex tools contract pin to expect forwarded tools
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).