### PR TITLE
docs(examples): default the Codex example to the priority (1.5x) tier

### DIFF
--- a/docs/examples/chatgpt-codex-oauth.toml
+++ b/docs/examples/chatgpt-codex-oauth.toml
@@ -35,6 +35,9 @@ auth_type = "oauth"           # Use OAuth instead of api_key.
 oauth_provider = "openai-codex"  # Token key in the TokenStore (set by `grob connect`).
 enabled = true
 models = []                   # Models are declared in the [[models]] blocks below.
+service_tier = "priority"     # "Fast" tier (~1.5x speed). Applied only to models
+                              # that support it (gpt-5.5/gpt-5.4); ignored for the
+                              # rest. Remove this line for the standard tier.
 
 # Default dev model: gpt-5.5 (OpenAI's recommended Codex default).
 # To prefer the dedicated coding model, set `default = "codex"` under [router].


### PR DESCRIPTION
Ships `docs/examples/chatgpt-codex-oauth.toml` with `service_tier = "priority"` so the default Codex config uses the Fast (~1.5x) tier. Applied only to gpt-5.5/gpt-5.4; remove the line for standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)