### PR TITLE
chore: release v0.36.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.61](https://github.com/azerozero/grob/compare/v0.36.60...v0.36.61) - 2026-06-01
+
+### Added
+
+- *(openai)* make Codex priority models and reasoning effort configurable
+- *(security)* disable rate limit, body size, and tool-spike caps by default
+
+### Other
+
+- *(security)* update integration assertions for off-by-default limits
+- *(examples)* default the Codex example to the priority (1.5x) tier
+
 ## [0.36.60](https://github.com/azerozero/grob/compare/v0.36.59...v0.36.60) - 2026-06-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.60"
+version = "0.36.61"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.60"
+version = "0.36.61"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.60 -> 0.36.61

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.61](https://github.com/azerozero/grob/compare/v0.36.60...v0.36.61) - 2026-06-01

### Added

- *(openai)* make Codex priority models and reasoning effort configurable
- *(security)* disable rate limit, body size, and tool-spike caps by default

### Other

- *(security)* update integration assertions for off-by-default limits
- *(examples)* default the Codex example to the priority (1.5x) tier
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).