### PR TITLE
feat(openai): forward Codex service_tier (priority = faster handling)

### DIFF
--- a/src/cli/config/providers.rs
+++ b/src/cli/config/providers.rs
@@ -94,6 +94,12 @@ pub struct ProviderConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
 
+    /// Codex processing tier — `"priority"` enables faster ("1.5x") handling on
+    /// eligible plans, `"default"` is standard. Sent verbatim (backend
+    /// validates). Only affects the OpenAI Responses (Codex) path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+
     /// Path to PEM client certificate for mTLS.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_cert: Option<String>,

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -25,6 +25,7 @@ pub(crate) struct ProviderBase {
     pub pass_through: bool,
     pub key_pool: Option<Arc<KeyPool>>,
     pub reasoning_effort: Option<String>,
+    pub service_tier: Option<String>,
 }
 
 impl ProviderBase {
@@ -45,6 +46,7 @@ impl ProviderBase {
             pass_through: params.pass_through,
             key_pool: params.key_pool,
             reasoning_effort: params.reasoning_effort,
+            service_tier: params.service_tier,
         }
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -224,6 +224,8 @@ pub struct ProviderParams {
     pub key_pool: Option<std::sync::Arc<key_pool::KeyPool>>,
     /// Forced Codex reasoning effort, overriding per-request auto-mapping.
     pub reasoning_effort: Option<String>,
+    /// Forced Codex processing tier (e.g. `"priority"` for faster handling).
+    pub service_tier: Option<String>,
 }
 
 // Re-export config types that were moved to cli::config to break the

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -64,7 +64,7 @@ pub mod test_api {
         request: &CanonicalRequest,
         instructions: &str,
     ) -> Result<serde_json::Value, String> {
-        let resp_req = transform::transform_to_responses_request(request, instructions, None)
+        let resp_req = transform::transform_to_responses_request(request, instructions, None, None)
             .map_err(|e| e.to_string())?;
         serde_json::to_value(&resp_req).map_err(|e| e.to_string())
     }
@@ -203,6 +203,7 @@ impl OpenAIProvider {
             request,
             CODEX_INSTRUCTIONS,
             self.base.reasoning_effort.as_deref(),
+            self.base.service_tier.as_deref(),
         )?;
 
         let endpoint = if self.base.is_oauth() {
@@ -390,6 +391,7 @@ impl LlmProvider for OpenAIProvider {
                 &request,
                 CODEX_INSTRUCTIONS,
                 self.base.reasoning_effort.as_deref(),
+                self.base.service_tier.as_deref(),
             )?;
             let body = serde_json::to_value(&responses_request)
                 .map_err(ProviderError::SerializationError)?;

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -583,6 +583,7 @@ pub(crate) fn transform_to_responses_request(
     request: &CanonicalRequest,
     codex_instructions: &str,
     forced_effort: Option<&str>,
+    forced_service_tier: Option<&str>,
 ) -> Result<OpenAIResponsesRequest, ProviderError> {
     let tools = transform_responses_tools(request);
 
@@ -636,7 +637,20 @@ pub(crate) fn transform_to_responses_request(
         tools,
         reasoning: resolve_reasoning_effort(request, forced_effort)
             .map(|effort| serde_json::json!({ "effort": effort })),
+        service_tier: resolve_service_tier(request, forced_service_tier),
     })
+}
+
+/// Resolves the Codex `service_tier` (processing speed) for a request.
+///
+/// A provider-config value wins, then a `service_tier` request extension. The
+/// value passes through verbatim — the backend validates it — so `"priority"`
+/// (faster handling) works without a whitelist. `None` leaves the field unset.
+fn resolve_service_tier(request: &CanonicalRequest, forced: Option<&str>) -> Option<String> {
+    forced
+        .map(str::to_string)
+        .or_else(|| request.extensions.service_tier.clone())
+        .filter(|s| !s.is_empty())
 }
 
 /// Resolves the Codex reasoning effort for a request.
@@ -858,7 +872,8 @@ mod tests {
             },
         ];
 
-        let req = transform_to_responses_request(&request, "FULL CODEX PROMPT", None).unwrap();
+        let req =
+            transform_to_responses_request(&request, "FULL CODEX PROMPT", None, None).unwrap();
         let json = serde_json::to_value(&req).unwrap();
 
         // Tools are forwarded in the flattened Responses shape.
@@ -897,7 +912,7 @@ mod tests {
             content: MessageContent::Text("be terse".to_string()),
         }];
 
-        let req = transform_to_responses_request(&request, "FULL", None).unwrap();
+        let req = transform_to_responses_request(&request, "FULL", None, None).unwrap();
         let json = serde_json::to_value(&req).unwrap();
         let input = json["input"].as_array().unwrap();
 
