### PR TITLE
fix(dispatch): surface the real upstream error instead of masking it

### DIFF
--- a/src/server/dispatch/provider_loop.rs
+++ b/src/server/dispatch/provider_loop.rs
@@ -50,6 +50,10 @@ pub(super) async fn dispatch_provider_loop(
             sorted_mappings
         };
 
+    // Most recent real upstream failure across attempted mappings, surfaced to
+    // the client when every mapping fails (instead of a misleading fallback).
+    let mut last_error: Option<RequestError> = None;
+
     for (idx, mapping) in effective_mappings.iter().enumerate() {
         let Some(provider) = resolve_provider(ctx, mapping).await else {
             continue;
@@ -123,7 +127,8 @@ pub(super) async fn dispatch_provider_loop(
 
         match result {
             Ok(dispatch_result) => return Ok(dispatch_result),
-            Err(ProviderLoopAction::RateLimited) => {
+            Err(ProviderLoopAction::RateLimited(err)) => {
+                last_error = Some(*err);
                 if let Some(ok) = try_rotate_and_retry(
                     ctx,
                     request,
@@ -149,7 +154,8 @@ pub(super) async fn dispatch_provider_loop(
                 tokio::task::yield_now().await;
                 continue;
             }
-            Err(ProviderLoopAction::Continue) => {
+            Err(ProviderLoopAction::Continue(err)) => {
+                last_error = Some(*err);
                 emit_fallback(
                     ctx,
                     mapping,
@@ -175,9 +181,16 @@ pub(super) async fn dispatch_provider_loop(
         }
     }
 
-    // All providers exhausted -- try backward-compat direct lookup
-    if let Some(result) = try_direct_provider_lookup(ctx, request, &decision.model_name).await? {
-        return Ok(result);
+    // Backward-compat direct lookup — only when no mapping was actually
+    // attempted (a bare model name not in `[[models.mappings]]`). When a mapping
+    // *was* tried and failed, the router model name (e.g. `dev`) is not a real
+    // upstream model, so re-sending it just yields a misleading "model not
+    // supported" error that masks the true failure (`last_error`).
+    if last_error.is_none() {
+        if let Some(result) = try_direct_provider_lookup(ctx, request, &decision.model_name).await?
+        {
+            return Ok(result);
+        }
     }
 
     // Audit: all providers failed
@@ -200,15 +213,21 @@ pub(super) async fn dispatch_provider_loop(
         "All provider mappings failed for model: {}",
         decision.model_name
     );
-    Err(RequestError::ProviderUpstream {
-        provider: "all".to_string(),
-        status: 502,
-        body: Some(format!(
-            "All {} provider mappings failed for model: {}",
-            effective_mappings.len(),
-            decision.model_name
-        )),
-    })
+
+    // Surface the real upstream failure (verbatim status + body, e.g. a 429
+    // `usage_limit_reached` with `resets_in_seconds`) when a mapping was tried;
+    // only fall back to a generic 502 when nothing was ever attempted.
+    Err(
+        last_error.unwrap_or_else(|| RequestError::ProviderUpstream {
+            provider: "all".to_string(),
+            status: 502,
+            body: Some(format!(
+                "All {} provider mappings failed for model: {}",
+                effective_mappings.len(),
+                decision.model_name
+            )),
+        }),
+    )
 }
 
 /// Returns the index of the next mapping to fall back to.

--- a/src/server/dispatch/retry.rs
+++ b/src/server/dispatch/retry.rs
@@ -20,18 +20,47 @@ use super::telemetry::{
     calculate_and_record_metrics, record_success_telemetry, store_response_cache,
 };
 use super::{telemetry, DispatchContext, DispatchResult};
+use crate::providers::error::ProviderError;
+use crate::server::RequestError;
 
 /// Internal signal from the per-attempt dispatch back to the outer provider loop.
 pub(super) enum ProviderLoopAction {
     /// Non-terminal failure: move to the next mapping in the priority list.
-    Continue,
-    /// Rate-limited (429): the caller should attempt key pool rotation
-    /// before falling through to the next provider mapping.
-    RateLimited,
+    ///
+    /// Carries the captured upstream error so the loop can surface the real
+    /// cause to the client when every mapping fails, instead of a generic 502.
+    Continue(Box<RequestError>),
+    /// Rate-limited (429): the caller should attempt key pool rotation before
+    /// falling through to the next provider mapping. Carries the captured
+    /// upstream error for the same reason as [`ProviderLoopAction::Continue`].
+    RateLimited(Box<RequestError>),
     /// Terminal auth failure (401 `authentication_error`): do NOT fall back
     /// to sibling providers — surface the error directly to the client so the
     /// user is prompted to run `grob connect --force-reauth`.
     AuthRevoked(String),
+}
+
+/// Captures a provider failure as a [`RequestError`] preserving the upstream
+/// status and body verbatim.
+///
+/// The blanket `From<ProviderError>` flattens a 429 to a body-less
+/// `RateLimited`, dropping the diagnostic payload (e.g. ChatGPT's
+/// `usage_limit_reached` with `resets_in_seconds`). Keeping status + body here
+/// lets the loop surface the true upstream cause when every mapping fails,
+/// rather than a misleading fallback or a generic 502.
+fn capture_upstream_error(provider: &str, err: &ProviderError) -> RequestError {
+    match err {
+        ProviderError::ApiError { status, message } => RequestError::ProviderUpstream {
+            provider: provider.to_string(),
+            status: *status,
+            body: Some(message.clone()),
+        },
+        other => RequestError::ProviderUpstream {
+            provider: provider.to_string(),
+            status: 502,
+            body: Some(other.to_string()),
+        },
+    }
 }
 
 /// Per-provider dispatch parameters (non-streaming path).
@@ -251,10 +280,11 @@ pub(super) async fn dispatch_streaming(
             if is_auth_revoked_error(&e) {
                 return Err(ProviderLoopAction::AuthRevoked(e.to_string()));
             }
+            let captured = Box::new(capture_upstream_error(&mapping.provider, &e));
             if is_upstream_rate_limit(&e) {
-                Err(ProviderLoopAction::RateLimited)
+                Err(ProviderLoopAction::RateLimited(captured))
             } else {
-                Err(ProviderLoopAction::Continue)
+                Err(ProviderLoopAction::Continue(captured))
             }
         }
     }
@@ -334,6 +364,9 @@ pub(super) async fn dispatch_non_streaming(
 
     // Wrap in Option so we can move (not clone) on the final attempt.
     let mut owned_request = Some(provider_request);
+    // Most recent failure, captured so the outer loop can surface the real
+    // upstream error (status + body, rate-limit flag) instead of a generic 502.
+    let mut last_error: Option<(bool, RequestError)> = None;
     for retry in 0..=max_retries {
         if is_backoff_attempt(retry) {
             let delay = retry_delay(backoff_step(retry));
@@ -431,6 +464,13 @@ pub(super) async fn dispatch_non_streaming(
                     return Err(ProviderLoopAction::AuthRevoked(e.to_string()));
                 }
 
+                // Remember the latest failure so it can be surfaced verbatim if
+                // this provider is ultimately given up on.
+                last_error = Some((
+                    is_upstream_rate_limit(&e),
+                    capture_upstream_error(&attempt.mapping.provider, &e),
+                ));
+
                 if classify_and_handle_error(ctx, attempt.mapping, &e, retry, max_retries) {
                     // On 429, try rotating to next pooled key before retrying.
                     let rate_limited = is_upstream_rate_limit(&e);
@@ -471,7 +511,17 @@ pub(super) async fn dispatch_non_streaming(
             }
         }
     }
-    Err(ProviderLoopAction::Continue)
+    match last_error {
+        Some((true, err)) => Err(ProviderLoopAction::RateLimited(Box::new(err))),
+        Some((false, err)) => Err(ProviderLoopAction::Continue(Box::new(err))),
+        None => Err(ProviderLoopAction::Continue(Box::new(
+            RequestError::ProviderUpstream {
+                provider: attempt.mapping.provider.clone(),
+                status: 502,
+                body: None,
+            },
+        ))),
+    }
 }
 
 /// Wrap a raw provider stream with DLP sanitization, HIT authorization, and Tap recording layers.


### PR DESCRIPTION
## Problem

When every provider mapping failed, the dispatch loop **discarded the real upstream error** and surfaced a misleading one:
- it ran a backward-compat *direct lookup* that re-sent the router model name (e.g. `dev`) as a literal model → **`400 "The 'dev' model is not supported"`**, or
- returned a generic **`502`**.

So the true cause — a `429 usage_limit_reached` (with `resets_in_seconds`), a `400` on `reasoning.effort`, a 5xx, etc. — never reached the client. Even the blanket `From<ProviderError>` flattened 429s to a body-less `RateLimited`, dropping the diagnostic payload.

## Fix

- Carry the captured upstream error (verbatim status + body) on the `Continue`/`RateLimited` loop actions (`capture_upstream_error` preserves `ApiError { status, message }`).
- Remember the last failure across mappings (`last_error`).
- **Skip the direct lookup** when a mapping was actually attempted — the router alias isn't a real upstream model, so re-sending it only masks the cause.
- **Return the captured error verbatim** when all mappings fail; fall back to the generic 502 only when nothing was ever attempted.

## Verified live (isolated instance, prod untouched)

Forcing a bad effort now surfaces the real upstream error on both streaming and non-streaming:
```json
{"message":"Invalid value: 'max'. Supported values are: 'none','minimal','low','medium','high','xhigh'",
 "param":"reasoning.effort","provider":"chatgpt-codex","upstream_status":400}
```
instead of the `dev` error. The same path now surfaces `429 usage_limit_reached` verbatim. Full suite green (1524).

🤖 Generated with [Claude Code](https://claude.com/claude-code)