### PR TITLE
feat(tracing): trace streaming responses to the JSONL file

### DIFF
--- a/src/server/dispatch/retry.rs
+++ b/src/server/dispatch/retry.rs
@@ -250,6 +250,7 @@ pub(super) async fn dispatch_streaming(
                 is_subscription: attempt.is_subscription,
                 estimated_input_tokens,
                 start_time: ctx.start_time,
+                trace_id: ctx.trace_id.clone(),
             };
             let accounted =
                 super::spend_stream::SpendStream::new(stream_response.stream, spend_ctx);

--- a/src/server/dispatch/spend_stream.rs
+++ b/src/server/dispatch/spend_stream.rs
@@ -81,6 +81,10 @@ pub(crate) struct SpendStreamContext {
     pub estimated_input_tokens: u32,
     /// Wall-clock instant the request started, for the latency metric.
     pub start_time: std::time::Instant,
+    /// Trace-correlation id, set when request/response tracing is enabled. When
+    /// present (and the tracer is active), the accumulated response text is
+    /// written as a `res` trace entry on termination.
+    pub trace_id: Option<String>,
 }
 
 /// Usage observed while streaming, used to compute spend on termination.
@@ -98,6 +102,10 @@ struct StreamUsage {
     /// ~4-chars/token heuristic is coarse enough that the ASCII-dominant SSE
     /// text makes the two effectively equal.
     output_bytes: usize,
+    /// Accumulated response text, captured ONLY when tracing is enabled (else
+    /// `None`, keeping the hot path allocation-free). Properly JSON-decoded from
+    /// each `text_delta` so escapes survive, unlike the coarse byte counter.
+    output_text: Option<String>,
 }
 
 /// Stream adapter that records spend on termination without altering bytes.