@@ -914,8 +929,8 @@ mod tests {
         use crate::models::ThinkingConfig;
 
         let effort = |req: &CanonicalRequest, forced: Option<&str>| {
-            serde_json::to_value(transform_to_responses_request(req, "X", forced).unwrap()).unwrap()
-                ["reasoning"]["effort"]
+            serde_json::to_value(transform_to_responses_request(req, "X", forced, None).unwrap())
+                .unwrap()["reasoning"]["effort"]
                 .clone()
         };
 
@@ -973,10 +988,37 @@ mod tests {
     }
 
     #[test]
+    fn service_tier_is_forwarded_from_config_and_extension() {
+        let tier = |req: &CanonicalRequest, forced: Option<&str>| {
+            serde_json::to_value(transform_to_responses_request(req, "X", None, forced).unwrap())
+                .unwrap()["service_tier"]
+                .clone()
+        };
+
+        let mut req = base_request();
+        req.system = None;
+
+        // Unset by default.
+        assert_eq!(tier(&req, None), serde_json::Value::Null);
+
+        // Provider config forces it (verbatim — backend validates "priority").
+        assert_eq!(tier(&req, Some("priority")), serde_json::json!("priority"));
+
+        // A request extension supplies it when no config override is set.
+        req.extensions.service_tier = Some("priority".to_string());
+        assert_eq!(tier(&req, None), serde_json::json!("priority"));
+
+        // An empty forced value falls back to unset, not an empty string.
+        req.extensions.service_tier = None;
+        assert_eq!(tier(&req, Some("")), serde_json::Value::Null);
+    }
+
+    #[test]
     fn responses_request_without_tools_keeps_full_instructions() {
         let mut request = base_request();
         request.system = None;
-        let req = transform_to_responses_request(&request, "FULL CODEX PROMPT", None).unwrap();
+        let req =
+            transform_to_responses_request(&request, "FULL CODEX PROMPT", None, None).unwrap();
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["instructions"], "FULL CODEX PROMPT");
         assert!(json.get("tools").is_none() || json["tools"].is_null());

--- a/src/providers/openai/types.rs
+++ b/src/providers/openai/types.rs
@@ -74,6 +74,9 @@ pub(crate) struct OpenAIResponsesRequest {
     /// Reasoning controls, e.g. `{"effort": "low"}`. Lower effort cuts latency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<serde_json::Value>,
+    /// Processing tier, e.g. `"priority"` for faster handling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 /// Input for Responses API is an array of typed items.

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -173,6 +173,7 @@ impl ProviderRegistry {
             tls_ca,
             key_pool,
             reasoning_effort: config.reasoning_effort.clone(),
+            service_tier: config.service_tier.clone(),
         }
     }
 
@@ -621,6 +622,7 @@ mod tests {
                 tls_ca: None,
                 pool: None,
                 reasoning_effort: None,
+                service_tier: None,
                 circuit_breaker: None,
 
                 health_check: None,
@@ -646,6 +648,7 @@ mod tests {
                 tls_ca: None,
                 pool: None,
                 reasoning_effort: None,
+                service_tier: None,
                 circuit_breaker: None,
 
                 health_check: None,
@@ -760,6 +763,7 @@ mod tests {
             tls_ca: None,
             pool: None,
             reasoning_effort: None,
+            service_tier: None,
             circuit_breaker: None,
             health_check: None,
             max_retries: None,

--- a/src/server/budget.rs
+++ b/src/server/budget.rs
@@ -585,6 +585,7 @@ mod tests {
             tls_ca: None,
             pool: None,
             reasoning_effort: None,
+            service_tier: None,
             circuit_breaker: None,
             health_check: None,
             max_retries,

--- a/src/storage/secrets.rs
+++ b/src/storage/secrets.rs
@@ -310,6 +310,7 @@ mod tests {
             tls_ca: None,
             pool: None,
             reasoning_effort: None,
+            service_tier: None,
             circuit_breaker: None,
             health_check: None,
             max_retries: None,

--- a/tests/helpers/fixtures.rs
+++ b/tests/helpers/fixtures.rs
@@ -124,6 +124,7 @@ pub fn base_provider_config(name: &str) -> grob::providers::ProviderConfig {
         tls_ca: None,
         pool: None,
         reasoning_effort: None,
+        service_tier: None,
         circuit_breaker: None,
 
         health_check: None,

--- a/tests/unit/provider_test.rs
+++ b/tests/unit/provider_test.rs
@@ -30,6 +30,7 @@ mod tests {
             tls_ca: None,
             pool: None,
             reasoning_effort: None,
+            service_tier: None,
             circuit_breaker: None,
 
             health_check: None,
@@ -62,6 +63,7 @@ mod tests {
             tls_ca: None,
             pool: None,
             reasoning_effort: None,
+            service_tier: None,
             circuit_breaker: None,
 
             health_check: None,


### PR DESCRIPTION
## What

The Responses (Codex) path never forwarded `service_tier`, so OpenAI's faster **"priority"** processing tier (the "~1.5x faster" option) was unreachable through grob.

## Verified live against the ChatGPT Codex backend

| `service_tier` | backend |
|----------------|---------|
| `priority` | **200** ✅ (faster) |
| `default` | 200 ✅ |
| `turbo` / `fast` / `flex` | 400 `{"detail":"Unsupported service_tier: …"}` |

## Change

- Add `service_tier` to the Responses request, resolved from a new `[[providers]] service_tier` config (forced) or a `service_tier` request extension, **passed through verbatim** (the backend validates it).
- Plumbed `ProviderConfig → ProviderParams → ProviderBase`, mirroring `reasoning_effort`.

## Usage

```toml
[[providers]]
name = "chatgpt-codex"
provider_type = "openai"
auth_type = "oauth"
oauth_provider = "openai-codex"
service_tier = "priority"   # faster responses
```

Validated end-to-end on an isolated instance (prod untouched): a request with `service_tier = "priority"` returns 200. Full suite green (1524).

🤖 Generated with [Claude Code](https://claude.com/claude-code)