### PR TITLE
fix(openai): apply Codex priority tier only to models that support it

### DIFF
--- a/src/cli/config/providers.rs
+++ b/src/cli/config/providers.rs
@@ -94,9 +94,11 @@ pub struct ProviderConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
 
-    /// Codex processing tier — `"priority"` enables faster ("1.5x") handling on
-    /// eligible plans, `"default"` is standard. Sent verbatim (backend
-    /// validates). Only affects the OpenAI Responses (Codex) path.
+    /// Codex processing tier — `"priority"` enables faster ("1.5x") handling,
+    /// `"default"` is standard. Only affects the OpenAI Responses (Codex) path.
+    /// `"priority"` is applied only to models that offer it (`gpt-5.5`,
+    /// `gpt-5.4`) and silently dropped for others (codex/mini) that would reject
+    /// it. Omit this field (or leave it unset) to disable — nothing is sent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
 

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -647,10 +647,27 @@ pub(crate) fn transform_to_responses_request(
 /// value passes through verbatim — the backend validates it — so `"priority"`
 /// (faster handling) works without a whitelist. `None` leaves the field unset.
 fn resolve_service_tier(request: &CanonicalRequest, forced: Option<&str>) -> Option<String> {
-    forced
+    let tier = forced
         .map(str::to_string)
         .or_else(|| request.extensions.service_tier.clone())
-        .filter(|s| !s.is_empty())
+        .filter(|s| !s.is_empty())?;
+    // The "priority" (1.5x) tier exists only on some models (gpt-5.5, gpt-5.4);
+    // others reject it with a 400. Drop it for unsupported models so a provider
+    // forcing `service_tier = "priority"` does not break `think`/`background`
+    // routes (which resolve to codex/mini models). Other tiers pass through.
+    if tier == "priority" && !priority_tier_supported(&request.model) {
+        return None;
+    }
+    Some(tier)
+}
+
+/// Returns whether the model offers the Codex `priority` (1.5x) service tier.
+///
+/// Per the Codex model catalog only `gpt-5.5` and `gpt-5.4` (not `-mini`) expose
+/// it; everything else (`gpt-5.4-mini`, `gpt-5.3-codex`, …) is standard-only.
+fn priority_tier_supported(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    m.starts_with("gpt-5.5") || (m.starts_with("gpt-5.4") && !m.contains("mini"))
 }
 
 /// Resolves the Codex reasoning effort for a request.
@@ -997,11 +1014,12 @@ mod tests {
 
         let mut req = base_request();
         req.system = None;
+        req.model = "gpt-5.5".to_string(); // supports the priority tier
 
         // Unset by default.
         assert_eq!(tier(&req, None), serde_json::Value::Null);
 
-        // Provider config forces it (verbatim — backend validates "priority").
+        // Provider config forces it on a supporting model.
         assert_eq!(tier(&req, Some("priority")), serde_json::json!("priority"));
 
         // A request extension supplies it when no config override is set.
@@ -1011,6 +1029,15 @@ mod tests {
         // An empty forced value falls back to unset, not an empty string.
         req.extensions.service_tier = None;
         assert_eq!(tier(&req, Some("")), serde_json::Value::Null);
+
+        // "priority" is dropped for models that don't offer it (would 400),
+        // so forcing it on a codex/mini route is a silent no-op rather than a
+        // failure. Other tiers still pass through on any model.
+        req.model = "gpt-5.3-codex".to_string();
+        assert_eq!(tier(&req, Some("priority")), serde_json::Value::Null);
+        assert_eq!(tier(&req, Some("default")), serde_json::json!("default"));
+        req.model = "gpt-5.4-mini".to_string();
+        assert_eq!(tier(&req, Some("priority")), serde_json::Value::Null);
     }
 
     #[test]


### PR DESCRIPTION
`service_tier = "priority"` (the "1.5x" tier — Codex labels it *"Fast — 1.5x speed, increased usage"*) is offered only by **gpt-5.5** and **gpt-5.4** per the Codex model catalog. `gpt-5.4-mini`, `gpt-5.3-codex`, etc. reject it with a 400.

Forcing `service_tier = "priority"` at the provider level therefore broke `think` → codex and `background` → mini routes.

## Fix

`resolve_service_tier` now drops `"priority"` when the resolved model doesn't offer it (`priority_tier_supported`: `gpt-5.5` / `gpt-5.4`, excluding `-mini`) — a silent no-op instead of a 400. Other tiers (`"default"`) pass through on any model.

**Disabling** stays trivial: omit the `service_tier` field and nothing is sent.

Tests cover: priority kept on gpt-5.5, dropped on gpt-5.3-codex and gpt-5.4-mini, default passing through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)