### PR TITLE
feat: agentic-friendly default limits + configurable Codex tuning

### DIFF
--- a/docs/examples/chatgpt-codex-oauth.toml
+++ b/docs/examples/chatgpt-codex-oauth.toml
@@ -39,6 +39,21 @@ service_tier = "priority"     # "Fast" tier (~1.5x speed). Applied only to model
                               # that support it (gpt-5.5/gpt-5.4); ignored for the
                               # rest. Remove this line for the standard tier.
 
+# Advanced Codex tuning (optional). The inline values below are the DEFAULTS,
+# shown for reference — omit the whole line to use them. Only affects the
+# OpenAI Responses (Codex) path.
+#   priority_models            Models that get the "priority" tier AND `xhigh`
+#                              reasoning effort by default. Prefix-matched;
+#                              `-mini` variants are excluded unless listed verbatim.
+#                              Add new flagship names here — no grob release needed.
+#   reasoning_auto_map         false → flat default effort (xhigh for the models
+#                              above, unset otherwise). true → map the request's
+#                              extended-thinking budget → effort (legacy).
+#   reasoning_xhigh_min_budget Thinking-budget threshold for `xhigh` in auto-map
+#                              mode (ignored when reasoning_auto_map = false).
+# An explicit `reasoning_effort = "low"|"medium"|"high"|"xhigh"` overrides all of this.
+# codex = { priority_models = ["gpt-5.5", "gpt-5.4"], reasoning_auto_map = false, reasoning_xhigh_min_budget = 16000 }
+
 # Default dev model: gpt-5.5 (OpenAI's recommended Codex default).
 # To prefer the dedicated coding model, set `default = "codex"` under [router].
 [[models]]

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -17,10 +17,12 @@ Setting `enabled = false` disables all security middleware (rate limiting, circu
 
 Token-bucket rate limiter keyed per tenant (from JWT `sub`/`tenant` claim, virtual key, or API key) with IP-address fallback.
 
+**Disabled by default.** `rate_limit_rps` defaults to `0`, which skips installing the limiter entirely — grob's primary use is single-user/local, where an autonomous agent easily exceeds any fixed rps and per-tenant throttling only risks 429-ing a legitimate burst. Enable it for multi-tenant deployments:
+
 ```toml
 [security]
-rate_limit_rps = 100    # requests per second (default: 100)
-rate_limit_burst = 200  # burst capacity (default: 200)
+rate_limit_rps = 100    # requests per second (default: 0 = disabled)
+rate_limit_burst = 200  # burst capacity (default: 0; ~2x rps is typical)
 ```
 
 ### Behavior
@@ -32,12 +34,12 @@ rate_limit_burst = 200  # burst capacity (default: 200)
 
 ### Capacity planning
 
-100 rps sustains roughly 10 concurrent Claude Code sessions (each bursting ~10 req/s during tool-use loops). The 2x burst factor absorbs short spikes without triggering 429s.
+When enabled, 100 rps sustains roughly 10 concurrent Claude Code sessions (each bursting ~10 req/s during tool-use loops). The 2x burst factor absorbs short spikes without triggering 429s.
 
 ### Edge cases
 
 - A new tenant gets a full burst allowance on its first request.
-- If `rate_limit_rps` is set to 0, no tokens ever refill and requests are blocked after the initial burst is consumed.
+- `rate_limit_rps = 0` (the default) disables the limiter: it is never installed and adds no per-request work. A positive `rps` with `burst = 0` would block after the (empty) burst is consumed, so set `burst` alongside `rps`.
 
 ## Circuit breakers
 
@@ -107,12 +109,14 @@ When Grob operates as a pure API proxy (the typical deployment), the `SecurityHe
 
 ## Request size limits
 
+**Disabled by default.** `max_body_size` defaults to `0` (unlimited): no `RequestBodyLimitLayer` is installed, so large agentic contexts are never rejected. Set a positive byte count to re-enable a bound (e.g. for multi-tenant deployments):
+
 ```toml
 [security]
-max_body_size = 10485760  # bytes, default: 10 MB (10 * 1024 * 1024)
+max_body_size = 10485760  # bytes (default: 0 = unlimited; e.g. 10 MiB here)
 ```
 
-Requests exceeding this limit are rejected with HTTP `413 Payload Too Large` before JSON parsing begins, preventing memory exhaustion from oversized payloads.
+When set, requests exceeding the limit are rejected with HTTP `413 Payload Too Large` before JSON parsing begins, preventing memory exhaustion from oversized payloads.
 
 ## Audit logging
 
@@ -232,15 +236,17 @@ Model mappings are sorted by `priority / adaptive_factor`. Providers with factor
 
 Detects per-session tool-call spikes so a misbehaving agent cannot exhaust provider quotas or trigger billing surprises. Runs in the dispatch pipeline after DLP scanning and before routing.
 
+**Disabled by default.** Both thresholds default to `0` — autonomous agentic clients (Claude Code, multi-agent runs) legitimately burst to thousands of tool events/min, so the detector produced more false positives than abuse protection for grob's single-user/local use. Enable it for multi-tenant quota protection:
+
 ```toml
 [security]
-tool_spike_warn_per_min = 500     # log + metric above this (default: 500)
-tool_spike_block_per_min = 2000   # return HTTP 429 above this (default: 2000)
+tool_spike_warn_per_min = 500     # log + metric above this (default: 0 = off)
+tool_spike_block_per_min = 2000   # return HTTP 429 above this (default: 0 = off)
 ```
 
 > Counting includes both `tool_use` and the `tool_result` echoed back, so one
-> tool round-trip scores ~2. The defaults are sized for agentic clients (Claude
-> Code, multi-skill runs); lower them for stricter quota protection.
+> tool round-trip scores ~2. The example values above (500/2000) suit a shared
+> deployment; raise them for heavier agentic workloads.
 
 ### Behavior
 
@@ -250,13 +256,13 @@ tool_spike_block_per_min = 2000   # return HTTP 429 above this (default: 2000)
 - **Warn**: crossing `tool_spike_warn_per_min` logs a `WARN` line and increments `grob_tool_spike_warn_total`. The request proceeds.
 - **Block**: crossing `tool_spike_block_per_min` increments `grob_tool_spike_blocked_total`, writes a signed `TOOL_SPIKE_BLOCKED` audit entry, and returns HTTP 429 with body type `rate_limited`. The block is terminal — it is **not** retried against a sibling provider.
 
-### Defaults
+### Choosing thresholds
 
-`100/min/session` is roughly the upper bound for a busy build run (an agent reading ~2 files/sec). `500/min` equals >8/sec sustained, which only a runaway loop produces.
+When enabled, `500/min/session` (warn) ≈ >8 tool events/sec sustained and `2000/min` (block) ≈ >33/sec — sized so heavy-but-legitimate agentic runs warn rather than block. For a single-user local proxy, leave the detector off (the default); a runaway loop there is a client bug, not an abuse vector.
 
-### Disabling
+### Enabling / disabling
 
-Set both thresholds to `0` to disable the detector entirely; it is then never installed and adds no per-request work. Setting only `tool_spike_block_per_min = 0` keeps warnings while disabling blocking.
+The detector is **off by default** (both thresholds `0`): it is never installed and adds no per-request work. Set `tool_spike_block_per_min` (and optionally `tool_spike_warn_per_min`) to a positive value to enable it. Setting only `tool_spike_warn_per_min` keeps a paper trail without ever blocking.
 
 ### Memory
 

--- a/src/cli/config/mod.rs
+++ b/src/cli/config/mod.rs
@@ -38,7 +38,7 @@ pub use cache::CacheConfig;
 #[cfg(feature = "harness")]
 pub use harness::HarnessConfig;
 pub use pricing::{PricingConfig, TokenCountingMode};
-pub use providers::{AuthType, PoolConfig, PoolStrategy, ProviderConfig};
+pub use providers::{AuthType, CodexOptions, PoolConfig, PoolStrategy, ProviderConfig};
 pub use reliability::{parse_duration, CircuitBreakerProviderConfig, HealthCheckProviderConfig};
 pub use routing::{
     FanOutConfig, FanOutMode, ModelConfig, ModelMapping, ModelStrategy, ProjectConfig,

--- a/src/cli/config/providers.rs
+++ b/src/cli/config/providers.rs
@@ -96,11 +96,21 @@ pub struct ProviderConfig {
 
     /// Codex processing tier — `"priority"` enables faster ("1.5x") handling,
     /// `"default"` is standard. Only affects the OpenAI Responses (Codex) path.
-    /// `"priority"` is applied only to models that offer it (`gpt-5.5`,
-    /// `gpt-5.4`) and silently dropped for others (codex/mini) that would reject
-    /// it. Omit this field (or leave it unset) to disable — nothing is sent.
+    /// `"priority"` is applied only to models that offer it (see
+    /// [`CodexOptions::priority_models`]) and silently dropped for others
+    /// (codex/mini) that would reject it. Omit this field (or leave it unset) to
+    /// disable — nothing is sent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
+
+    /// Codex (OpenAI Responses API) tuning: which models support the `priority`
+    /// tier / default to `xhigh` effort, and the reasoning-effort auto-mapping.
+    ///
+    /// Optional — the defaults track the current ChatGPT Codex line-up, so most
+    /// configs omit it. Only affects the OpenAI Responses (Codex) path. See
+    /// [`CodexOptions`].
+    #[serde(default)]
+    pub codex: CodexOptions,
 
     /// Path to PEM client certificate for mTLS.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -160,6 +170,64 @@ impl ProviderConfig {
     pub fn is_enabled(&self) -> bool {
         self.enabled.unwrap_or(true)
     }
+}
+
+/// Codex (OpenAI Responses API) tuning knobs.
+///
+/// Shapes how grob maps requests onto the Responses API for the ChatGPT Codex
+/// (OAuth) backend. Every field has a default matching OpenAI's current model
+/// line-up, so the whole block is optional.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodexOptions {
+    /// Models that support the `priority` (1.5x) service tier and receive the
+    /// `xhigh` reasoning effort by default.
+    ///
+    /// Each entry is matched case-insensitively against the resolved model name:
+    /// an exact match always qualifies, and a prefix match qualifies unless the
+    /// model name contains `mini` (the fast tier never gets priority/xhigh unless
+    /// listed verbatim). Defaults to `["gpt-5.5", "gpt-5.4"]`. Add new flagship
+    /// model names here when OpenAI ships them — no grob release required.
+    #[serde(default = "default_priority_models")]
+    pub priority_models: Vec<String>,
+
+    /// When `true`, the reasoning effort is auto-mapped from the request's
+    /// extended-thinking budget (`>= reasoning_xhigh_min_budget` → `xhigh`, else
+    /// `medium`; no thinking → `low`). When `false` (default), the effort is the
+    /// flat model-based default: `xhigh` for [`Self::priority_models`], otherwise
+    /// unset (the backend picks). An explicit `reasoning_effort` always wins.
+    #[serde(default)]
+    pub reasoning_auto_map: bool,
+
+    /// Thinking budget (tokens) at/above which auto-mapping selects `xhigh`
+    /// (below it, `medium`). Only consulted when `reasoning_auto_map` is `true`.
+    /// Defaults to 16000.
+    #[serde(default = "default_reasoning_xhigh_min_budget")]
+    pub reasoning_xhigh_min_budget: u32,
+}
+
+impl Default for CodexOptions {
+    fn default() -> Self {
+        Self {
+            priority_models: default_priority_models(),
+            reasoning_auto_map: false,
+            reasoning_xhigh_min_budget: default_reasoning_xhigh_min_budget(),
+        }
+    }
+}
+
+// NOTE: The flagship models that expose the `priority` (1.5x) tier per the Codex
+// catalog. Prefix-matched, so future point releases (e.g. `gpt-5.5-...`) inherit
+// it; `-mini` variants are excluded by the matcher as the fast/standard tier.
+fn default_priority_models() -> Vec<String> {
+    vec!["gpt-5.5".to_string(), "gpt-5.4".to_string()]
+}
+
+// NOTE: 16000 tokens is the threshold above which Claude Code's explicit-budget
+// thinking turns warrant the backend's max reasoning tier. Only used in the
+// opt-in `reasoning_auto_map` mode; the default flat mapping ignores it.
+fn default_reasoning_xhigh_min_budget() -> u32 {
+    16_000
 }
 
 /// Strategy for cycling through pooled API keys.

--- a/src/cli/config/security.rs
+++ b/src/cli/config/security.rs
@@ -13,13 +13,19 @@ pub struct SecurityConfig {
     /// Master switch for security middleware
     #[serde(default = "default_true")]
     pub enabled: bool,
-    /// Rate limit: requests per second per tenant/IP
+    /// Rate limit: requests per second per tenant/IP (default 0 = disabled).
+    ///
+    /// `0` skips the rate limiter entirely (no throttling). Set a positive value
+    /// (e.g. `100`) to enable per-tenant/IP throttling for multi-tenant deployments.
     #[serde(default = "default_rate_limit_rps")]
     pub rate_limit_rps: u32,
-    /// Rate limit: burst capacity
+    /// Rate limit: burst capacity (only used when `rate_limit_rps` > 0).
     #[serde(default = "default_rate_limit_burst")]
     pub rate_limit_burst: u32,
-    /// Maximum request body size in bytes (default: 10MB)
+    /// Maximum request body size in bytes (default 0 = unlimited).
+    ///
+    /// `0` disables the limit (no `RequestBodyLimitLayer` is installed). Set a
+    /// positive byte count (e.g. `10485760` for 10 MiB) to reject larger bodies.
     #[serde(default)]
     pub max_body_size: BodySizeLimit,
     /// Apply OWASP security headers to all responses
@@ -67,18 +73,17 @@ pub struct SecurityConfig {
     /// keyed on a non-anonymous tenant id.
     #[serde(default)]
     pub strict_tenant: bool,
-    /// Tool-call spike: warn threshold per session per minute (default 500).
+    /// Tool-call spike: warn threshold per session per minute (default 0 = off).
     ///
-    /// Crossing this rolling 60s count logs a warning and emits a
-    /// metric without rejecting the request. Set to `0` to disable
-    /// warnings.
+    /// Crossing this rolling 60s count logs a warning and emits a metric without
+    /// rejecting the request. Disabled by default; set a value to enable.
     #[serde(default = "default_tool_spike_warn_per_min")]
     pub tool_spike_warn_per_min: u32,
-    /// Tool-call spike: block threshold per session per minute (default 2000).
+    /// Tool-call spike: block threshold per session per minute (default 0 = off).
     ///
-    /// Crossing this rolling 60s count returns HTTP 429, writes a
-    /// signed audit entry, and emits a metric. Set to `0` to disable
-    /// blocking. Setting both thresholds to `0` disables the detector.
+    /// Crossing this rolling 60s count returns HTTP 429, writes a signed audit
+    /// entry, and emits a metric. Disabled by default (both thresholds `0`); set
+    /// a value to enable (e.g. 2000 for multi-tenant abuse protection).
     #[serde(default = "default_tool_spike_block_per_min")]
     pub tool_spike_block_per_min: u32,
 }
@@ -118,15 +123,19 @@ fn default_flush_interval_ms() -> u64 {
     5000
 }
 
-// NOTE: 100 rps sustains ~10 concurrent Claude Code sessions (each bursting
-// ~10 req/s during tool-use loops) while protecting providers from runaway clients.
+// NOTE: Disabled by default (0 = no rate limiting). grob's primary use is
+// single-user/local, where per-tenant request throttling only risks 429-ing a
+// legitimate burst (an autonomous agent easily exceeds any fixed rps). Re-enable
+// for multi-tenant deployments by setting `rate_limit_rps` (e.g. 100) in
+// `[security]`; a value of `0` skips installing the limiter entirely.
 fn default_rate_limit_rps() -> u32 {
-    100
+    0
 }
 
-// NOTE: 2x sustained rate allows short tool-use bursts without 429s.
+// NOTE: Paired with `rate_limit_rps`; only consulted when the limiter is enabled
+// (rps > 0). A typical multi-tenant setting is ~2x rps (e.g. 200) for short bursts.
 fn default_rate_limit_burst() -> u32 {
-    200
+    0
 }
 
 // NOTE: 0.3 gives ~70% weight to recent latency, ~30% to history. Standard
@@ -147,21 +156,20 @@ fn default_scoring_decay_rate() -> f64 {
     0.001
 }
 
-// NOTE: The detector counts both `tool_use` blocks and the `tool_result`
-// blocks echoed back, so a single tool round-trip scores ~2. Agentic clients
-// (Claude Code, multi-skill orchestrations like `/cli-cycle`) legitimately burst
-// to several hundred tool events/min, so the warn level is the early signal for
-// that band — a paper trail without rejecting the request.
+// NOTE: Disabled by default (0/0). Autonomous agentic clients (Claude Code,
+// multi-agent runs) legitimately burst to thousands of tool events/min, so the
+// detector produced more false positives than abuse protection for grob's
+// primary single-user/local use. It stays fully parametrable — set
+// `tool_spike_warn_per_min` / `tool_spike_block_per_min` in `[security]` to
+// re-enable (e.g. 500 / 2000 for multi-tenant deployments). The detector counts
+// both `tool_use` and the echoed `tool_result`, so one round-trip scores ~2.
 fn default_tool_spike_warn_per_min() -> u32 {
-    500
+    0
 }
 
-// NOTE: 2000 tool events/min/session (~33/sec counting both directions, i.e.
-// ~16 round-trips/sec) is firmly anomalous — only a runaway loop sustains it,
-// while heavy-but-legitimate agentic runs stay below it. Blocks and audit-logs.
-// (The previous 500 throttled real multi-skill workloads with HTTP 429.)
+// See `default_tool_spike_warn_per_min` — disabled by default, opt-in via config.
 fn default_tool_spike_block_per_min() -> u32 {
-    2000
+    0
 }
 
 /// EU AI Act compliance configuration

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,7 +11,7 @@ pub use config::parse_duration;
 #[cfg(feature = "harness")]
 pub use config::HarnessConfig;
 pub use config::{
-    AcmeConfig, AuthType, BudgetConfig, CacheConfig, CircuitBreakerProviderConfig,
+    AcmeConfig, AuthType, BudgetConfig, CacheConfig, CircuitBreakerProviderConfig, CodexOptions,
     ComplianceConfig, EnforcementMode, FanOutConfig, FanOutMode, FipsConfig,
     HealthCheckProviderConfig, ModelConfig, ModelMapping, ModelStrategy, OtelConfig, PoolConfig,
     PoolStrategy, PresetConfig, PricingConfig, ProjectConfig, ProjectRouterOverlay, PromptRule,

--- a/src/cli/newtypes.rs
+++ b/src/cli/newtypes.rs
@@ -121,34 +121,29 @@ impl<'de> Deserialize<'de> for Port {
     }
 }
 
-/// Request body size limit in bytes. Rejects 0 at parse time, defaults to 10 MiB.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+/// Request body size limit in bytes. `0` means unlimited; defaults to unlimited.
+///
+/// The default is `0` (no limit): grob's primary use is single-user/local, where
+/// an agentic client legitimately sends large contexts, so a cap only risks
+/// rejecting a valid request. Set `max_body_size` to re-enable a bound.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Default)]
 #[serde(transparent)]
 pub struct BodySizeLimit(usize);
 
 impl BodySizeLimit {
-    /// Creates a new `BodySizeLimit`, returning an error if 0.
+    /// Creates a new `BodySizeLimit`. A value of `0` means "no limit".
     ///
     /// # Errors
     ///
-    /// Returns a `String` if `value` is zero.
+    /// Never returns an error; the `Result` is retained for call-site
+    /// compatibility (and to leave room for future bounds validation).
     pub fn new(value: usize) -> Result<Self, String> {
-        if value == 0 {
-            Err("max_body_size must be non-zero".to_string())
-        } else {
-            Ok(Self(value))
-        }
+        Ok(Self(value))
     }
 
-    /// Returns the inner byte count.
+    /// Returns the inner byte count (`0` = unlimited).
     pub fn value(self) -> usize {
         self.0
-    }
-}
-
-impl Default for BodySizeLimit {
-    fn default() -> Self {
-        Self(10 * 1024 * 1024) // 10 MiB
     }
 }
 

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -3,7 +3,9 @@
 //! Eliminates field and method duplication across OpenAI, Gemini,
 //! and Anthropic-compatible providers.
 
-use super::{build_provider_client, error::ProviderError, key_pool::KeyPool, ProviderParams};
+use super::{
+    build_provider_client, error::ProviderError, key_pool::KeyPool, CodexOptions, ProviderParams,
+};
 use crate::auth::{OAuthConfig, TokenStore};
 use reqwest::Client;
 use secrecy::{ExposeSecret, SecretString};
@@ -26,6 +28,7 @@ pub(crate) struct ProviderBase {
     pub key_pool: Option<Arc<KeyPool>>,
     pub reasoning_effort: Option<String>,
     pub service_tier: Option<String>,
+    pub codex: CodexOptions,
 }
 
 impl ProviderBase {
@@ -47,6 +50,7 @@ impl ProviderBase {
             key_pool: params.key_pool,
             reasoning_effort: params.reasoning_effort,
             service_tier: params.service_tier,
+            codex: params.codex,
         }
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -226,12 +226,14 @@ pub struct ProviderParams {
     pub reasoning_effort: Option<String>,
     /// Forced Codex processing tier (e.g. `"priority"` for faster handling).
     pub service_tier: Option<String>,
+    /// Codex (Responses API) tuning: priority-model list and reasoning auto-map.
+    pub codex: CodexOptions,
 }
 
 // Re-export config types that were moved to cli::config to break the
 // cli <-> providers dependency cycle. Downstream code using
 // `crate::providers::{AuthType, ProviderConfig}` keeps compiling.
-pub use crate::cli::{AuthType, ProviderConfig};
+pub use crate::cli::{AuthType, CodexOptions, ProviderConfig};
 
 pub use anthropic_compatible::AnthropicCompatibleProvider;
 pub use openai::OpenAIProvider;

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -64,7 +64,9 @@ pub mod test_api {
         request: &CanonicalRequest,
         instructions: &str,
     ) -> Result<serde_json::Value, String> {
-        let resp_req = transform::transform_to_responses_request(request, instructions, None, None)
+        let codex = crate::providers::CodexOptions::default();
+        let tuning = transform::CodexTuning::from_options(&codex, None, None);
+        let resp_req = transform::transform_to_responses_request(request, instructions, &tuning)
             .map_err(|e| e.to_string())?;
         serde_json::to_value(&resp_req).map_err(|e| e.to_string())
     }
@@ -199,12 +201,13 @@ impl OpenAIProvider {
         auth_value: &str,
         base_url: &str,
     ) -> Result<ProviderResponse, ProviderError> {
-        let responses_request = transform::transform_to_responses_request(
-            request,
-            CODEX_INSTRUCTIONS,
+        let tuning = transform::CodexTuning::from_options(
+            &self.base.codex,
             self.base.reasoning_effort.as_deref(),
             self.base.service_tier.as_deref(),
-        )?;
+        );
+        let responses_request =
+            transform::transform_to_responses_request(request, CODEX_INSTRUCTIONS, &tuning)?;
 
         let endpoint = if self.base.is_oauth() {
             "/codex/responses"
@@ -387,12 +390,13 @@ impl LlmProvider for OpenAIProvider {
                 endpoint,
                 request.model
             );
-            let responses_request = transform::transform_to_responses_request(
-                &request,
-                CODEX_INSTRUCTIONS,
+            let tuning = transform::CodexTuning::from_options(
+                &self.base.codex,
                 self.base.reasoning_effort.as_deref(),
                 self.base.service_tier.as_deref(),
-            )?;
+            );
+            let responses_request =
+                transform::transform_to_responses_request(&request, CODEX_INSTRUCTIONS, &tuning)?;
             let body = serde_json::to_value(&responses_request)
                 .map_err(ProviderError::SerializationError)?;
             (format!("{}{}", base_url, endpoint), body)

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -1,7 +1,7 @@
 use super::types::*;
 use crate::models::{CanonicalRequest, MessageContent};
 use crate::providers::error::ProviderError;
-use crate::providers::{ContentBlock, KnownContentBlock, ProviderResponse, Usage};
+use crate::providers::{CodexOptions, ContentBlock, KnownContentBlock, ProviderResponse, Usage};
 use serde::Serialize;
 use thiserror::Error;
 
@@ -578,12 +578,47 @@ provided tools through the function-calling interface to take actions — do not
 inside a code block. When you need to run a command, read, or edit, call the matching provided tool \
 with its required arguments.";
 
+/// Per-call knobs for the Codex (OpenAI Responses API) transform.
+///
+/// Bundles the operator-forced overrides with the provider's [`CodexOptions`]
+/// so the resolver functions stay parameterised instead of reaching for global
+/// state. Build it with [`CodexTuning::from_options`].
+#[derive(Clone, Copy)]
+pub(crate) struct CodexTuning<'a> {
+    /// Operator-forced reasoning effort (highest precedence). `None` = auto.
+    pub forced_effort: Option<&'a str>,
+    /// Operator-forced service tier (e.g. `"priority"`). `None` = request/none.
+    pub forced_service_tier: Option<&'a str>,
+    /// Models eligible for the `priority` tier and default `xhigh` effort.
+    pub priority_models: &'a [String],
+    /// When `true`, map the extended-thinking budget → effort (opt-in).
+    pub reasoning_auto_map: bool,
+    /// Thinking budget at/above which auto-map selects `xhigh` (else `medium`).
+    pub reasoning_xhigh_min_budget: u32,
+}
+
+impl<'a> CodexTuning<'a> {
+    /// Borrows a provider's [`CodexOptions`] alongside any forced overrides.
+    pub(crate) fn from_options(
+        opts: &'a CodexOptions,
+        forced_effort: Option<&'a str>,
+        forced_service_tier: Option<&'a str>,
+    ) -> Self {
+        Self {
+            forced_effort,
+            forced_service_tier,
+            priority_models: &opts.priority_models,
+            reasoning_auto_map: opts.reasoning_auto_map,
+            reasoning_xhigh_min_budget: opts.reasoning_xhigh_min_budget,
+        }
+    }
+}
+
 /// Transform Anthropic request to OpenAI Responses API format.
 pub(crate) fn transform_to_responses_request(
     request: &CanonicalRequest,
     codex_instructions: &str,
-    forced_effort: Option<&str>,
-    forced_service_tier: Option<&str>,
+    tuning: &CodexTuning<'_>,
 ) -> Result<OpenAIResponsesRequest, ProviderError> {
     let tools = transform_responses_tools(request);
 
@@ -635,9 +670,9 @@ pub(crate) fn transform_to_responses_request(
         tool_choice: tools.as_ref().and(transform_responses_tool_choice(request)),
         parallel_tool_calls: tools.as_ref().map(|_| true),
         tools,
-        reasoning: resolve_reasoning_effort(request, forced_effort)
+        reasoning: resolve_reasoning_effort(request, tuning)
             .map(|effort| serde_json::json!({ "effort": effort })),
-        service_tier: resolve_service_tier(request, forced_service_tier),
+        service_tier: resolve_service_tier(request, tuning),
     })
 }
 
@@ -646,16 +681,18 @@ pub(crate) fn transform_to_responses_request(
 /// A provider-config value wins, then a `service_tier` request extension. The
 /// value passes through verbatim — the backend validates it — so `"priority"`
 /// (faster handling) works without a whitelist. `None` leaves the field unset.
-fn resolve_service_tier(request: &CanonicalRequest, forced: Option<&str>) -> Option<String> {
-    let tier = forced
+fn resolve_service_tier(request: &CanonicalRequest, tuning: &CodexTuning<'_>) -> Option<String> {
+    let tier = tuning
+        .forced_service_tier
         .map(str::to_string)
         .or_else(|| request.extensions.service_tier.clone())
         .filter(|s| !s.is_empty())?;
-    // The "priority" (1.5x) tier exists only on some models (gpt-5.5, gpt-5.4);
-    // others reject it with a 400. Drop it for unsupported models so a provider
-    // forcing `service_tier = "priority"` does not break `think`/`background`
-    // routes (which resolve to codex/mini models). Other tiers pass through.
-    if tier == "priority" && !priority_tier_supported(&request.model) {
+    // The "priority" (1.5x) tier exists only on some models (by default gpt-5.5
+    // and gpt-5.4 — see `CodexOptions::priority_models`); others reject it with a
+    // 400. Drop it for unsupported models so a provider forcing
+    // `service_tier = "priority"` does not break `think`/`background` routes
+    // (which resolve to codex/mini models). Other tiers pass through.
+    if tier == "priority" && !priority_tier_supported(&request.model, tuning.priority_models) {
         return None;
     }
     Some(tier)
@@ -663,47 +700,70 @@ fn resolve_service_tier(request: &CanonicalRequest, forced: Option<&str>) -> Opt
 
 /// Returns whether the model offers the Codex `priority` (1.5x) service tier.
 ///
-/// Per the Codex model catalog only `gpt-5.5` and `gpt-5.4` (not `-mini`) expose
-/// it; everything else (`gpt-5.4-mini`, `gpt-5.3-codex`, …) is standard-only.
-fn priority_tier_supported(model: &str) -> bool {
+/// The eligible set is configurable via [`CodexOptions::priority_models`]
+/// (default `["gpt-5.5", "gpt-5.4"]`). An entry matches the model by exact name
+/// or as a prefix; a prefix match excludes `-mini` fast-tier variants unless the
+/// model is listed verbatim. The same set also gates the default `xhigh` effort.
+fn priority_tier_supported(model: &str, priority_models: &[String]) -> bool {
     let m = model.to_ascii_lowercase();
-    m.starts_with("gpt-5.5") || (m.starts_with("gpt-5.4") && !m.contains("mini"))
+    priority_models.iter().any(|entry| {
+        let p = entry.to_ascii_lowercase();
+        m == p || (m.starts_with(&p) && !m.contains("mini"))
+    })
 }
 
 /// Resolves the Codex reasoning effort for a request.
 ///
-/// Precedence: a provider-config `forced_effort` wins, then an explicit
-/// `reasoning_effort` request extension (e.g. from a Codex CLI client),
-/// otherwise the effort is auto-mapped from the request's extended-thinking
-/// setting so simple turns stay fast while deliberate thinking turns get more
-/// reasoning.
-///
-/// An operator- or client-supplied effort passes through verbatim — the backend
-/// validates it — so newer tiers (e.g. `xhigh`) work without a grob release; an
-/// invalid value surfaces a backend error rather than being silently dropped.
-/// Only the auto-mapped value is constrained, since it must be a known-safe tier.
-fn resolve_reasoning_effort(request: &CanonicalRequest, forced: Option<&str>) -> Option<String> {
-    let supplied = forced
+/// Precedence:
+/// 1. A provider-config `forced_effort` or an explicit `reasoning_effort`
+///    request extension (e.g. from a Codex CLI client) — passed through verbatim
+///    so newer tiers (e.g. `xhigh`) work without a grob release.
+/// 2. If `reasoning_auto_map` is enabled, the effort auto-maps from the
+///    request's extended-thinking budget (legacy behavior).
+/// 3. Otherwise the flat default: `xhigh` for the priority/flagship models
+///    (see [`priority_tier_supported`]), and `None` for the rest so the backend
+///    applies its own default effort.
+fn resolve_reasoning_effort(
+    request: &CanonicalRequest,
+    tuning: &CodexTuning<'_>,
+) -> Option<String> {
+    let supplied = tuning
+        .forced_effort
         .map(str::to_string)
         .or_else(|| request.extensions.reasoning_effort.clone())
         .filter(|s| !s.is_empty());
-    Some(supplied.unwrap_or_else(|| auto_map_thinking_effort(request)))
+    if let Some(effort) = supplied {
+        return Some(effort);
+    }
+    if tuning.reasoning_auto_map {
+        return Some(auto_map_thinking_effort(
+            request,
+            tuning.reasoning_xhigh_min_budget,
+        ));
+    }
+    // Flat default: max out the flagship models, leave the rest to the backend.
+    if priority_tier_supported(&request.model, tuning.priority_models) {
+        Some("xhigh".to_string())
+    } else {
+        None
+    }
 }
 
 /// Maps Anthropic extended-thinking config to a Codex reasoning-effort tier.
 ///
-/// No thinking (or an explicitly `disabled` block) maps to `low` for snappy
-/// responses. Any other thinking block means the client opted into extended
-/// reasoning, so it maps high: Claude Code's adaptive mode (`type: "adaptive"`,
-/// no budget — the same for every `think`/`think hard`/`ultrathink` keyword, so
-/// they cannot be told apart) maps to `xhigh`, the backend's max tier; a small
-/// explicit budget maps to `medium`. Effort tiers: `low` < `medium` < `high` <
-/// `xhigh` (`max` is rejected by the backend).
+/// Only used in the opt-in `reasoning_auto_map` mode. No thinking (or an
+/// explicitly `disabled` block) maps to `low` for snappy responses. Any other
+/// thinking block means the client opted into extended reasoning, so it maps
+/// high: Claude Code's adaptive mode (`type: "adaptive"`, no budget — the same
+/// for every `think`/`think hard`/`ultrathink` keyword, so they cannot be told
+/// apart) maps to `xhigh`, the backend's max tier; an explicit budget maps to
+/// `xhigh` at/above `xhigh_min_budget`, else `medium`. Effort tiers:
+/// `low` < `medium` < `high` < `xhigh` (`max` is rejected by the backend).
 ///
 /// Note: Claude Code's `/effort` slider is client-internal and never reaches the
 /// API, so it cannot be mapped here — only the thinking keywords, which set a
 /// thinking block, do.
-fn auto_map_thinking_effort(request: &CanonicalRequest) -> String {
+fn auto_map_thinking_effort(request: &CanonicalRequest, xhigh_min_budget: u32) -> String {
     let Some(thinking) = request.thinking.as_ref() else {
         return "low".to_string();
     };
@@ -711,7 +771,7 @@ fn auto_map_thinking_effort(request: &CanonicalRequest) -> String {
         return "low".to_string();
     }
     match thinking.budget_tokens {
-        Some(budget) if budget >= 16_000 => "xhigh",
+        Some(budget) if budget >= xhigh_min_budget => "xhigh",
         Some(_) => "medium",
         // Adaptive thinking (no budget) is opt-in deep reasoning — give it the max.
         None => "xhigh",
@@ -889,8 +949,13 @@ mod tests {
             },
         ];
 
-        let req =
-            transform_to_responses_request(&request, "FULL CODEX PROMPT", None, None).unwrap();
+        let opts = CodexOptions::default();
+        let req = transform_to_responses_request(
+            &request,
+            "FULL CODEX PROMPT",
+            &CodexTuning::from_options(&opts, None, None),
+        )
+        .unwrap();
         let json = serde_json::to_value(&req).unwrap();
 
         // Tools are forwarded in the flattened Responses shape.
@@ -929,7 +994,13 @@ mod tests {
             content: MessageContent::Text("be terse".to_string()),
         }];
 
-        let req = transform_to_responses_request(&request, "FULL", None, None).unwrap();
+        let opts = CodexOptions::default();
+        let req = transform_to_responses_request(
+            &request,
+            "FULL",
+            &CodexTuning::from_options(&opts, None, None),
+        )
+        .unwrap();
         let json = serde_json::to_value(&req).unwrap();
         let input = json["input"].as_array().unwrap();
 
@@ -942,72 +1013,122 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_effort_auto_maps_and_respects_overrides() {
-        use crate::models::ThinkingConfig;
-
-        let effort = |req: &CanonicalRequest, forced: Option<&str>| {
-            serde_json::to_value(transform_to_responses_request(req, "X", forced, None).unwrap())
+    fn reasoning_effort_default_is_xhigh_for_priority_models() {
+        // Default mode (auto_map off): flagship/priority models get xhigh, other
+        // models are left unset so the backend applies its own default. A forced
+        // or extension effort always wins.
+        let opts = CodexOptions::default();
+        let effort = |model: &str, forced: Option<&str>, ext: Option<&str>| {
+            let mut req = base_request();
+            req.system = None;
+            req.model = model.to_string();
+            req.extensions.reasoning_effort = ext.map(str::to_string);
+            let tuning = CodexTuning::from_options(&opts, forced, None);
+            serde_json::to_value(transform_to_responses_request(&req, "X", &tuning).unwrap())
                 .unwrap()["reasoning"]["effort"]
                 .clone()
         };
 
-        let mut req = base_request();
-        req.system = None;
-
-        // No thinking → low (snappy).
-        assert_eq!(effort(&req, None), serde_json::json!("low"));
-
-        // Thinking enabled with a large explicit budget → xhigh, the max tier.
-        req.thinking = Some(ThinkingConfig {
-            r#type: "enabled".to_string(),
-            budget_tokens: Some(20_000),
-        });
-        assert_eq!(effort(&req, None), serde_json::json!("xhigh"));
-
-        // Smaller budget → medium.
-        req.thinking = Some(ThinkingConfig {
-            r#type: "enabled".to_string(),
-            budget_tokens: Some(4_000),
-        });
-        assert_eq!(effort(&req, None), serde_json::json!("medium"));
-
-        // Claude Code's adaptive thinking (no budget — every think/ultrathink
-        // keyword looks identical) → xhigh, since thinking is opt-in.
-        req.thinking = Some(ThinkingConfig {
-            r#type: "adaptive".to_string(),
-            budget_tokens: None,
-        });
-        assert_eq!(effort(&req, None), serde_json::json!("xhigh"));
-
-        // An explicitly disabled thinking block → low.
-        req.thinking = Some(ThinkingConfig {
-            r#type: "disabled".to_string(),
-            budget_tokens: None,
-        });
-        assert_eq!(effort(&req, None), serde_json::json!("low"));
-
-        // Provider-forced effort overrides the auto-mapping.
-        req.thinking = None;
-        assert_eq!(effort(&req, Some("minimal")), serde_json::json!("minimal"));
-
+        // Priority/flagship model → xhigh by default (thinking ignored here).
+        assert_eq!(effort("gpt-5.5", None, None), serde_json::json!("xhigh"));
+        // Non-priority model → unset (the backend picks its own effort).
+        assert_eq!(effort("gpt-5.3-codex", None, None), serde_json::Value::Null);
+        // A forced effort wins on any model.
+        assert_eq!(
+            effort("gpt-5.5", Some("low"), None),
+            serde_json::json!("low")
+        );
+        assert_eq!(
+            effort("gpt-5.3-codex", Some("high"), None),
+            serde_json::json!("high")
+        );
         // A request extension forces effort when no provider override is set.
-        req.thinking = None;
-        req.extensions.reasoning_effort = Some("high".to_string());
-        assert_eq!(effort(&req, None), serde_json::json!("high"));
+        assert_eq!(
+            effort("gpt-4o", None, Some("medium")),
+            serde_json::json!("medium")
+        );
+        // An empty forced effort falls back to the default (xhigh for priority).
+        assert_eq!(
+            effort("gpt-5.5", Some(""), None),
+            serde_json::json!("xhigh")
+        );
+    }
 
-        // A supplied effort passes through verbatim (the backend validates it),
-        // so newer tiers like "xhigh" reach Codex without a grob release.
-        assert_eq!(effort(&req, Some("xhigh")), serde_json::json!("xhigh"));
+    #[test]
+    fn reasoning_auto_map_maps_thinking_budget_when_enabled() {
+        use crate::models::ThinkingConfig;
 
-        // An empty forced effort falls back to the auto-map rather than being sent.
-        req.extensions.reasoning_effort = None;
-        assert_eq!(effort(&req, Some("")), serde_json::json!("low"));
+        // Opt-in mode: effort follows the extended-thinking budget (legacy).
+        let opts = CodexOptions {
+            reasoning_auto_map: true,
+            ..CodexOptions::default()
+        };
+        let effort = |thinking: Option<ThinkingConfig>, forced: Option<&str>| {
+            let mut req = base_request();
+            req.system = None;
+            req.thinking = thinking;
+            let tuning = CodexTuning::from_options(&opts, forced, None);
+            serde_json::to_value(transform_to_responses_request(&req, "X", &tuning).unwrap())
+                .unwrap()["reasoning"]["effort"]
+                .clone()
+        };
+        let enabled = |b: u32| {
+            Some(ThinkingConfig {
+                r#type: "enabled".to_string(),
+                budget_tokens: Some(b),
+            })
+        };
+        let typed = |t: &str| {
+            Some(ThinkingConfig {
+                r#type: t.to_string(),
+                budget_tokens: None,
+            })
+        };
+
+        // No thinking → low; large budget → xhigh; smaller → medium.
+        assert_eq!(effort(None, None), serde_json::json!("low"));
+        assert_eq!(effort(enabled(20_000), None), serde_json::json!("xhigh"));
+        assert_eq!(effort(enabled(4_000), None), serde_json::json!("medium"));
+        // Adaptive (no budget) → xhigh; explicitly disabled → low.
+        assert_eq!(effort(typed("adaptive"), None), serde_json::json!("xhigh"));
+        assert_eq!(effort(typed("disabled"), None), serde_json::json!("low"));
+        // A forced effort still wins over the auto-map.
+        assert_eq!(effort(None, Some("minimal")), serde_json::json!("minimal"));
+    }
+
+    #[test]
+    fn reasoning_xhigh_min_budget_is_configurable() {
+        use crate::models::ThinkingConfig;
+
+        // The auto-map xhigh threshold is parametrable, not hard-coded at 16000.
+        let opts = CodexOptions {
+            reasoning_auto_map: true,
+            reasoning_xhigh_min_budget: 5_000,
+            ..CodexOptions::default()
+        };
+        let effort = |budget: u32| {
+            let mut req = base_request();
+            req.system = None;
+            req.thinking = Some(ThinkingConfig {
+                r#type: "enabled".to_string(),
+                budget_tokens: Some(budget),
+            });
+            let tuning = CodexTuning::from_options(&opts, None, None);
+            serde_json::to_value(transform_to_responses_request(&req, "X", &tuning).unwrap())
+                .unwrap()["reasoning"]["effort"]
+                .clone()
+        };
+
+        assert_eq!(effort(4_999), serde_json::json!("medium"));
+        assert_eq!(effort(5_000), serde_json::json!("xhigh"));
     }
 
     #[test]
     fn service_tier_is_forwarded_from_config_and_extension() {
+        let opts = CodexOptions::default();
         let tier = |req: &CanonicalRequest, forced: Option<&str>| {
-            serde_json::to_value(transform_to_responses_request(req, "X", None, forced).unwrap())
+            let tuning = CodexTuning::from_options(&opts, None, forced);
+            serde_json::to_value(transform_to_responses_request(req, "X", &tuning).unwrap())
                 .unwrap()["service_tier"]
                 .clone()
         };
@@ -1041,11 +1162,44 @@ mod tests {
     }
 
     #[test]
+    fn priority_models_list_is_configurable() {
+        // Adding a model to `priority_models` enables the priority tier (and the
+        // xhigh default) for it; removing the built-ins disables them — all
+        // without a grob release.
+        let opts = CodexOptions {
+            priority_models: vec!["gpt-5.3-codex".to_string()],
+            ..CodexOptions::default()
+        };
+        let resolve = |model: &str| {
+            let mut req = base_request();
+            req.system = None;
+            req.model = model.to_string();
+            let tuning = CodexTuning::from_options(&opts, None, Some("priority"));
+            serde_json::to_value(transform_to_responses_request(&req, "X", &tuning).unwrap())
+                .unwrap()
+        };
+
+        // The newly-listed model now gets priority and the default xhigh effort.
+        let codex = resolve("gpt-5.3-codex");
+        assert_eq!(codex["service_tier"], serde_json::json!("priority"));
+        assert_eq!(codex["reasoning"]["effort"], serde_json::json!("xhigh"));
+
+        // A model dropped from the list loses priority (silent no-op).
+        let flagship = resolve("gpt-5.5");
+        assert_eq!(flagship["service_tier"], serde_json::Value::Null);
+    }
+
+    #[test]
     fn responses_request_without_tools_keeps_full_instructions() {
         let mut request = base_request();
         request.system = None;
-        let req =
-            transform_to_responses_request(&request, "FULL CODEX PROMPT", None, None).unwrap();
+        let opts = CodexOptions::default();
+        let req = transform_to_responses_request(
+            &request,
+            "FULL CODEX PROMPT",
+            &CodexTuning::from_options(&opts, None, None),
+        )
+        .unwrap();
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["instructions"], "FULL CODEX PROMPT");
         assert!(json.get("tools").is_none() || json["tools"].is_null());

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -174,6 +174,7 @@ impl ProviderRegistry {
             key_pool,
             reasoning_effort: config.reasoning_effort.clone(),
             service_tier: config.service_tier.clone(),
+            codex: config.codex.clone(),
         }
     }
 
@@ -623,6 +624,7 @@ mod tests {
                 pool: None,
                 reasoning_effort: None,
                 service_tier: None,
+                codex: crate::cli::CodexOptions::default(),
                 circuit_breaker: None,
 
                 health_check: None,
@@ -649,6 +651,7 @@ mod tests {
                 pool: None,
                 reasoning_effort: None,
                 service_tier: None,
+                codex: crate::cli::CodexOptions::default(),
                 circuit_breaker: None,
 
                 health_check: None,
@@ -764,6 +767,7 @@ mod tests {
             pool: None,
             reasoning_effort: None,
             service_tier: None,
+            codex: crate::cli::CodexOptions::default(),
             circuit_breaker: None,
             health_check: None,
             max_retries: None,

--- a/src/security/tool_spike.rs
+++ b/src/security/tool_spike.rs
@@ -42,21 +42,16 @@ pub enum SpikeAction {
 }
 
 /// Warn and block thresholds for the tool-spike detector.
-#[derive(Debug, Clone, Copy)]
+///
+/// Both default to `0`, which disables the detector — autonomous agentic clients
+/// legitimately burst past any fixed threshold, so it is opt-in via `[security]`.
+/// Setting a non-zero `warn_per_min`/`block_per_min` re-enables it.
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ToolSpikeConfig {
-    /// Per-key rolling-window count above which a warning fires (no block).
+    /// Per-key rolling-window count above which a warning fires (`0` = off).
     pub warn_per_min: u32,
-    /// Per-key rolling-window count above which the request is blocked.
+    /// Per-key rolling-window count above which the request is blocked (`0` = off).
     pub block_per_min: u32,
-}
-
-impl Default for ToolSpikeConfig {
-    fn default() -> Self {
-        Self {
-            warn_per_min: 500,
-            block_per_min: 2000,
-        }
-    }
 }
 
 impl ToolSpikeConfig {

--- a/src/server/budget.rs
+++ b/src/server/budget.rs
@@ -586,6 +586,7 @@ mod tests {
             pool: None,
             reasoning_effort: None,
             service_tier: None,
+            codex: crate::cli::CodexOptions::default(),
             circuit_breaker: None,
             health_check: None,
             max_retries,

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -262,20 +262,37 @@ pub(crate) async fn init_auth(
 /// Initializes rate limiter, circuit breakers, audit log, and cache.
 pub(crate) fn init_security(config: &AppConfig) -> anyhow::Result<SecurityServices> {
     let security_enabled = config.security.enabled;
-    let rate_limiter = if security_enabled {
+    // 0 = unlimited; render it as such instead of "0MB".
+    let body_limit_desc = if config.security.max_body_size.value() == 0 {
+        "unlimited".to_string()
+    } else {
+        format!(
+            "{}MB",
+            config.security.max_body_size.value() / (1024 * 1024)
+        )
+    };
+    // A rate_limit_rps of 0 disables throttling — don't install the limiter
+    // (rps=0 would otherwise starve the token bucket and reject every request).
+    let rate_limiter = if security_enabled && config.security.rate_limit_rps > 0 {
         let rl_config = RateLimitConfig {
             requests_per_second: config.security.rate_limit_rps,
             burst: config.security.rate_limit_burst,
         };
         info!(
-            "🛡️  Security: rate limit {}rps burst={}, body limit {}MB, headers={}, circuit_breaker={}",
+            "🛡️  Security: rate limit {}rps burst={}, body limit {}, headers={}, circuit_breaker={}",
             config.security.rate_limit_rps,
             config.security.rate_limit_burst,
-            config.security.max_body_size.value() / (1024 * 1024),
+            body_limit_desc,
             config.security.security_headers,
             config.security.circuit_breaker,
         );
         Some(Arc::new(RateLimiter::new(rl_config)))
+    } else if security_enabled {
+        info!(
+            "🛡️  Security: rate limit disabled, body limit {}, headers={}, circuit_breaker={}",
+            body_limit_desc, config.security.security_headers, config.security.circuit_breaker,
+        );
+        None
     } else {
         info!("🛡️  Security middleware disabled");
         None

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -424,9 +424,15 @@ fn build_app_router(config: &AppConfig, state: Arc<AppState>) -> axum::Router {
         app
     };
 
-    let app = app.layer(RequestBodyLimitLayer::new(
-        config.security.max_body_size.value(),
-    ));
+    // A body-size limit of 0 means "unlimited" — skip the layer entirely so
+    // large agentic contexts are not rejected (see `BodySizeLimit`).
+    let app = if config.security.max_body_size.value() > 0 {
+        app.layer(RequestBodyLimitLayer::new(
+            config.security.max_body_size.value(),
+        ))
+    } else {
+        app
+    };
 
     // Audit middleware: captures every request lifecycle, including those
     // rejected by rate-limit / auth before reaching a handler. Layered

--- a/src/storage/secrets.rs
+++ b/src/storage/secrets.rs
@@ -311,6 +311,7 @@ mod tests {
             pool: None,
             reasoning_effort: None,
             service_tier: None,
+            codex: crate::cli::CodexOptions::default(),
             circuit_breaker: None,
             health_check: None,
             max_retries: None,

--- a/tests/helpers/fixtures.rs
+++ b/tests/helpers/fixtures.rs
@@ -125,6 +125,7 @@ pub fn base_provider_config(name: &str) -> grob::providers::ProviderConfig {
         pool: None,
         reasoning_effort: None,
         service_tier: None,
+        codex: grob::providers::CodexOptions::default(),
         circuit_breaker: None,
 
         health_check: None,

--- a/tests/integration/e2e_test.rs
+++ b/tests/integration/e2e_test.rs
@@ -7,9 +7,11 @@ use grob::cli::{AppConfig, SecurityConfig};
 fn test_security_config_defaults() {
     let config = SecurityConfig::default();
     assert!(config.enabled);
-    assert_eq!(config.rate_limit_rps, 100);
-    assert_eq!(config.rate_limit_burst, 200);
-    assert_eq!(config.max_body_size.value(), 10 * 1024 * 1024);
+    // Rate limiting and the body-size cap are disabled by default (agentic-friendly);
+    // re-enable per-deployment via `[security]`. See `default_rate_limit_rps`.
+    assert_eq!(config.rate_limit_rps, 0);
+    assert_eq!(config.rate_limit_burst, 0);
+    assert_eq!(config.max_body_size.value(), 0);
     assert!(config.security_headers);
     assert!(config.circuit_breaker);
     assert!(config.audit_dir.is_empty());
@@ -52,8 +54,8 @@ fn test_security_config_disabled() {
 
     let config: AppConfig = toml::from_str(toml_str).unwrap();
     assert!(!config.security.enabled);
-    // Defaults should still be present
-    assert_eq!(config.security.rate_limit_rps, 100);
+    // Defaults should still be present (rate limiting now defaults to disabled).
+    assert_eq!(config.security.rate_limit_rps, 0);
 }
 
 #[test]

--- a/tests/integration/e2e_test.rs
+++ b/tests/integration/e2e_test.rs
@@ -101,8 +101,9 @@ fn test_config_without_security_section_uses_defaults() {
     "#;
 
     let config: AppConfig = toml::from_str(toml_str).unwrap();
-    // Should use defaults when [security] section is omitted
+    // Should use defaults when [security] section is omitted. Rate limiting is
+    // disabled by default (agentic-friendly); re-enable via [security].
     assert!(config.security.enabled);
-    assert_eq!(config.security.rate_limit_rps, 100);
-    assert_eq!(config.security.rate_limit_burst, 200);
+    assert_eq!(config.security.rate_limit_rps, 0);
+    assert_eq!(config.security.rate_limit_burst, 0);
 }

--- a/tests/integration/http_test.rs
+++ b/tests/integration/http_test.rs
@@ -235,11 +235,14 @@ api_key = "my-secret-key"
 
     #[test]
     fn test_metrics_body_limit_config() {
-        // Default max body size should be reasonable
+        // The body-size limit is disabled by default (0 = unlimited): grob's
+        // primary use is single-user/local, where large agentic contexts are
+        // legitimate. Set `max_body_size` to re-enable a bound.
         let config = SecurityConfig::default();
-        assert!(
-            config.max_body_size.value() > 0,
-            "max_body_size should be > 0"
+        assert_eq!(
+            config.max_body_size.value(),
+            0,
+            "max_body_size defaults to 0 (unlimited)"
         );
     }
 

--- a/tests/unit/provider_test.rs
+++ b/tests/unit/provider_test.rs
@@ -31,6 +31,7 @@ mod tests {
             pool: None,
             reasoning_effort: None,
             service_tier: None,
+            codex: grob::providers::CodexOptions::default(),
             circuit_breaker: None,
 
             health_check: None,
@@ -64,6 +65,7 @@ mod tests {
             pool: None,
             reasoning_effort: None,
             service_tier: None,
+            codex: grob::providers::CodexOptions::default(),
             circuit_breaker: None,
 
             health_check: None,


### PR DESCRIPTION
## Why

Several limits were hard-coded in a way that surprised autonomous/agentic use of grob (the primary single-user/local case): the tool-spike detector blocked a heavy `/cli-cycle` run, and the priority-model list + reasoning-effort thresholds couldn't be tuned without a release. This makes the defaults agentic-friendly and the knobs configurable.

## Changes

### `feat(security)`: abuse-protection caps off by default (all parametrable)
- **`rate_limit_rps`/`burst`** → default `0`: the limiter is no longer installed (a `0` rps previously *starved* the token bucket and blocked every request — now it cleanly disables).
- **`max_body_size`** → default `0` = unlimited: no `RequestBodyLimitLayer`, so large agentic contexts aren't rejected.
- **`tool_spike_warn/block_per_min`** → default `0`: detector not installed.
- Set a positive value on any of them in `[security]` to re-enable (multi-tenant). Docs updated in `docs/reference/security.md`.

### `feat(openai)`: per-provider `codex` block (Codex / Responses API)
Replaces the hard-coded priority list + effort thresholds with `CodexOptions`:
- **`priority_models`** (default `["gpt-5.5", "gpt-5.4"]`): models that get the `priority` (1.5x) tier **and** `xhigh` effort by default. Prefix-matched, `-mini` excluded; add new flagships without a release.
- **`reasoning_auto_map`** (default `false`): off → flat default effort (xhigh for priority models, unset otherwise); on → map the extended-thinking budget → effort (legacy).
- **`reasoning_xhigh_min_budget`** (default `16000`): the auto-map xhigh threshold.
- An explicit `reasoning_effort` still overrides everything. Defaults preserve current gpt-5.5/gpt-5.4 behavior (xhigh).

## Validation
- `cargo test --lib` (1236 passed) + touched integration tests green; `cargo clippy --all-targets` clean; `cargo fmt --check` clean.
- New unit tests cover both effort modes, the configurable threshold, and the configurable priority list.
- Boot-validated on an **isolated port (13599)** with a `codex = { … }` inline-table config — parses cleanly, server logs `rate limit disabled, body limit unlimited`, `/health` 200. Prod daemon untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)