### PR TITLE
chore: release v0.36.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.57](https://github.com/azerozero/grob/compare/v0.36.56...v0.36.57) - 2026-05-31
+
+### Added
+
+- *(openai)* forward Codex service_tier (priority = faster handling)
+
 ## [0.36.56](https://github.com/azerozero/grob/compare/v0.36.55...v0.36.56) - 2026-05-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.56"
+version = "0.36.57"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.56"
+version = "0.36.57"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.56 -> 0.36.57

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.57](https://github.com/azerozero/grob/compare/v0.36.56...v0.36.57) - 2026-05-31

### Added

- *(openai)* forward Codex service_tier (priority = faster handling)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).