### PR TITLE
feat(openai): match the Codex CLI request fingerprint on the OAuth path

### DIFF
--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -134,33 +134,51 @@ impl OpenAIProvider {
             return req_builder;
         };
 
-        let mut builder = req_builder
-            .header("chatgpt-account-id", account_id)
-            .header(
-                "User-Agent",
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-            )
-            .header("Origin", "https://chatgpt.com")
-            .header("Referer", "https://chatgpt.com/")
-            .header(
-                "sec-ch-ua",
-                "\"Google Chrome\";v=\"131\", \"Chromium\";v=\"131\", \"Not_A Brand\";v=\"24\"",
-            )
-            .header("sec-ch-ua-mobile", "?0")
-            .header("sec-ch-ua-platform", "\"macOS\"")
-            .header("sec-fetch-dest", "empty")
-            .header("sec-fetch-mode", "cors")
-            .header("sec-fetch-site", "same-origin");
+        let mut builder = req_builder.header("chatgpt-account-id", account_id);
 
         if is_codex {
+            // Match the real Codex CLI request fingerprint: a `codex_cli_rs`
+            // User-Agent + `originator` and `x-codex-beta-features`, WITHOUT the
+            // browser headers (Origin/Referer/sec-*) or `OpenAI-Beta` that the
+            // CLI does not send. A browser User-Agent combined with
+            // `originator: codex_cli_rs` is an inconsistent fingerprint the
+            // backend can flag. OS/arch are derived from the build target.
+            let os = match std::env::consts::OS {
+                "macos" => "Mac OS",
+                "linux" => "Linux",
+                "windows" => "Windows",
+                other => other,
+            };
+            let arch = match std::env::consts::ARCH {
+                "aarch64" => "arm64",
+                other => other,
+            };
             builder = builder
-                .header("OpenAI-Beta", "responses=experimental")
-                .header("originator", "codex_cli_rs");
+                .header("User-Agent", format!("codex_cli_rs/0.136.0 ({os}; {arch})"))
+                .header("originator", "codex_cli_rs")
+                .header("x-codex-beta-features", "terminal_resize_reflow");
             tracing::debug!(
                 "Using OAuth Bearer token for ChatGPT Codex on {}",
                 provider_name
             );
         } else {
+            // Plain ChatGPT (web-app) path keeps a browser-style fingerprint.
+            builder = builder
+                .header(
+                    "User-Agent",
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+                )
+                .header("Origin", "https://chatgpt.com")
+                .header("Referer", "https://chatgpt.com/")
+                .header(
+                    "sec-ch-ua",
+                    "\"Google Chrome\";v=\"131\", \"Chromium\";v=\"131\", \"Not_A Brand\";v=\"24\"",
+                )
+                .header("sec-ch-ua-mobile", "?0")
+                .header("sec-ch-ua-platform", "\"macOS\"")
+                .header("sec-fetch-dest", "empty")
+                .header("sec-fetch-mode", "cors")
+                .header("sec-fetch-site", "same-origin");
             tracing::debug!("Using OAuth Bearer token for ChatGPT on {}", provider_name);
         }
 


### PR DESCRIPTION
## Why

By capturing a live `codex exec` request and comparing it to what grob sends, the OAuth Codex path was advertising an **inconsistent fingerprint**: a **Chrome browser** `User-Agent` + browser headers (`Origin`/`Referer`/`sec-ch-ua`/`sec-fetch-*`) **AND** `originator: codex_cli_rs`. No real client sends both — a browser doesn't claim to be the Codex CLI, and the Codex CLI doesn't send browser headers. This is trivially fingerprintable and is a **plausible contributor to the ChatGPT token revocations** seen recently (alongside heavy concurrent volume and the cross-instance refresh race).

## What the real Codex CLI sends (captured)
```
user-agent: codex_cli_rs/0.136.0 (Mac OS 26.5.0; arm64) <terminal>
originator: codex_cli_rs
chatgpt-account-id: …
x-codex-beta-features: terminal_resize_reflow
(NO Origin / Referer / sec-* / OpenAI-Beta)
```

## Change
On the **Codex** OAuth path, `apply_oauth_headers` now sends:
- `User-Agent: codex_cli_rs/0.136.0 (<os>; <arch>)` (OS/arch derived from the build target) — was a Chrome UA
- `originator: codex_cli_rs` + `x-codex-beta-features: terminal_resize_reflow`
- **drops** `Origin`, `Referer`, `sec-ch-ua*`, `sec-fetch-*`, and `OpenAI-Beta` (the CLI sends none of these)

The plain-ChatGPT (non-Codex) OAuth path keeps the browser-style headers unchanged.

## Honest ceiling
This narrows the most glaring tells but **cannot make grob byte-identical to Codex**: grob forwards **Claude Code's** tools (Bash/Read/Edit/…), not Codex's native tools (`exec_command`/`apply_patch`/…), and that difference is fundamental to what grob does. Follow-ups (separate): add `prompt_cache_key` + `client_metadata` + `include:[reasoning.encrypted_content]` to the body (see #393), and the per-session `x-codex-turn-metadata`/`session-id`/`thread-id` headers.

> Should be live-validated against the Codex backend before deploying to a long-running prod instance (the change drops `OpenAI-Beta`, which the real CLI also omits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)