@@ -128,10 +136,18 @@ where
 {
     /// Wraps an inner SSE byte stream to record spend on completion.
     pub(crate) fn new(inner: S, ctx: SpendStreamContext) -> Self {
+        // Capture the response body only when tracing is active, so the common
+        // path stays allocation-free.
+        let output_text = (ctx.trace_id.is_some()
+            && ctx.state.observability.message_tracer.is_enabled())
+        .then(String::new);
         Self {
             inner,
             ctx,
-            usage: StreamUsage::default(),
+            usage: StreamUsage {
+                output_text,
+                ..Default::default()
+            },
             carry: String::new(),
             recorded: false,
         }
@@ -177,6 +193,7 @@ fn scan_chunk(chunk: &str, carry: &mut String, usage: &mut StreamUsage) {
         // Output text accumulation: only `text_delta` deltas carry billable text.
         if memmem::find(complete.as_bytes(), b"text_delta").is_some() {
             accumulate_text_deltas(complete, usage);
+            collect_response_text(complete, usage);
         }
         // Provider usage: present only in `message_start` / `message_delta`.
         if memmem::find(complete.as_bytes(), b"\"usage\"").is_some() {
@@ -204,10 +221,57 @@ fn flush_carry(carry: &mut String, usage: &mut StreamUsage) {
     let tail = std::mem::take(carry);
     if memmem::find(tail.as_bytes(), b"text_delta").is_some() {
         accumulate_text_deltas(&tail, usage);
+        collect_response_text(&tail, usage);
     }
     if memmem::find(tail.as_bytes(), b"\"usage\"").is_some() {
         accumulate_usage_events(&tail, usage);
     }
+}
+
+/// Appends the JSON-decoded text of every `text_delta` event to the trace buffer.
+///
+/// Runs only when tracing is enabled (`usage.output_text` is `Some`). Unlike the
+/// coarse byte counter, it parses each event so escaped characters are preserved
+/// verbatim in the recorded response body.
+fn collect_response_text(buffer: &str, usage: &mut StreamUsage) {
+    let Some(buf) = usage.output_text.as_mut() else {
+        return;
+    };
+    for event in crate::providers::streaming::parse_sse_events(buffer) {
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&event.data) else {
+            continue;
+        };
+        if json
+            .pointer("/delta/type")
+            .and_then(serde_json::Value::as_str)
+            == Some("text_delta")
+        {
+            if let Some(text) = json
+                .pointer("/delta/text")
+                .and_then(serde_json::Value::as_str)
+            {
+                buf.push_str(text);
+            }
+        }
+    }
+}
+
+/// Writes the accumulated response body as a `res` trace entry on termination.
+///
+/// No-op unless tracing captured text (`output_text` is `Some`) and the context
+/// carries a `trace_id` correlating it to the `req` entry.
+fn trace_stream_response(ctx: &SpendStreamContext, usage: &StreamUsage) {
+    let (Some(trace_id), Some(text)) = (ctx.trace_id.as_ref(), usage.output_text.as_ref()) else {
+        return;
+    };
+    let latency_ms = ctx.start_time.elapsed().as_millis() as u64;
+    ctx.state.observability.message_tracer.trace_response_text(
+        trace_id,
+        text.clone(),
+        usage.input_tokens,
+        usage.output_tokens,
+        latency_ms,
+    );
 }
 
 /// Sums the byte length of every `text_delta` text value in the buffer.
@@ -414,6 +478,7 @@ where
                     // termination is never blocked on the spend mutex / disk.
                     flush_carry(this.carry, this.usage);
                     record_stream_spend(this.ctx, this.usage);
+                    trace_stream_response(this.ctx, this.usage);
                 }
                 Poll::Ready(None)
             }
@@ -447,6 +512,35 @@ mod tests {
         assert!(usage.saw_usage);
         assert_eq!(usage.input_tokens, 42);
         assert_eq!(usage.output_tokens, 17);
+    }
+
+    #[test]
+    fn collects_response_text_with_escapes_when_tracing() {
+        let sse = concat!(
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\" \\\"world\\\"\"}}\n\n",
+        );
+        let mut usage = StreamUsage {
+            output_text: Some(String::new()),
+            ..Default::default()
+        };
+        let mut carry = String::new();
+        scan_chunk(sse, &mut carry, &mut usage);
+        // Escapes are JSON-decoded into the trace, unlike the coarse byte counter.
+        assert_eq!(usage.output_text.as_deref(), Some("Hello \"world\""));
+    }
+
+    #[test]
+    fn skips_text_collection_when_tracing_disabled() {
+        let sse = concat!(
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+        );
+        let usage = scan_all(sse); // output_text defaults to None
+        assert!(usage.output_text.is_none());
+        assert_eq!(usage.output_bytes, 2); // byte counter still runs
     }
 
     #[test]
@@ -583,6 +677,7 @@ mod tests {
             output_tokens: 50,
             saw_usage: true,
             output_bytes: 9999,
+            ..Default::default()
         };
         assert_eq!(resolve_billed_tokens(&usage, true, 7), Some((100, 50)));
         assert_eq!(resolve_billed_tokens(&usage, false, 7), Some((100, 50)));

--- a/src/shared/message_tracing/mod.rs
+++ b/src/shared/message_tracing/mod.rs
@@ -192,6 +192,42 @@ impl MessageTracer {
         self.write_trace(&trace, file_mutex);
     }
 
+    /// Traces a streaming response assembled from accumulated `text_delta` content.
+    ///
+    /// A streaming turn never yields a single [`ProviderResponse`], so the spend
+    /// wrapper accumulates the emitted text and provider usage as the SSE stream
+    /// flows and records the `res` entry here on termination.
+    pub fn trace_response_text(
+        &self,
+        id: &str,
+        text: String,
+        input_tokens: u32,
+        output_tokens: u32,
+        latency_ms: u64,
+    ) {
+        let Some(ref file_mutex) = self.file else {
+            return;
+        };
+
+        let trace = ResponseTrace {
+            ts: Utc::now(),
+            dir: "res",
+            id: id.to_string(),
+            latency_ms,
+            stop_reason: "end_turn".to_string(),
+            input_tokens,
+            output_tokens,
+            content: serde_json::json!([{ "type": "text", "text": text }]),
+        };
+
+        self.write_trace(&trace, file_mutex);
+    }
+
+    /// Returns `true` when tracing is active (the trace file is open).
+    pub fn is_enabled(&self) -> bool {
+        self.file.is_some()
+    }
+
     /// Traces an error.
     pub fn trace_error(&self, id: &str, error: &str) {
         let Some(ref file_mutex) = self.file else {
@@ -280,6 +316,21 @@ impl crate::traits::Tracer for MessageTracer {
 
     fn trace_error(&self, id: &str, error: &str) {
         self.trace_error(id, error);
+    }
+
+    fn trace_response_text(
+        &self,
+        id: &str,
+        text: String,
+        input_tokens: u32,
+        output_tokens: u32,
+        latency_ms: u64,
+    ) {
+        self.trace_response_text(id, text, input_tokens, output_tokens, latency_ms);
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.is_enabled()
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -118,6 +118,24 @@ pub trait Tracer: Send + Sync {
 
     /// Records an error trace entry.
     fn trace_error(&self, id: &str, error: &str);
+
+    /// Records a streaming response assembled from accumulated text.
+    ///
+    /// Default no-op so non-file tracers (mocks) need not implement it.
+    fn trace_response_text(
+        &self,
+        _id: &str,
+        _text: String,
+        _input_tokens: u32,
+        _output_tokens: u32,
+        _latency_ms: u64,
+    ) {
+    }
+
+    /// Returns whether tracing is active. Default `false`.
+    fn is_enabled(&self) -> bool {
+        false
+    }
 }
 
 // ── Spend Tracking ──


### PR DESCRIPTION
## Problem
`[server.tracing]` wrote a `res` (response) entry only for **non-streaming** turns — the only path that yields a single `ProviderResponse`. Streaming turns (the common path for Claude Code and Codex CLI) left **only the `req` entry**, so the response body was never captured in the trace file. Confirmed live: a streaming request produced `dir:"req"` but no `dir:"res"`.

## Fix
The `SpendStream` wrapper already scans every SSE chunk (for spend/usage). Extend it to also accumulate the **JSON-decoded `text_delta` content** and emit a `res` trace entry on stream termination with the full response text, token counts, and latency.

- **Zero overhead when off**: the text accumulator (`output_text: Option<String>`) is `Some` only when `trace_id` is set *and* the tracer is active; otherwise the hot path stays allocation-free (unchanged byte-counting only).
- **Escapes preserved**: unlike the coarse byte counter, the trace text is JSON-decoded per `text_delta`, so quotes/escapes survive verbatim.
- `Tracer` trait + `MessageTracer`: `trace_response_text` + `is_enabled` (default no-op → mock / non-file tracers unaffected).

## Validation
- Unit tests: text accumulation + escape decoding + the off path (`output_text` stays `None`, byte counter still runs). `cargo test --lib spend_stream` → 16 passed.
- `cargo clippy --all-targets` clean.
- **End-to-end** on an isolated instance with tracing on: a streaming `/v1/messages` request now writes **both** entries —
  `{"dir":"req", …}` and `{"dir":"res","content":[{"type":"text","text":"bonjour le monde"}]}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)