### PR TITLE
feat(server): log inbound Codex Responses request shape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ codeql-results.sarif
 codeql-db/
 codeql-results.sarif
 docs/reviews/
+grob-codex-proxy.toml

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -343,6 +343,20 @@ pub(crate) async fn handle_responses(
     let model = responses_request.model.clone();
     let is_streaming = responses_request.stream == Some(true);
 
+    // Surface the inbound Codex CLI request shape so a proxy operator can see
+    // the requested model and the service_tier (`"priority"` = the ~1.5x faster
+    // mode) and reasoning effort the real client sends.
+    tracing::info!(
+        "↘️  Codex inbound: model={} service_tier={:?} effort={:?} stream={}",
+        model,
+        responses_request.service_tier,
+        responses_request
+            .reasoning
+            .as_ref()
+            .and_then(|r| r.effort.clone()),
+        is_streaming,
+    );
+
     let prelude = prepare_dispatch(&state, &claims, &vk_ctx, &headers);
 
     // Transform Responses → canonical format


### PR DESCRIPTION
Adds a one-line INFO log at the start of `handle_responses` (the `/v1/responses` Codex CLI endpoint) surfacing the inbound request shape:

```
↘️  Codex inbound: model=gpt-5.5 service_tier=Some("priority") effort=Some("medium") stream=false
```

Nothing logged the `service_tier` or reasoning effort before (the model already appeared in the routing line). Routing the real Codex CLI through grob now makes exactly what it sends visible — useful for proxy/observation setups (e.g. confirming the `"priority"` ~1.5x tier and the model names the client uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)