### PR TITLE
fix(openai): preserve codex streams through grob

### DIFF
--- a/grob-openai-logged.toml
+++ b/grob-openai-logged.toml
@@ -62,6 +62,17 @@ provider = "chatgpt-codex"
 actual_model = "gpt-5.4-mini"
 priority = 1
 
+# Codex CLI sends its real model slug; expose it so codex keeps full model
+# metadata (and its agentic tool loop) instead of falling back to "dev".
+# NOTE: name must be the CANONICAL form — grob canonicalizes the inbound model
+# (gpt-5.5 → gpt-5-5, dot→dash for known families) but NOT config names.
+[[models]]
+name = "gpt-5-5"
+[[models.mappings]]
+provider = "chatgpt-codex"
+actual_model = "gpt-5.5"
+priority = 1
+
 [router]
 default = "dev"
 think = "codex"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -119,6 +119,9 @@ pub enum Commands {
         /// Run as a background daemon
         #[arg(short = 'd', long)]
         detach: bool,
+        /// Internal: allow binding beside an existing SO_REUSEPORT listener.
+        #[arg(long, hide = true)]
+        hot_upgrade: bool,
     },
     /// Stop the router service
     Stop,

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -37,6 +37,10 @@ pub async fn poll_health(base_url: &str, max_attempts: u32, interval_ms: u64) ->
 pub async fn stop_service(pid: u32) -> anyhow::Result<()> {
     use nix::sys::signal::{kill, Signal};
     use nix::unistd::Pid;
+    if !crate::shared::pid::is_process_running(pid) {
+        anyhow::bail!("refusing to stop PID {}: not a running Grob process", pid);
+    }
+
     let nix_pid = Pid::from_raw(pid as i32);
     kill(nix_pid, Signal::SIGTERM).map_err(|e| anyhow::anyhow!("Failed to stop service: {}", e))?;
 
@@ -44,8 +48,8 @@ pub async fn stop_service(pid: u32) -> anyhow::Result<()> {
     // Check every 100ms for up to 5 seconds.
     for _ in 0..50 {
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        if kill(nix_pid, None).is_err() {
-            // Process is gone — signal 0 failed means PID doesn't exist.
+        if !crate::shared::pid::is_process_running(pid) {
+            // Process is gone, or the PID was reused by a non-Grob process.
             return Ok(());
         }
     }
@@ -55,11 +59,17 @@ pub async fn stop_service(pid: u32) -> anyhow::Result<()> {
         "Process {} did not exit after SIGTERM, sending SIGKILL",
         pid
     );
-    let _ = kill(nix_pid, Signal::SIGKILL);
+    if crate::shared::pid::is_process_running(pid) {
+        kill(nix_pid, Signal::SIGKILL)
+            .map_err(|e| anyhow::anyhow!("Failed to force stop service: {}", e))?;
+    }
     tokio::time::sleep(tokio::time::Duration::from_millis(
         PROCESS_TRANSITION_GRACE_MS,
     ))
     .await;
+    if crate::shared::pid::is_process_running(pid) {
+        anyhow::bail!("service PID {} is still running after SIGKILL", pid);
+    }
     Ok(())
 }
 
@@ -142,7 +152,7 @@ pub async fn start_foreground(
     };
 
     let result = crate::server::start_server(config, config_source, shutdown).await;
-    let _ = crate::shared::pid::cleanup_pid();
+    let _ = crate::shared::pid::cleanup_pid_if_current();
     result
 }
 
@@ -159,7 +169,11 @@ pub fn daemon_log_path() -> Option<std::path::PathBuf> {
 /// '--config'" and the daemon never binds. The order is therefore: global flags,
 /// subcommand, then subcommand flags (`--port`). Returning the args as a vector
 /// keeps this ordering unit-testable without spawning a process.
-fn daemon_command_args(port: Option<u16>, config: Option<String>) -> Vec<String> {
+fn daemon_command_args(
+    port: Option<u16>,
+    config: Option<String>,
+    hot_upgrade: bool,
+) -> Vec<String> {
     let mut args = Vec::new();
     if let Some(config) = config {
         args.push("--config".to_string());
@@ -169,6 +183,9 @@ fn daemon_command_args(port: Option<u16>, config: Option<String>) -> Vec<String>
     if let Some(port) = port {
         args.push("--port".to_string());
         args.push(port.to_string());
+    }
+    if hot_upgrade {
+        args.push("--hot-upgrade".to_string());
     }
     args
 }
@@ -183,11 +200,27 @@ pub fn spawn_background_service(
     port: Option<u16>,
     config: Option<String>,
 ) -> anyhow::Result<Option<std::path::PathBuf>> {
+    spawn_background_service_with_mode(port, config, false)
+}
+
+/// Spawns a detached daemon for zero-downtime upgrade.
+pub fn spawn_upgrade_background_service(
+    port: Option<u16>,
+    config: Option<String>,
+) -> anyhow::Result<Option<std::path::PathBuf>> {
+    spawn_background_service_with_mode(port, config, true)
+}
+
+fn spawn_background_service_with_mode(
+    port: Option<u16>,
+    config: Option<String>,
+    hot_upgrade: bool,
+) -> anyhow::Result<Option<std::path::PathBuf>> {
     use std::process::Stdio;
 
     let exe_path = std::env::current_exe()?;
     let mut cmd = Command::new(&exe_path);
-    cmd.args(daemon_command_args(port, config));
+    cmd.args(daemon_command_args(port, config, hot_upgrade));
 
     #[cfg(all(unix, feature = "unix-signals"))]
     {
@@ -259,7 +292,7 @@ mod tests {
 
     #[test]
     fn daemon_args_with_config_parse_back_into_clap() {
-        let args = daemon_command_args(Some(13456), Some("/tmp/grob.toml".to_string()));
+        let args = daemon_command_args(Some(13456), Some("/tmp/grob.toml".to_string()), false);
 
         // The global flag must precede the subcommand.
         let start_idx = args.iter().position(|a| a == "start").unwrap();
@@ -275,19 +308,37 @@ mod tests {
             cli.command,
             Some(Commands::Start {
                 port: Some(13456),
-                detach: false
+                detach: false,
+                hot_upgrade: false
             })
         ));
     }
 
     #[test]
     fn daemon_args_without_config_parse_back_into_clap() {
-        let args = daemon_command_args(None, None);
+        let args = daemon_command_args(None, None, false);
         let cli = parse(&args);
         assert_eq!(cli.config, None);
         assert!(matches!(
             cli.command,
             Some(Commands::Start { port: None, .. })
+        ));
+    }
+
+    #[test]
+    fn daemon_args_for_upgrade_parse_with_hot_upgrade_flag() {
+        let args = daemon_command_args(Some(13456), Some("/tmp/grob.toml".to_string()), true);
+        assert!(args.iter().any(|arg| arg == "--hot-upgrade"));
+
+        let cli = parse(&args);
+        assert_eq!(cli.config.as_deref(), Some("/tmp/grob.toml"));
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Start {
+                port: Some(13456),
+                detach: false,
+                hot_upgrade: true
+            })
         ));
     }
 }

--- a/src/commands/setup/screens/auth.rs
+++ b/src/commands/setup/screens/auth.rs
@@ -202,9 +202,12 @@ fn auth_key_only(out: &mut Vec<AuthOverride>, name: &str, env_var: &str) {
 mod tests {
     use super::*;
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// Guards the default GH_TOKEN-style skip behavior.
     #[test]
     fn env_skip_default_is_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::remove_var("GROB_SETUP_NO_ENV_SKIP");
         assert!(env_skip_enabled());
     }
@@ -212,6 +215,7 @@ mod tests {
     /// `GROB_SETUP_NO_ENV_SKIP=1` must restore the legacy interactive prompt.
     #[test]
     fn env_skip_disabled_by_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("GROB_SETUP_NO_ENV_SKIP", "1");
         assert!(!env_skip_enabled());
         std::env::remove_var("GROB_SETUP_NO_ENV_SKIP");
@@ -220,6 +224,7 @@ mod tests {
     /// Values other than 1/true/yes are ignored.
     #[test]
     fn env_skip_ignores_garbage() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("GROB_SETUP_NO_ENV_SKIP", "maybe");
         assert!(env_skip_enabled());
         std::env::remove_var("GROB_SETUP_NO_ENV_SKIP");

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -24,6 +24,7 @@ pub async fn cmd_start(
     port: Option<u16>,
     detach: bool,
     cli_config: Option<String>,
+    hot_upgrade: bool,
 ) -> anyhow::Result<()> {
     print_startup_warnings(&config);
 
@@ -81,7 +82,9 @@ pub async fn cmd_start(
         config.server.port = Port::new(port).expect("valid port");
     }
 
-    if instance::is_instance_running(&config.server.host, config.server.port.value()).await {
+    if !hot_upgrade
+        && instance::is_instance_running(&config.server.host, config.server.port.value()).await
+    {
         if let Some(pid) =
             instance::find_instance_pid(&config.server.host, config.server.port.value()).await
         {

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -51,14 +51,14 @@ async fn cmd_upgrade_unix(
     base_url: &str,
     old_pid: u32,
 ) -> anyhow::Result<()> {
-    spawn_background_service(Some(_config.server.port.value()), cli_config)?;
+    spawn_upgrade_background_service(Some(_config.server.port.value()), cli_config)?;
     println!("   Spawned new process, waiting for health...");
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(35);
     let new_pid = loop {
         if std::time::Instant::now() > deadline {
             eprintln!("❌ Timeout waiting for new process to become healthy");
-            return Ok(());
+            anyhow::bail!("new Grob process did not become healthy during upgrade");
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(HEALTH_POLL_INTERVAL_MS)).await;
 
@@ -86,7 +86,14 @@ async fn cmd_upgrade_unix(
         use nix::unistd::Pid;
         println!("   Sending SIGUSR1 to old process (PID: {})...", old_pid);
         if let Err(e) = kill(Pid::from_raw(old_pid as i32), Signal::SIGUSR1) {
-            eprintln!("   Warning: Failed to signal old process: {}", e);
+            if pid::is_process_running(old_pid) {
+                stop_new_process_after_failed_upgrade(
+                    new_pid,
+                    format!("failed to signal old Grob process {old_pid}: {e}"),
+                )
+                .await?;
+            }
+            eprintln!("   Old process (PID: {}) already exited", old_pid);
         }
     }
 
@@ -97,14 +104,27 @@ async fn cmd_upgrade_unix(
             break;
         }
         if std::time::Instant::now() > drain_deadline {
-            eprintln!("   Warning: Old process still running after 35s drain timeout");
-            break;
+            anyhow::bail!(
+                "old Grob process {} still running after 35s drain timeout; new Grob process {} is healthy and left active",
+                old_pid,
+                new_pid
+            );
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
     }
 
     println!("✅ Upgrade complete! New PID: {}", new_pid);
     Ok(())
+}
+
+#[cfg(feature = "unix-signals")]
+async fn stop_new_process_after_failed_upgrade(new_pid: u32, reason: String) -> anyhow::Result<()> {
+    eprintln!("❌ {reason}");
+    eprintln!("   Stopping new process (PID: {new_pid}) to keep the old instance authoritative...");
+    if let Err(e) = stop_service(new_pid).await {
+        anyhow::bail!("{reason}; additionally failed to stop new process {new_pid}: {e}");
+    }
+    anyhow::bail!(reason)
 }
 
 #[cfg(windows)]
@@ -125,8 +145,10 @@ async fn cmd_upgrade_windows(
             break;
         }
         if std::time::Instant::now() > drain_deadline {
-            eprintln!("   Warning: Old process still running after 35s drain timeout");
-            break;
+            anyhow::bail!(
+                "old Grob process {} still running after 35s drain timeout",
+                old_pid
+            );
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
     }
@@ -136,7 +158,7 @@ async fn cmd_upgrade_windows(
 
     if !poll_health(base_url, HEALTH_POLL_MAX_ATTEMPTS, HEALTH_POLL_INTERVAL_MS).await {
         eprintln!("❌ Timeout waiting for new process to become healthy");
-        return Ok(());
+        anyhow::bail!("new Grob process did not become healthy during upgrade");
     }
 
     let new_pid = instance::find_instance_pid(&config.server.host, config.server.port.value())

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,9 +152,20 @@ async fn main() -> anyhow::Result<()> {
     }
 
     match command {
-        Commands::Start { port, detach } => {
-            commands::start::cmd_start(config, config_source, port, detach, cli_args.config)
-                .await?;
+        Commands::Start {
+            port,
+            detach,
+            hot_upgrade,
+        } => {
+            commands::start::cmd_start(
+                config,
+                config_source,
+                port,
+                detach,
+                cli_args.config,
+                hot_upgrade,
+            )
+            .await?;
         }
         Commands::Stop => commands::stop::cmd_stop(&config).await?,
         Commands::Restart { detach } => {

--- a/src/models/extensions.rs
+++ b/src/models/extensions.rs
@@ -38,4 +38,13 @@ pub struct RequestExtensions {
     pub openai_system_name: Option<String>,
     /// Optional author names for canonical messages, indexed by message position.
     pub openai_message_names: Vec<Option<String>>,
+
+    // Routing hints.
+    /// Set when the request originates from the Codex CLI (Responses API).
+    ///
+    /// Codex's own `instructions` ARE the authoritative Codex agent prompt, so
+    /// the OpenAI Responses transform forwards them as the top-level
+    /// `instructions` (keeping the backend in full agentic mode) instead of
+    /// swapping in the minimal tool-deferring preamble used for foreign clients.
+    pub codex_native: bool,
 }

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -647,9 +647,26 @@ fn build_stream_finalization_output(state: &StreamTransformState) -> String {
         ));
     }
 
+    for block_index in state.responses_fc_blocks.values() {
+        let block_stop = serde_json::json!({
+            "type": "content_block_stop",
+            "index": block_index
+        });
+        output.push_str(&format!(
+            "event: content_block_stop\ndata: {}\n\n",
+            block_stop
+        ));
+    }
+
+    let stop_reason = if state.had_tool_calls {
+        "tool_use"
+    } else {
+        "end_turn"
+    };
+
     let message_delta = serde_json::json!({
         "type": "message_delta",
-        "delta": { "stop_reason": "end_turn", "stop_sequence": null },
+        "delta": { "stop_reason": stop_reason, "stop_sequence": null },
         "usage": { "output_tokens": 0 }
     });
     output.push_str(&format!(

--- a/src/providers/openai/streaming.rs
+++ b/src/providers/openai/streaming.rs
@@ -219,15 +219,7 @@ fn emit_salvaged_tool_use(
         block_start
     ));
 
-    let input_delta = serde_json::json!({
-        "type": "content_block_delta",
-        "index": block_index,
-        "delta": { "type": "input_json_delta", "partial_json": call.input.to_string() }
-    });
-    output.push_str(&format!(
-        "event: content_block_delta\ndata: {}\n\n",
-        input_delta
-    ));
+    emit_tool_input_delta(output, block_index, &call.name, &call.input.to_string());
 
     emit_block_stop(output, block_index);
 }
@@ -248,6 +240,13 @@ fn emit_tool_call_deltas(
             .and_then(|f| f.get("name"))
             .and_then(|n| n.as_str())
             .is_some();
+        if let Some(tool_name) = tool_call
+            .get("function")
+            .and_then(|f| f.get("name"))
+            .and_then(|n| n.as_str())
+        {
+            state.tool_names.insert(tool_index, tool_name.to_string());
+        }
 
         if has_id && has_name && !state.tool_blocks.contains_key(&tool_index) {
             let tool_id = tool_call
@@ -306,15 +305,13 @@ fn emit_tool_call_deltas(
                             idx
                         });
 
-                let input_delta = serde_json::json!({
-                    "type": "content_block_delta",
-                    "index": block_index,
-                    "delta": { "type": "input_json_delta", "partial_json": args }
-                });
-                output.push_str(&format!(
-                    "event: content_block_delta\ndata: {}\n\n",
-                    input_delta
-                ));
+                let tool_name = tool_call
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|n| n.as_str())
+                    .or_else(|| state.tool_names.get(&tool_index).map(String::as_str))
+                    .unwrap_or("unknown");
+                emit_tool_input_delta(output, block_index, tool_name, args);
             }
         }
     }
@@ -325,16 +322,44 @@ fn emit_tool_call_deltas(
 /// Codex streams a structured tool call as `output_item.added` (the call shell),
 /// then `function_call_arguments.delta` chunks, then `output_item.done`. The
 /// block is keyed by the Responses `output_index` so argument deltas correlate.
+fn resolve_responses_fc_output_index(
+    state: &StreamTransformState,
+    json: &serde_json::Value,
+    item: Option<&serde_json::Value>,
+    fallback_to_single_open: bool,
+) -> Option<u64> {
+    if let Some(output_index) = json.get("output_index").and_then(|v| v.as_u64()) {
+        return Some(output_index);
+    }
+
+    for id in [
+        json.get("item_id").and_then(|v| v.as_str()),
+        item.and_then(|i| i.get("id")).and_then(|v| v.as_str()),
+        item.and_then(|i| i.get("call_id")).and_then(|v| v.as_str()),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Some(output_index) = state.responses_fc_item_indexes.get(id) {
+            return Some(*output_index);
+        }
+    }
+
+    if fallback_to_single_open && state.responses_fc_blocks.len() == 1 {
+        return state.responses_fc_blocks.keys().next().copied();
+    }
+
+    None
+}
+
 fn emit_responses_fc_start(
     output: &mut String,
     state: &mut StreamTransformState,
     json: &serde_json::Value,
     item: &serde_json::Value,
 ) {
-    let output_index = json
-        .get("output_index")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
+    let output_index =
+        resolve_responses_fc_output_index(state, json, Some(item), false).unwrap_or(0);
     if state.responses_fc_blocks.contains_key(&output_index) {
         return;
     }
@@ -355,7 +380,24 @@ fn emit_responses_fc_start(
     state.next_block_index += 1;
     state.responses_fc_blocks.insert(output_index, block_index);
     state.had_tool_calls = true;
+    state.responses_fc_args.entry(output_index).or_default();
+    state
+        .responses_fc_names
+        .insert(output_index, name.to_string());
+    for id in [
+        item.get("id").and_then(|v| v.as_str()),
+        item.get("call_id").and_then(|v| v.as_str()),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        state
+            .responses_fc_item_indexes
+            .insert(id.to_string(), output_index);
+    }
 
+    // Anthropic streams tool input incrementally: start with an empty object,
+    // then send the real arguments as input_json_delta events.
     let block_start = serde_json::json!({
         "type": "content_block_start",
         "index": block_index,
@@ -369,7 +411,12 @@ fn emit_responses_fc_start(
     // `output_item.added` sometimes already carries the full arguments.
     if let Some(args) = item.get("arguments").and_then(|v| v.as_str()) {
         if !args.is_empty() {
-            emit_responses_fc_input(output, block_index, args);
+            emit_tool_input_delta(output, block_index, name, args);
+            state
+                .responses_fc_args
+                .entry(output_index)
+                .or_default()
+                .push_str(args);
         }
     }
 }
@@ -381,12 +428,21 @@ fn emit_responses_fc_args(
     json: &serde_json::Value,
     delta: &str,
 ) {
-    let output_index = json
-        .get("output_index")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
+    let Some(output_index) = resolve_responses_fc_output_index(state, json, None, true) else {
+        return;
+    };
     if let Some(&block_index) = state.responses_fc_blocks.get(&output_index) {
-        emit_responses_fc_input(output, block_index, delta);
+        let tool_name = state
+            .responses_fc_names
+            .get(&output_index)
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        emit_tool_input_delta(output, block_index, tool_name, delta);
+        state
+            .responses_fc_args
+            .entry(output_index)
+            .or_default()
+            .push_str(delta);
     }
 }
 
@@ -400,26 +456,275 @@ fn emit_responses_fc_done(
     json: &serde_json::Value,
     item: &serde_json::Value,
 ) {
-    let output_index = json
-        .get("output_index")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
+    let output_index =
+        resolve_responses_fc_output_index(state, json, Some(item), true).unwrap_or(0);
     if !state.responses_fc_blocks.contains_key(&output_index) {
         emit_responses_fc_start(output, state, json, item);
+    }
+    let emitted_args = state
+        .responses_fc_args
+        .get(&output_index)
+        .is_some_and(|args| !args.is_empty());
+    if !emitted_args {
+        if let Some(args) = item.get("arguments").and_then(|v| v.as_str()) {
+            if !args.is_empty() {
+                if let Some(&block_index) = state.responses_fc_blocks.get(&output_index) {
+                    let tool_name = state
+                        .responses_fc_names
+                        .get(&output_index)
+                        .map(String::as_str)
+                        .or_else(|| item.get("name").and_then(|v| v.as_str()))
+                        .unwrap_or("unknown");
+                    emit_tool_input_delta(output, block_index, tool_name, args);
+                }
+            }
+        }
     }
     if let Some(block_index) = state.responses_fc_blocks.remove(&output_index) {
         emit_block_stop(output, block_index);
     }
+    state.responses_fc_args.remove(&output_index);
+    for id in [
+        item.get("id").and_then(|v| v.as_str()),
+        item.get("call_id").and_then(|v| v.as_str()),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        state.responses_fc_item_indexes.remove(id);
+    }
+    state.responses_fc_names.remove(&output_index);
 }
 
 /// Emits a tool-use `input_json_delta` carrying a partial arguments string.
-fn emit_responses_fc_input(output: &mut String, block_index: u32, partial_json: &str) {
+fn emit_tool_input_delta(
+    output: &mut String,
+    block_index: u32,
+    tool_name: &str,
+    partial_json: &str,
+) {
+    let partial_json = sanitize_tool_input_delta(tool_name, partial_json);
     let delta = serde_json::json!({
         "type": "content_block_delta",
         "index": block_index,
-        "delta": { "type": "input_json_delta", "partial_json": partial_json }
+        "delta": { "type": "input_json_delta", "partial_json": partial_json.as_ref() }
     });
     output.push_str(&format!("event: content_block_delta\ndata: {}\n\n", delta));
+}
+
+fn sanitize_tool_input_delta<'a>(
+    tool_name: &str,
+    partial_json: &'a str,
+) -> std::borrow::Cow<'a, str> {
+    if tool_name != "Read" || !has_read_tool_normalizable_field(partial_json) {
+        return std::borrow::Cow::Borrowed(partial_json);
+    }
+
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(partial_json) else {
+        return std::borrow::Cow::Borrowed(partial_json);
+    };
+    let Some(obj) = value.as_object_mut() else {
+        return std::borrow::Cow::Borrowed(partial_json);
+    };
+
+    let mut changed = apply_read_pages_normalization(obj);
+    changed |= apply_read_integer_normalization(obj, "offset", 0);
+    changed |= apply_read_integer_normalization(obj, "limit", 1);
+
+    if !changed {
+        return std::borrow::Cow::Borrowed(partial_json);
+    }
+
+    match serde_json::to_string(&value) {
+        Ok(sanitized) => {
+            tracing::debug!("Normalized Read tool arguments");
+            std::borrow::Cow::Owned(sanitized)
+        }
+        Err(_) => std::borrow::Cow::Borrowed(partial_json),
+    }
+}
+
+fn has_read_tool_normalizable_field(partial_json: &str) -> bool {
+    partial_json.contains("\"pages\"")
+        || partial_json.contains("\"offset\"")
+        || partial_json.contains("\"limit\"")
+}
+
+fn apply_read_pages_normalization(obj: &mut serde_json::Map<String, serde_json::Value>) -> bool {
+    let Some(action) = normalize_read_pages(obj.get("pages")) else {
+        return false;
+    };
+
+    match action {
+        ReadPagesNormalization::Set(pages) => {
+            obj.insert("pages".to_string(), serde_json::Value::String(pages));
+        }
+        ReadPagesNormalization::Remove => {
+            obj.remove("pages");
+        }
+    }
+    true
+}
+
+enum ReadPagesNormalization {
+    Set(String),
+    Remove,
+}
+
+fn normalize_read_pages(value: Option<&serde_json::Value>) -> Option<ReadPagesNormalization> {
+    let value = value?;
+    match value {
+        serde_json::Value::String(raw) => normalize_read_pages_string(raw),
+        serde_json::Value::Number(number) => page_number_to_string(number)
+            .map(ReadPagesNormalization::Set)
+            .or(Some(ReadPagesNormalization::Remove)),
+        serde_json::Value::Array(items) => normalize_read_pages_array(items),
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Object(_) => {
+            Some(ReadPagesNormalization::Remove)
+        }
+    }
+}
+
+fn normalize_read_pages_string(raw: &str) -> Option<ReadPagesNormalization> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Some(ReadPagesNormalization::Remove);
+    }
+    if !is_valid_read_pages_spec(trimmed) {
+        return Some(ReadPagesNormalization::Remove);
+    }
+    if trimmed == raw {
+        None
+    } else {
+        Some(ReadPagesNormalization::Set(trimmed.to_string()))
+    }
+}
+
+fn normalize_read_pages_array(items: &[serde_json::Value]) -> Option<ReadPagesNormalization> {
+    match items {
+        [] => Some(ReadPagesNormalization::Remove),
+        [single] => page_value_to_string(single)
+            .map(ReadPagesNormalization::Set)
+            .or(Some(ReadPagesNormalization::Remove)),
+        [start, end] => match (page_value_to_u64(start), page_value_to_u64(end)) {
+            (Some(start), Some(end)) if start <= end => {
+                Some(ReadPagesNormalization::Set(format!("{start}-{end}")))
+            }
+            _ => Some(ReadPagesNormalization::Remove),
+        },
+        _ => Some(ReadPagesNormalization::Remove),
+    }
+}
+
+fn page_value_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(raw) if is_valid_read_pages_spec(raw.trim()) => {
+            Some(raw.trim().to_string())
+        }
+        serde_json::Value::Number(number) => page_number_to_string(number),
+        _ => None,
+    }
+}
+
+fn page_value_to_u64(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Number(number) => page_number_to_u64(number),
+        serde_json::Value::String(raw) => raw.trim().parse::<u64>().ok().filter(|page| *page > 0),
+        _ => None,
+    }
+}
+
+fn page_number_to_string(number: &serde_json::Number) -> Option<String> {
+    page_number_to_u64(number).map(|page| page.to_string())
+}
+
+fn page_number_to_u64(number: &serde_json::Number) -> Option<u64> {
+    if let Some(page) = number.as_u64() {
+        return (page > 0).then_some(page);
+    }
+    let page = number.as_f64()?;
+    if page.is_finite() && page.fract() == 0.0 && page > 0.0 && page <= u64::MAX as f64 {
+        Some(page as u64)
+    } else {
+        None
+    }
+}
+
+fn is_valid_read_pages_spec(spec: &str) -> bool {
+    if let Some((start, end)) = spec.split_once('-') {
+        match (start.parse::<u64>(), end.parse::<u64>()) {
+            (Ok(start), Ok(end)) => start > 0 && start <= end,
+            _ => false,
+        }
+    } else {
+        spec.parse::<u64>().is_ok_and(|page| page > 0)
+    }
+}
+
+fn apply_read_integer_normalization(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    min: u64,
+) -> bool {
+    let Some(action) = normalize_read_integer(obj.get(field), min) else {
+        return false;
+    };
+
+    match action {
+        ReadIntegerNormalization::Set(value) => {
+            obj.insert(field.to_string(), serde_json::Value::Number(value.into()));
+        }
+        ReadIntegerNormalization::Remove => {
+            obj.remove(field);
+        }
+    }
+    true
+}
+
+enum ReadIntegerNormalization {
+    Set(u64),
+    Remove,
+}
+
+fn normalize_read_integer(
+    value: Option<&serde_json::Value>,
+    min: u64,
+) -> Option<ReadIntegerNormalization> {
+    let value = value?;
+    match value {
+        serde_json::Value::String(raw) => parse_read_integer_string(raw, min)
+            .map(ReadIntegerNormalization::Set)
+            .or(Some(ReadIntegerNormalization::Remove)),
+        serde_json::Value::Number(number) => {
+            if number.as_u64().is_some_and(|value| value >= min) {
+                None
+            } else {
+                read_integer_number_to_u64(number, min)
+                    .map(ReadIntegerNormalization::Set)
+                    .or(Some(ReadIntegerNormalization::Remove))
+            }
+        }
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Array(_)
+        | serde_json::Value::Object(_) => Some(ReadIntegerNormalization::Remove),
+    }
+}
+
+fn parse_read_integer_string(raw: &str, min: u64) -> Option<u64> {
+    let trimmed = raw.trim();
+    let digits = trimmed.strip_prefix('+').unwrap_or(trimmed);
+    digits.parse::<u64>().ok().filter(|value| *value >= min)
+}
+
+fn read_integer_number_to_u64(number: &serde_json::Number, min: u64) -> Option<u64> {
+    let value = number.as_f64()?;
+    if value.is_finite() && value.fract() == 0.0 && value >= min as f64 && value <= u64::MAX as f64
+    {
+        Some(value as u64)
+    } else {
+        None
+    }
 }
 
 fn emit_stream_end(
@@ -510,6 +815,10 @@ pub(crate) fn transform_codex_event_to_anthropic_sse(
 ) -> String {
     let mut output = String::new();
 
+    if state.stream_ended {
+        return output;
+    }
+
     let Ok(json) = serde_json::from_str::<serde_json::Value>(data) else {
         return output;
     };
@@ -556,9 +865,13 @@ pub(crate) fn transform_codex_event_to_anthropic_sse(
                 }
             }
         }
-        "response.completed" | "response.incomplete" | "response.failed" => {
+        "response.completed" | "response.incomplete" => {
             ensure_message_started(&mut output, state, message_id, model);
             emit_codex_stream_end(&mut output, state, &json);
+        }
+        "response.failed" => {
+            ensure_message_started(&mut output, state, message_id, model);
+            emit_codex_stream_failure(&mut output, state, &json);
         }
         _ => {}
     }
@@ -626,10 +939,47 @@ fn emit_codex_stream_end(
     ));
 }
 
+/// Emits an Anthropic-compatible stream error for a failed Responses-API event.
+fn emit_codex_stream_failure(
+    output: &mut String,
+    state: &mut StreamTransformState,
+    json: &serde_json::Value,
+) {
+    if state.stream_ended {
+        return;
+    }
+    state.stream_ended = true;
+    flush_text_buffer(output, state);
+
+    close_open_blocks(output, state);
+    for block_index in state.tool_blocks.values() {
+        emit_block_stop(output, *block_index);
+    }
+    for block_index in state.responses_fc_blocks.values() {
+        emit_block_stop(output, *block_index);
+    }
+
+    let message = json
+        .pointer("/response/error/message")
+        .or_else(|| json.pointer("/error/message"))
+        .or_else(|| json.get("detail"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("Responses stream failed");
+    let event = serde_json::json!({
+        "type": "error",
+        "error": {
+            "type": "api_error",
+            "message": message
+        }
+    });
+    output.push_str(&format!("event: error\ndata: {}\n\n", event));
+}
+
 #[cfg(test)]
 mod codex_stream_tests {
     use super::transform_codex_event_to_anthropic_sse as transform;
-    use crate::providers::openai::types::StreamTransformState;
+    use crate::providers::openai::types::{OpenAIStreamChunk, StreamTransformState};
+    use crate::providers::streaming::parse_sse_events;
 
     fn run(events: &[&str]) -> String {
         let mut state = StreamTransformState::default();
@@ -638,6 +988,48 @@ mod codex_stream_tests {
             out.push_str(&transform(event, "msg_test", "gpt-5.5", &mut state));
         }
         out
+    }
+
+    fn run_openai_chunks(chunks: &[&str]) -> String {
+        let mut state = StreamTransformState::default();
+        let mut out = String::new();
+        for chunk in chunks {
+            let chunk: OpenAIStreamChunk = serde_json::from_str(chunk).unwrap();
+            out.push_str(&super::transform_openai_chunk_to_anthropic_sse(
+                &chunk, "msg_test", &mut state,
+            ));
+        }
+        out
+    }
+
+    fn collected_tool_input(output: &str) -> String {
+        parse_sse_events(output)
+            .into_iter()
+            .filter(|event| event.event.as_deref() == Some("content_block_delta"))
+            .filter_map(|event| serde_json::from_str::<serde_json::Value>(&event.data).ok())
+            .filter(|json| json["delta"]["type"] == "input_json_delta")
+            .filter_map(|json| json["delta"]["partial_json"].as_str().map(str::to_string))
+            .collect::<String>()
+    }
+
+    #[test]
+    fn chat_completions_read_tool_empty_pages_argument_is_stripped() {
+        let out = run_openai_chunks(&[
+            r#"{"model":"gpt-4.1","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_read","type":"function","function":{"name":"Read","arguments":""}}]},"finish_reason":null}]}"#,
+            r#"{"model":"gpt-4.1","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"file_path\":\"/tmp/SKILL.md\",\"offset\":0,\"limit\":2000,\"pages\":\"\"}"}}]},"finish_reason":null}]}"#,
+            r#"{"model":"gpt-4.1","choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#,
+        ]);
+
+        assert!(out.contains(r#""type":"tool_use""#));
+        assert!(out.contains(r#""name":"Read""#));
+
+        let input = collected_tool_input(&out);
+        let json: serde_json::Value = serde_json::from_str(&input).unwrap();
+        assert_eq!(json["file_path"], "/tmp/SKILL.md");
+        assert_eq!(json["offset"], 0);
+        assert_eq!(json["limit"], 2000);
+        assert!(json.get("pages").is_none());
+        assert!(out.contains(r#""stop_reason":"tool_use""#));
     }
 
     #[test]
@@ -679,6 +1071,32 @@ mod codex_stream_tests {
             r#"{"type":"response.incomplete","response":{"status":"incomplete"}}"#,
         ]);
         assert!(out.contains("max_tokens"));
+    }
+
+    #[test]
+    fn failed_status_emits_error_not_successful_stop() {
+        let out = run(&[
+            r#"{"type":"response.output_text.delta","delta":"partial"}"#,
+            r#"{"type":"response.failed","response":{"status":"failed","error":{"message":"boom"}}}"#,
+        ]);
+        assert!(out.contains("event: error"));
+        assert!(out.contains("boom"));
+        assert!(!out.contains("event: message_stop"));
+        assert!(!out.contains(r#""stop_reason":"end_turn""#));
+    }
+
+    #[test]
+    fn events_after_terminal_response_are_ignored() {
+        let out = run(&[
+            r#"{"type":"response.output_text.delta","delta":"before"}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+            r#"{"type":"response.output_text.delta","delta":"after"}"#,
+            r#"{"type":"response.failed","response":{"status":"failed","error":{"message":"late"}}}"#,
+        ]);
+        assert!(out.contains(r#""text":"before""#));
+        assert!(!out.contains(r#""text":"after""#));
+        assert!(!out.contains("late"));
+        assert_eq!(out.matches("event: message_stop").count(), 1);
     }
 
     #[test]
@@ -728,6 +1146,142 @@ mod codex_stream_tests {
         // The block is closed and the turn ends with tool_use.
         assert!(out.contains("event: content_block_stop"));
         assert!(out.contains(r#""stop_reason":"tool_use""#));
+    }
+
+    #[test]
+    fn structured_function_call_after_preamble_uses_its_output_index() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_text.delta","output_index":0,"delta":"I'll run that."}"#,
+            r#"{"type":"response.output_item.added","output_index":1,"item":{"id":"fc_1","type":"function_call","call_id":"call_exec","name":"exec_command","arguments":""}}"#,
+            r#"{"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":1,"delta":"{\"cmd\":\""}"#,
+            r#"{"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":1,"delta":"ls\"}"}"#,
+            r#"{"type":"response.output_item.done","output_index":1,"item":{"id":"fc_1","type":"function_call","call_id":"call_exec","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        assert!(out.contains(r#""text":"I'll run that.""#));
+        assert!(out.contains(r#""type":"tool_use""#));
+        assert!(out.contains(r#""id":"call_exec""#));
+        assert!(out.contains(r#""name":"exec_command""#));
+        assert_eq!(collected_tool_input(&out), r#"{"cmd":"ls"}"#);
+        assert!(out.contains(r#""stop_reason":"tool_use""#));
+    }
+
+    #[test]
+    fn structured_function_call_done_arguments_fill_missing_deltas() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_exec","name":"exec_command","arguments":""}}"#,
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_exec","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        assert!(out.contains(r#""type":"tool_use""#));
+        assert!(out.contains("input_json_delta"));
+        assert_eq!(collected_tool_input(&out), r#"{"cmd":"ls"}"#);
+        assert!(out.contains(r#""stop_reason":"tool_use""#));
+    }
+
+    #[test]
+    fn read_tool_empty_pages_argument_is_stripped() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":""}}"#,
+            r#"{"type":"response.function_call_arguments.delta","item_id":"fc_read","output_index":0,"delta":"{\"file_path\":\"/tmp/SKILL.md\",\"offset\":0,\"limit\":2000,\"pages\":\"\"}"}"#,
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":"{\"file_path\":\"/tmp/SKILL.md\",\"offset\":0,\"limit\":2000,\"pages\":\"\"}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        let input = collected_tool_input(&out);
+        let json: serde_json::Value = serde_json::from_str(&input).unwrap();
+        assert_eq!(json["file_path"], "/tmp/SKILL.md");
+        assert_eq!(json["offset"], 0);
+        assert_eq!(json["limit"], 2000);
+        assert!(json.get("pages").is_none());
+        assert!(out.contains(r#""stop_reason":"tool_use""#));
+    }
+
+    #[test]
+    fn read_tool_numeric_pages_argument_is_converted() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":""}}"#,
+            r#"{"type":"response.function_call_arguments.delta","item_id":"fc_read","output_index":0,"delta":"{\"file_path\":\"/tmp/manual.pdf\",\"pages\":3}"}"#,
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":"{\"file_path\":\"/tmp/manual.pdf\",\"pages\":3}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        let input = collected_tool_input(&out);
+        let json: serde_json::Value = serde_json::from_str(&input).unwrap();
+        assert_eq!(json["file_path"], "/tmp/manual.pdf");
+        assert_eq!(json["pages"], "3");
+    }
+
+    #[test]
+    fn read_tool_pages_array_range_argument_is_converted() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":""}}"#,
+            r#"{"type":"response.function_call_arguments.delta","item_id":"fc_read","output_index":0,"delta":"{\"file_path\":\"/tmp/manual.pdf\",\"pages\":[1,5]}"}"#,
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":"{\"file_path\":\"/tmp/manual.pdf\",\"pages\":[1,5]}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        let input = collected_tool_input(&out);
+        let json: serde_json::Value = serde_json::from_str(&input).unwrap();
+        assert_eq!(json["file_path"], "/tmp/manual.pdf");
+        assert_eq!(json["pages"], "1-5");
+    }
+
+    #[test]
+    fn read_tool_invalid_pages_argument_is_stripped() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":""}}"#,
+            r#"{"type":"response.function_call_arguments.delta","item_id":"fc_read","output_index":0,"delta":"{\"file_path\":\"/tmp/manual.pdf\",\"pages\":\"0-2\"}"}"#,
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":"{\"file_path\":\"/tmp/manual.pdf\",\"pages\":\"0-2\"}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        let input = collected_tool_input(&out);
+        let json: serde_json::Value = serde_json::from_str(&input).unwrap();
+        assert_eq!(json["file_path"], "/tmp/manual.pdf");
+        assert!(json.get("pages").is_none());
+    }
+
+    #[test]
+    fn read_tool_string_offset_and_limit_arguments_are_converted() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":""}}"#,
+            r#"{"type":"response.function_call_arguments.delta","item_id":"fc_read","output_index":0,"delta":"{\"file_path\":\"/tmp/SKILL.md\",\"offset\":\" +0 \",\"limit\":\"2000\"}"}"#,
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":"{\"file_path\":\"/tmp/SKILL.md\",\"offset\":\" +0 \",\"limit\":\"2000\"}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        let input = collected_tool_input(&out);
+        let json: serde_json::Value = serde_json::from_str(&input).unwrap();
+        assert_eq!(json["file_path"], "/tmp/SKILL.md");
+        assert_eq!(json["offset"], 0);
+        assert_eq!(json["limit"], 2000);
+    }
+
+    #[test]
+    fn read_tool_invalid_offset_and_limit_arguments_are_stripped() {
+        let out = run(&[
+            r#"{"type":"response.created","response":{"model":"gpt-5.5"}}"#,
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":""}}"#,
+            r#"{"type":"response.function_call_arguments.delta","item_id":"fc_read","output_index":0,"delta":"{\"file_path\":\"/tmp/SKILL.md\",\"offset\":-1,\"limit\":\"0\"}"}"#,
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_read","type":"function_call","call_id":"call_read","name":"Read","arguments":"{\"file_path\":\"/tmp/SKILL.md\",\"offset\":-1,\"limit\":\"0\"}"}}"#,
+            r#"{"type":"response.completed","response":{"status":"completed"}}"#,
+        ]);
+
+        let input = collected_tool_input(&out);
+        let json: serde_json::Value = serde_json::from_str(&input).unwrap();
+        assert_eq!(json["file_path"], "/tmp/SKILL.md");
+        assert!(json.get("offset").is_none());
+        assert!(json.get("limit").is_none());
     }
 
     #[test]

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -592,7 +592,8 @@ The harness provides its own system prompt and a set of tools in this request. U
 provided tools through the function-calling interface to take actions — do not assume any built-in \
 `shell`, `apply_patch`, or `update_plan` tool exists, and never emit a tool call as plain text or \
 inside a code block. When you need to run a command, read, or edit, call the matching provided tool \
-with its required arguments.";
+with its required arguments. Omit optional arguments that are unset; never send an empty string as a \
+placeholder for a missing optional argument.";
 
 /// Per-call knobs for the Codex (OpenAI Responses API) transform.
 ///
@@ -638,9 +639,22 @@ pub(crate) fn transform_to_responses_request(
 ) -> Result<OpenAIResponsesRequest, ProviderError> {
     let tools = transform_responses_tools(request);
 
-    // Forwarding tools and the Codex CLI prompt at once makes the model call
-    // non-existent built-in tools, so swap to a tool-deferring preamble.
-    let instructions = if tools.is_some() {
+    // Codex CLI requests carry their own authoritative Codex agent prompt as
+    // `instructions` (canonical `system`). Forward it verbatim as the
+    // top-level `instructions` so the backend stays in full agentic mode.
+    // Demoting it to a user item (the foreign-client path) makes the model emit
+    // a preamble and stop instead of calling the provided tools.
+    let codex_native = request.extensions.codex_native;
+
+    let instructions = if codex_native {
+        request
+            .system
+            .as_ref()
+            .map(|s| s.to_text())
+            .unwrap_or_else(|| codex_instructions.to_string())
+    } else if tools.is_some() {
+        // Forwarding tools and the full Codex CLI prompt at once makes a foreign
+        // client's model call non-existent built-in tools, so defer to a preamble.
         CODEX_TOOL_INSTRUCTIONS.to_string()
     } else {
         codex_instructions.to_string()
@@ -649,11 +663,15 @@ pub(crate) fn transform_to_responses_request(
     let mut items = Vec::new();
 
     // Codex has no separate system role; hoist the system prompt to a user item.
-    if let Some(ref system) = request.system {
-        items.push(OpenAIResponsesItem::Message {
-            role: "user".to_string(),
-            content: Some(system.to_text()),
-        });
+    // Skip on the codex-native path: the system is already the top-level
+    // `instructions` above, so re-adding it here would duplicate it.
+    if !codex_native {
+        if let Some(ref system) = request.system {
+            items.push(OpenAIResponsesItem::Message {
+                role: "user".to_string(),
+                content: Some(system.to_text()),
+            });
+        }
     }
 
     for msg in &request.messages {
@@ -681,6 +699,8 @@ pub(crate) fn transform_to_responses_request(
         model: request.model.clone(),
         input: OpenAIResponsesInput::Items(items),
         instructions,
+        // The ChatGPT Codex backend REQUIRES store=false (returns 400 "Store must
+        // be set to false" otherwise), so this is fixed for every path.
         store: false,
         stream: true,
         tool_choice: tools.as_ref().and(transform_responses_tool_choice(request)),
@@ -1026,6 +1046,49 @@ mod tests {
         assert!(input
             .iter()
             .any(|i| i["role"] == "user" && i["content"] == "be terse"));
+    }
+
+    #[test]
+    fn codex_native_request_forwards_system_as_instructions_once() {
+        use crate::models::Tool;
+
+        let mut request = base_request();
+        request.model = "gpt-5.5".to_string();
+        request.system = Some(SystemPrompt::Text("FULL CODEX CLI PROMPT".to_string()));
+        request.extensions.codex_native = true;
+        request.tools = Some(vec![Tool {
+            r#type: Some("function".to_string()),
+            name: Some("exec_command".to_string()),
+            description: Some("Run a command".to_string()),
+            input_schema: Some(serde_json::json!({
+                "type": "object",
+                "properties": { "cmd": { "type": "string" } }
+            })),
+        }]);
+        request.messages = vec![Message {
+            role: "user".to_string(),
+            content: MessageContent::Text("run ls".to_string()),
+        }];
+
+        let opts = CodexOptions::default();
+        let req = transform_to_responses_request(
+            &request,
+            "BUILTIN CODEX PROMPT",
+            &CodexTuning::from_options(&opts, None, None),
+        )
+        .unwrap();
+        let json = serde_json::to_value(&req).unwrap();
+
+        assert_eq!(json["instructions"], "FULL CODEX CLI PROMPT");
+        assert_eq!(json["tools"][0]["name"], "exec_command");
+
+        let input = json["input"].as_array().unwrap();
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+        assert_eq!(input[0]["content"], "run ls");
+        assert!(!input
+            .iter()
+            .any(|item| item["content"] == "FULL CODEX CLI PROMPT"));
     }
 
     #[test]

--- a/src/providers/openai/types.rs
+++ b/src/providers/openai/types.rs
@@ -281,6 +281,11 @@ pub(crate) struct StreamTransformState {
     /// Tool call indices that have had content_block_start emitted
     /// Maps OpenAI tool_call index → Anthropic content_block index
     pub tool_blocks: std::collections::HashMap<u32, u32>,
+    /// OpenAI Chat Completions tool_call index -> tool name.
+    ///
+    /// Chat Completions streams often send the function name before later
+    /// argument chunks, so keep it for tool-specific argument normalization.
+    pub tool_names: std::collections::HashMap<u32, String>,
     /// Next available content block index
     pub next_block_index: u32,
     /// Has finish_reason been received?
@@ -300,4 +305,19 @@ pub(crate) struct StreamTransformState {
     /// Tracks structured Codex `function_call` items as they stream so argument
     /// deltas land on the right `tool_use` block.
     pub responses_fc_blocks: std::collections::HashMap<u64, u32>,
+    /// Responses-API function-call item id/call id to output index.
+    ///
+    /// Some Responses stream events key argument deltas by `item_id`; keep both
+    /// ids so deltas still route correctly if `output_index` is absent.
+    pub responses_fc_item_indexes: std::collections::HashMap<String, u64>,
+    /// Arguments already emitted for each Responses function-call output index.
+    ///
+    /// Used to avoid duplicating full arguments from `output_item.done` after
+    /// incremental `function_call_arguments.delta` chunks were already sent.
+    pub responses_fc_args: std::collections::HashMap<u64, String>,
+    /// Responses-API function-call output index -> tool name.
+    ///
+    /// Kept so argument deltas can be normalized with tool-specific rules even
+    /// when later delta events only carry `output_index` or `item_id`.
+    pub responses_fc_names: std::collections::HashMap<u64, String>,
 }

--- a/src/providers/streaming.rs
+++ b/src/providers/streaming.rs
@@ -240,10 +240,12 @@ impl<S> LoggingSseStream<S> {
                         .ok()
                         .and_then(|json| json.get("usage").cloned());
                     if let Some(usage) = usage {
-                        tracking.output_tokens += usage
-                            .get("output_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
+                        tracking.output_tokens = tracking.output_tokens.max(
+                            usage
+                                .get("output_tokens")
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0),
+                        );
                         let input = usage
                             .get("input_tokens")
                             .and_then(|v| v.as_u64())
@@ -278,6 +280,7 @@ impl<S> LoggingSseStream<S> {
         };
 
         let total_input = tokens.input + tokens.cache_creation + tokens.cache_read;
+        let total_tokens = total_input.saturating_add(tokens.output);
 
         let cache_info = if tokens.cache_creation > 0 || tokens.cache_read > 0 {
             let cache_pct = (tokens.cache_read * 100)
@@ -309,12 +312,13 @@ impl<S> LoggingSseStream<S> {
         };
 
         tracing::info!(
-            "📊 {}:{} {}ms ttft:{}ms {:.1}t/s out:{} in:{}{}{}",
+            "📊 {}:{} {}ms ttft:{}ms {:.1}t/s total:{} out:{} in:{}{}{}",
             provider_name,
             model_display,
             total_time.as_millis(),
             ttft.as_millis(),
             tok_per_sec,
+            total_tokens,
             tokens.output,
             total_input,
             cache_info,

--- a/src/server/dispatch/provider_loop.rs
+++ b/src/server/dispatch/provider_loop.rs
@@ -181,12 +181,12 @@ pub(super) async fn dispatch_provider_loop(
         }
     }
 
-    // Backward-compat direct lookup — only when no mapping was actually
-    // attempted (a bare model name not in `[[models.mappings]]`). When a mapping
-    // *was* tried and failed, the router model name (e.g. `dev`) is not a real
-    // upstream model, so re-sending it just yields a misleading "model not
-    // supported" error that masks the true failure (`last_error`).
-    if last_error.is_none() {
+    // Backward-compat direct lookup — only when no mapping was resolved at all
+    // (a bare upstream model name handled by legacy provider model lists). When
+    // mappings exist, the router model name may be a local alias (e.g. `dev`).
+    // If those mappings are skipped by circuit breaker / endpoint health, direct
+    // lookup would bypass `actual_model` and send that alias upstream.
+    if should_try_direct_lookup(effective_mappings.len(), &last_error) {
         if let Some(result) = try_direct_provider_lookup(ctx, request, &decision.model_name).await?
         {
             return Ok(result);
@@ -237,6 +237,16 @@ pub(super) async fn dispatch_provider_loop(
 #[inline]
 fn next_mapping_index(idx: usize) -> usize {
     idx + 1
+}
+
+/// Returns whether the provider loop may use legacy direct model lookup.
+///
+/// Direct lookup is unsafe once a model resolved to mappings, even if no
+/// provider was attempted: the decision model may be a local alias whose
+/// upstream name lives only in [`crate::cli::ModelMapping::actual_model`].
+#[inline]
+fn should_try_direct_lookup(mapping_count: usize, last_error: &Option<RequestError>) -> bool {
+    mapping_count == 0 && last_error.is_none()
 }
 
 /// Returns the ` [n/total]` retry suffix, or an empty string for the first try.
@@ -360,6 +370,24 @@ mod tests {
         // mutant would return an empty string here instead.
         assert_eq!(retry_suffix(1, 3), " [2/3]");
         assert_eq!(retry_suffix(2, 3), " [3/3]");
+    }
+
+    #[test]
+    fn direct_lookup_allowed_only_without_mappings_or_errors() {
+        assert!(should_try_direct_lookup(0, &None));
+    }
+
+    #[test]
+    fn direct_lookup_skipped_when_mappings_exist_even_without_error() {
+        // Mappings may all be skipped by endpoint health or circuit breakers.
+        // In that case direct lookup would send the local tier name upstream.
+        assert!(!should_try_direct_lookup(1, &None));
+    }
+
+    #[test]
+    fn direct_lookup_skipped_after_upstream_error() {
+        let err = Some(RequestError::RoutingError("boom".to_string()));
+        assert!(!should_try_direct_lookup(0, &err));
     }
 
     #[test]

--- a/src/server/dispatch/retry.rs
+++ b/src/server/dispatch/retry.rs
@@ -13,6 +13,7 @@ use bytes::Bytes;
 use futures::stream::Stream;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Instant;
 use tracing::{info, warn};
 
 use super::super::{is_auth_revoked_error, is_retryable, provider_max_retries, retry_delay};
@@ -80,6 +81,61 @@ pub(super) struct StreamingAttempt<'a> {
     pub mapping: &'a crate::cli::ModelMapping,
     pub decision: &'a crate::models::RouteDecision,
     pub is_subscription: bool,
+}
+
+/// Traces cancellation before a streaming response body exists.
+///
+/// Normal streams are traced by the response body wrapper in `handlers.rs`.
+/// This guard covers the earlier gap while waiting for upstream response
+/// headers: if the client disconnects there, no body wrapper is ever created.
+struct PreStreamTraceGuard {
+    tracer: Option<Arc<dyn crate::traits::Tracer>>,
+    trace_id: Option<String>,
+    start_time: Instant,
+}
+
+impl PreStreamTraceGuard {
+    fn new(ctx: &DispatchContext<'_>) -> Self {
+        let (tracer, trace_id) = match &ctx.trace_id {
+            Some(id) => (
+                Some(Arc::clone(&ctx.state.observability.message_tracer)),
+                Some(id.clone()),
+            ),
+            None => (None, None),
+        };
+
+        Self {
+            tracer,
+            trace_id,
+            start_time: ctx.start_time,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.tracer = None;
+        self.trace_id = None;
+    }
+
+    fn finish(&mut self, status: &str) {
+        let (Some(tracer), Some(trace_id)) = (self.tracer.take(), self.trace_id.take()) else {
+            return;
+        };
+
+        tracer.trace_stream_end(
+            &trace_id,
+            0,
+            0,
+            self.start_time.elapsed().as_millis() as u64,
+            status,
+            None,
+        );
+    }
+}
+
+impl Drop for PreStreamTraceGuard {
+    fn drop(&mut self) {
+        self.finish("dropped_before_stream");
+    }
 }
 
 /// Returns `true` when a provider error reports a 429 rate-limit upstream.
@@ -211,6 +267,7 @@ pub(super) async fn dispatch_streaming(
     attempt: &StreamingAttempt<'_>,
 ) -> Result<DispatchResult, ProviderLoopAction> {
     let mapping = attempt.mapping;
+    let mut pre_stream_trace = PreStreamTraceGuard::new(ctx);
 
     // Capture request body for tap before ownership moves.
     let tap_request_body = if ctx.state.security.tap_sender.is_some() {
@@ -230,6 +287,7 @@ pub(super) async fn dispatch_streaming(
 
     match provider.send_message_stream(provider_request).await {
         Ok(stream_response) => {
+            pre_stream_trace.disarm();
             // Overhead = time from request receipt to first SSE byte (before provider responded).
             let overhead_ms = ctx.start_time.elapsed().as_millis() as u64;
             let latency_ms = overhead_ms;
@@ -269,6 +327,7 @@ pub(super) async fn dispatch_streaming(
             })
         }
         Err(e) => {
+            pre_stream_trace.disarm();
             ctx.record_provider_failure(&mapping.provider).await;
             ctx.record_endpoint_failure(&mapping.provider, &mapping.actual_model);
             if let Some(ref trace_id) = ctx.trace_id {
@@ -669,7 +728,91 @@ fn build_encrypted_content(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::{CanonicalRequest, RouteType};
+    use crate::providers::ProviderResponse;
+    use crate::traits::Tracer;
     use std::cell::Cell;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingTracer {
+        stream_ends: Mutex<Vec<(String, u64, usize, String)>>,
+    }
+
+    impl Tracer for RecordingTracer {
+        fn new_trace_id(&self) -> String {
+            "trace".to_string()
+        }
+
+        fn trace_request(
+            &self,
+            _id: &str,
+            _request: &CanonicalRequest,
+            _provider: &str,
+            _route_type: &RouteType,
+            _is_stream: bool,
+        ) {
+        }
+
+        fn trace_response(&self, _id: &str, _response: &ProviderResponse, _latency_ms: u64) {}
+
+        fn trace_stream_end(
+            &self,
+            id: &str,
+            chunk_count: u64,
+            byte_count: usize,
+            _latency_ms: u64,
+            status: &str,
+            _usage: Option<crate::traits::StreamTraceUsage>,
+        ) {
+            self.stream_ends.lock().unwrap().push((
+                id.to_string(),
+                chunk_count,
+                byte_count,
+                status.to_string(),
+            ));
+        }
+
+        fn trace_error(&self, _id: &str, _error: &str) {}
+    }
+
+    // ── pre-stream trace guard ──
+
+    #[test]
+    fn pre_stream_trace_guard_records_drop_before_stream() {
+        let tracer = Arc::new(RecordingTracer::default());
+
+        {
+            let _guard = PreStreamTraceGuard {
+                tracer: Some(tracer.clone()),
+                trace_id: Some("abc123".to_string()),
+                start_time: Instant::now(),
+            };
+        }
+
+        let events = tracer.stream_ends.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "abc123");
+        assert_eq!(events[0].1, 0);
+        assert_eq!(events[0].2, 0);
+        assert_eq!(events[0].3, "dropped_before_stream");
+    }
+
+    #[test]
+    fn pre_stream_trace_guard_disarm_suppresses_drop_trace() {
+        let tracer = Arc::new(RecordingTracer::default());
+
+        {
+            let mut guard = PreStreamTraceGuard {
+                tracer: Some(tracer.clone()),
+                trace_id: Some("abc123".to_string()),
+                start_time: Instant::now(),
+            };
+            guard.disarm();
+        }
+
+        assert!(tracer.stream_ends.lock().unwrap().is_empty());
+    }
 
     // ── classify_and_handle_error retry decision ──
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -6,8 +6,14 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use futures::stream::TryStreamExt;
-use std::sync::Arc;
+use bytes::Bytes;
+use futures::stream::{Stream, TryStreamExt};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Instant,
+};
 use tracing::{debug, error};
 
 use super::middleware::AuditedAlready;
@@ -60,6 +66,206 @@ impl Drop for ActiveRequestGuard {
             .active_requests
             .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
     }
+}
+
+#[derive(Default)]
+struct ResponseTraceUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+    saw_usage: bool,
+}
+
+impl ResponseTraceUsage {
+    fn as_trace_usage(&self) -> Option<crate::traits::StreamTraceUsage> {
+        self.saw_usage.then_some(crate::traits::StreamTraceUsage {
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+        })
+    }
+}
+
+const TRACE_USAGE_MAX_CARRY: usize = 8 * 1024;
+
+fn scan_response_trace_usage(chunk: &str, carry: &mut String, usage: &mut ResponseTraceUsage) {
+    let scan_owned;
+    let scan: &str = if carry.is_empty() {
+        chunk
+    } else {
+        carry.push_str(chunk);
+        scan_owned = std::mem::take(carry);
+        &scan_owned
+    };
+
+    let (complete, tail) = match scan.rfind("\n\n") {
+        Some(pos) => (&scan[..pos + 2], &scan[pos + 2..]),
+        None => ("", scan),
+    };
+
+    if complete.contains("\"usage\"") {
+        accumulate_response_trace_usage(complete, usage);
+    }
+
+    if !tail.is_empty() {
+        let start = tail.len().saturating_sub(TRACE_USAGE_MAX_CARRY);
+        carry.push_str(&tail[tail.ceil_char_boundary(start)..]);
+    }
+}
+
+fn flush_response_trace_usage(carry: &mut String, usage: &mut ResponseTraceUsage) {
+    if carry.is_empty() {
+        return;
+    }
+    let tail = std::mem::take(carry);
+    if tail.contains("\"usage\"") {
+        accumulate_response_trace_usage(&tail, usage);
+    }
+}
+
+fn accumulate_response_trace_usage(buffer: &str, usage: &mut ResponseTraceUsage) {
+    for event in crate::providers::streaming::parse_sse_events(buffer) {
+        match event.event.as_deref() {
+            Some("message_start") => {
+                parse_response_trace_usage_json(&event.data, "/message/usage", usage);
+            }
+            Some("message_delta") => {
+                parse_response_trace_usage_json(&event.data, "/usage", usage);
+            }
+            Some("response.completed") | Some("response.incomplete") | Some("response.failed") => {
+                parse_response_trace_usage_json(&event.data, "/response/usage", usage);
+            }
+            _ => {
+                parse_response_trace_usage_json(&event.data, "/usage", usage);
+            }
+        }
+    }
+}
+
+fn parse_response_trace_usage_json(data: &str, pointer: &str, usage: &mut ResponseTraceUsage) {
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(data) else {
+        return;
+    };
+    let Some(value) = json.pointer(pointer) else {
+        return;
+    };
+    update_response_trace_usage(value, usage);
+}
+
+fn update_response_trace_usage(value: &serde_json::Value, usage: &mut ResponseTraceUsage) {
+    let input = value
+        .get("input_tokens")
+        .or_else(|| value.get("prompt_tokens"))
+        .and_then(serde_json::Value::as_u64);
+    if let Some(input) = input {
+        let input = u32::try_from(input).unwrap_or(u32::MAX);
+        if input > 0 || usage.input_tokens == 0 {
+            usage.input_tokens = input;
+        }
+        usage.saw_usage = true;
+    }
+
+    let output = value
+        .get("output_tokens")
+        .or_else(|| value.get("completion_tokens"))
+        .and_then(serde_json::Value::as_u64);
+    if let Some(output) = output {
+        usage.output_tokens = usage
+            .output_tokens
+            .max(u32::try_from(output).unwrap_or(u32::MAX));
+        usage.saw_usage = true;
+    }
+}
+
+struct ResponseTraceStream<S> {
+    inner: Pin<Box<S>>,
+    tracer: Arc<dyn crate::traits::Tracer>,
+    trace_id: String,
+    chunk_count: u64,
+    byte_count: usize,
+    usage: ResponseTraceUsage,
+    usage_carry: String,
+    start_time: Instant,
+    ended: bool,
+}
+
+impl<S> ResponseTraceStream<S> {
+    fn finish(&mut self, status: &str) {
+        if self.ended {
+            return;
+        }
+        self.ended = true;
+        flush_response_trace_usage(&mut self.usage_carry, &mut self.usage);
+        self.tracer.trace_stream_end(
+            &self.trace_id,
+            self.chunk_count,
+            self.byte_count,
+            self.start_time.elapsed().as_millis() as u64,
+            status,
+            self.usage.as_trace_usage(),
+        );
+    }
+}
+
+impl<S> Unpin for ResponseTraceStream<S> {}
+
+impl<S> Stream for ResponseTraceStream<S>
+where
+    S: Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
+{
+    type Item = Result<Bytes, std::io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(chunk))) => {
+                let seq = this.chunk_count;
+                this.chunk_count += 1;
+                this.byte_count += chunk.len();
+                let text = String::from_utf8_lossy(&chunk);
+                scan_response_trace_usage(&text, &mut this.usage_carry, &mut this.usage);
+                this.tracer
+                    .trace_stream_chunk(&this.trace_id, seq, chunk.as_ref());
+                Poll::Ready(Some(Ok(chunk)))
+            }
+            Poll::Ready(Some(Err(err))) => {
+                this.tracer
+                    .trace_error(&this.trace_id, &format!("stream error: {err}"));
+                this.finish("error");
+                Poll::Ready(Some(Err(err)))
+            }
+            Poll::Ready(None) => {
+                this.finish("complete");
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S> Drop for ResponseTraceStream<S> {
+    fn drop(&mut self) {
+        self.finish("dropped");
+    }
+}
+
+fn trace_response_stream<S>(
+    stream: S,
+    tracer: Arc<dyn crate::traits::Tracer>,
+    trace_id: String,
+) -> Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>
+where
+    S: Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
+{
+    Box::pin(ResponseTraceStream {
+        inner: Box::pin(stream),
+        tracer,
+        trace_id,
+        chunk_count: 0,
+        byte_count: 0,
+        usage: ResponseTraceUsage::default(),
+        usage_carry: String::new(),
+        start_time: Instant::now(),
+        ended: false,
+    })
 }
 
 /// Build a JSON response with optional transparency headers.
@@ -262,6 +468,7 @@ pub(crate) async fn handle_openai_chat_completions(
     let is_streaming = openai_request.stream == Some(true);
 
     let prelude = prepare_dispatch(&state, &claims, &vk_ctx, &headers);
+    let trace_id = state.observability.message_tracer.new_trace_id();
 
     // Transform OpenAI → Anthropic format
     let mut request =
@@ -286,7 +493,7 @@ pub(crate) async fn handle_openai_chat_completions(
         req_id: &request_id.0,
         start_time,
         headers: &headers,
-        trace_id: None,
+        trace_id: Some(trace_id.clone()),
         audited: audited_flag.clone(),
         #[cfg(feature = "policies")]
         resolved_policy,
@@ -302,6 +509,8 @@ pub(crate) async fn handle_openai_chat_completions(
     };
     let model_for_stream = model.clone();
     let model_for_fanout = model.clone();
+    let tracer_for_stream = Arc::clone(&state.observability.message_tracer);
+    let trace_id_for_stream = trace_id.clone();
 
     let mut response = finish_dispatch(
         result,
@@ -313,7 +522,12 @@ pub(crate) async fn handle_openai_chat_completions(
             let mapped = stream
                 .map_ok(move |bytes| transformer.transform_bytes(&bytes))
                 .try_filter(|b| futures::future::ready(!b.is_empty()));
-            Body::from_stream(mapped.map_err(|e| std::io::Error::other(e.to_string())))
+            let body_stream = mapped.map_err(|e| std::io::Error::other(e.to_string()));
+            Body::from_stream(trace_response_stream(
+                body_stream,
+                tracer_for_stream,
+                trace_id_for_stream,
+            ))
         },
         |resp| {
             let openai_response = openai_compat::transform_canonical_to_openai(resp, model.clone());
@@ -358,6 +572,7 @@ pub(crate) async fn handle_responses(
     );
 
     let prelude = prepare_dispatch(&state, &claims, &vk_ctx, &headers);
+    let trace_id = state.observability.message_tracer.new_trace_id();
 
     // Transform Responses → canonical format
     let mut request = responses_compat::transform_responses_to_canonical(responses_request)
@@ -382,7 +597,7 @@ pub(crate) async fn handle_responses(
         req_id: &request_id.0,
         start_time,
         headers: &headers,
-        trace_id: None,
+        trace_id: Some(trace_id.clone()),
         audited: audited_flag.clone(),
         #[cfg(feature = "policies")]
         resolved_policy,
@@ -398,6 +613,8 @@ pub(crate) async fn handle_responses(
     };
     let model_for_stream = model.clone();
     let model_for_fanout = model.clone();
+    let tracer_for_stream = Arc::clone(&state.observability.message_tracer);
+    let trace_id_for_stream = trace_id.clone();
 
     let mut response = finish_dispatch(
         result,
@@ -410,7 +627,12 @@ pub(crate) async fn handle_responses(
             let mapped = stream
                 .map_ok(move |bytes| transformer.transform_bytes(&bytes))
                 .try_filter(|b| futures::future::ready(!b.is_empty()));
-            Body::from_stream(mapped.map_err(|e| std::io::Error::other(e.to_string())))
+            let body_stream = mapped.map_err(|e| std::io::Error::other(e.to_string()));
+            Body::from_stream(trace_response_stream(
+                body_stream,
+                tracer_for_stream,
+                trace_id_for_stream,
+            ))
         },
         |resp| {
             let responses_response =
@@ -501,7 +723,7 @@ pub(crate) async fn handle_messages(
         req_id,
         start_time,
         headers: &headers,
-        trace_id: Some(trace_id),
+        trace_id: Some(trace_id.clone()),
         audited: audited_flag.clone(),
         #[cfg(feature = "policies")]
         resolved_policy,
@@ -515,6 +737,8 @@ pub(crate) async fn handle_messages(
             return Ok(response);
         }
     };
+    let tracer_for_stream = Arc::clone(&state.observability.message_tracer);
+    let trace_id_for_stream = trace_id.clone();
 
     let mut response = finish_dispatch(
         result,
@@ -526,7 +750,11 @@ pub(crate) async fn handle_messages(
                 error!("Stream error: {}", e);
                 std::io::Error::other(e.to_string())
             });
-            Body::from_stream(body_stream)
+            Body::from_stream(trace_response_stream(
+                body_stream,
+                tracer_for_stream,
+                trace_id_for_stream,
+            ))
         },
         |resp| serialize_response(&resp),
         |resp| Json(resp).into_response(),

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -7,6 +7,8 @@
 use super::{oauth_handlers, AppState};
 use crate::config::AppConfig;
 use axum::{routing::get, Router as AxumRouter};
+#[cfg(any(feature = "tls", feature = "acme"))]
+use std::future::Future;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
@@ -15,6 +17,14 @@ use tracing::{error, info, warn};
 /// The configured `server.oauth_callback_port` is attempt one; each later attempt
 /// increments the port by one.
 const OAUTH_CALLBACK_BIND_ATTEMPTS: u16 = crate::shared::net::DEFAULT_PORT_RETRY_ATTEMPTS;
+/// Number of short retries on the configured OAuth port before trying fallbacks.
+///
+/// During a hot upgrade the old process still owns the OAuth callback port until
+/// the new process becomes healthy and SIGUSR1 is sent. Retrying the preferred
+/// port prevents the new process from permanently falling back to an adjacent
+/// port that OpenAI Codex cannot use for its pinned redirect URI.
+const OAUTH_CALLBACK_PREFERRED_RETRIES: u32 = 100;
+const OAUTH_CALLBACK_PREFERRED_RETRY_INTERVAL_MS: u64 = 100;
 
 /// Binds the server socket and serves with optional TLS and graceful shutdown.
 pub(super) async fn bind_and_serve(
@@ -65,19 +75,23 @@ pub(super) async fn bind_and_serve(
     } else if tls_acme {
         #[cfg(feature = "acme")]
         {
+            let handle = axum_server::Handle::new();
+            spawn_axum_server_shutdown(shutdown_signal, handle.clone());
             let acceptor = crate::shared::acme::build_acme_acceptor(&config.server.tls.acme)?;
             info!("Server listening on {} (ACME TLS, {})", addr, REUSE_LABEL);
-            let listener = crate::shared::net::bind_reuseport(&addr).await?;
-            axum_server::Server::bind(addr.parse()?)
+            let std_listener = crate::shared::net::bind_reuseport_std(&addr)?;
+            axum_server::Server::from_tcp(std_listener)
                 .acceptor(acceptor)
+                .handle(handle)
                 .serve(app.into_make_service())
                 .await?;
-            drop(listener);
         }
     } else {
         #[cfg(feature = "tls")]
         {
             use axum_server::tls_rustls::RustlsConfig;
+            let handle = axum_server::Handle::new();
+            spawn_axum_server_shutdown(shutdown_signal, handle.clone());
             let rustls_config = RustlsConfig::from_pem_file(
                 &config.server.tls.cert_path,
                 &config.server.tls.key_path,
@@ -86,12 +100,24 @@ pub(super) async fn bind_and_serve(
             info!("Server listening on {} (TLS, {})", addr, REUSE_LABEL);
             let std_listener = crate::shared::net::bind_reuseport_std(&addr)?;
             axum_server::from_tcp_rustls(std_listener, rustls_config)
+                .handle(handle)
                 .serve(app.into_make_service())
                 .await?;
         }
     }
 
     Ok(())
+}
+
+#[cfg(any(feature = "tls", feature = "acme"))]
+fn spawn_axum_server_shutdown(
+    shutdown_signal: impl Future<Output = ()> + Send + 'static,
+    handle: axum_server::Handle,
+) {
+    tokio::spawn(async move {
+        shutdown_signal.await;
+        handle.graceful_shutdown(Some(std::time::Duration::from_secs(30)));
+    });
 }
 
 /// Waits for all active requests to complete or times out after 30 seconds.
@@ -138,13 +164,7 @@ pub(super) fn spawn_oauth_callback(oauth_state: Arc<AppState>) {
             .route("/auth/callback", get(oauth_handlers::oauth_callback))
             .with_state(oauth_state.clone());
 
-        match crate::shared::net::bind_with_port_retry(
-            "127.0.0.1",
-            configured_port,
-            OAUTH_CALLBACK_BIND_ATTEMPTS,
-        )
-        .await
-        {
+        match bind_oauth_callback_listener(configured_port).await {
             Ok((oauth_listener, actual_port)) => {
                 oauth_state
                     .actual_oauth_callback_port
@@ -173,4 +193,31 @@ pub(super) fn spawn_oauth_callback(oauth_state: Arc<AppState>) {
             }
         }
     });
+}
+
+async fn bind_oauth_callback_listener(
+    configured_port: u16,
+) -> anyhow::Result<(tokio::net::TcpListener, u16)> {
+    let preferred_addr = format!("127.0.0.1:{configured_port}");
+    for _ in 0..OAUTH_CALLBACK_PREFERRED_RETRIES {
+        match tokio::net::TcpListener::bind(&preferred_addr).await {
+            Ok(listener) => return Ok((listener, configured_port)),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    OAUTH_CALLBACK_PREFERRED_RETRY_INTERVAL_MS,
+                ))
+                .await;
+            }
+            Err(e) => {
+                return Err(anyhow::Error::new(e).context(format!("bind {preferred_addr}")));
+            }
+        }
+    }
+
+    crate::shared::net::bind_with_port_retry(
+        "127.0.0.1",
+        configured_port,
+        OAUTH_CALLBACK_BIND_ATTEMPTS,
+    )
+    .await
 }

--- a/src/server/openai_compat/transform.rs
+++ b/src/server/openai_compat/transform.rs
@@ -282,6 +282,7 @@ pub fn transform_openai_to_canonical(
         service_tier: openai_req.service_tier,
         openai_system_name,
         openai_message_names,
+        codex_native: false,
     };
 
     Ok(CanonicalRequest {

--- a/src/server/responses_compat/stream.rs
+++ b/src/server/responses_compat/stream.rs
@@ -4,22 +4,57 @@
 //! instead of the `data: {...}` format used by Chat Completions.
 
 use bytes::Bytes;
+use std::collections::HashMap;
 
 use crate::providers::streaming::{parse_sse_events, SseEvent};
+
+#[derive(Debug)]
+enum ActiveOutputItem {
+    Message {
+        item_id: String,
+        output_index: u32,
+        text: String,
+    },
+    FunctionCall {
+        item_id: String,
+        output_index: u32,
+        call_id: String,
+        name: String,
+        arguments: String,
+    },
+}
+
+#[derive(Debug, Default)]
+struct StreamUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+}
+
+impl StreamUsage {
+    fn total_tokens(&self) -> u32 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens(),
+        })
+    }
+}
 
 /// State machine that transforms Anthropic SSE events → Responses API SSE events.
 pub struct AnthropicToResponsesStream {
     response_id: String,
     model: String,
-    output_index: u32,
-    content_index: u32,
-    current_item_id: String,
-    /// Text accumulated for the current message item, replayed in
-    /// `response.output_text.done` (the Responses client expects the full text).
-    current_text: String,
+    next_output_index: u32,
+    /// Active Anthropic content blocks keyed by their `index`.
+    active_items: HashMap<u32, ActiveOutputItem>,
     /// Completed output items, included in the final `response.completed` so the
     /// client can render the assistant message (Codex reads `response.output`).
-    output_items: Vec<serde_json::Value>,
+    output_items: Vec<(u32, serde_json::Value)>,
+    usage: StreamUsage,
 }
 
 impl AnthropicToResponsesStream {
@@ -28,11 +63,10 @@ impl AnthropicToResponsesStream {
         Self {
             response_id: format!("resp_{}", uuid::Uuid::new_v4().simple()),
             model,
-            output_index: 0,
-            content_index: 0,
-            current_item_id: String::new(),
-            current_text: String::new(),
+            next_output_index: 0,
+            active_items: HashMap::new(),
             output_items: Vec::new(),
+            usage: StreamUsage::default(),
         }
     }
 
@@ -69,6 +103,36 @@ impl AnthropicToResponsesStream {
         })
     }
 
+    fn completed_response_object(&self, output: serde_json::Value) -> serde_json::Value {
+        let mut response = self.response_object("completed", output);
+        if let Some(map) = response.as_object_mut() {
+            map.insert("usage".to_string(), self.usage.to_json());
+        }
+        response
+    }
+
+    fn capture_usage(&mut self, data: &str, pointer: &str) {
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(data) else {
+            return;
+        };
+        let Some(usage) = json.pointer(pointer) else {
+            return;
+        };
+
+        if let Some(input) = usage.get("input_tokens").and_then(|v| v.as_u64()) {
+            let input = u32::try_from(input).unwrap_or(u32::MAX);
+            if input > 0 || self.usage.input_tokens == 0 {
+                self.usage.input_tokens = input;
+            }
+        }
+        if let Some(output) = usage.get("output_tokens").and_then(|v| v.as_u64()) {
+            self.usage.output_tokens = self
+                .usage
+                .output_tokens
+                .max(u32::try_from(output).unwrap_or(u32::MAX));
+        }
+    }
+
     /// Formats the `response.created` event emitted at stream start.
     fn make_response_created(&self) -> Bytes {
         let data = serde_json::json!({
@@ -87,17 +151,22 @@ impl AnthropicToResponsesStream {
             return out;
         };
         let cb_type = cb.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let block_index = json
+            .get("index")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(self.next_output_index as u64) as u32;
+        let output_index = self.next_output_index;
+        self.next_output_index += 1;
 
         match cb_type {
             "text" => {
-                self.current_item_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
-                self.content_index = 0;
+                let item_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
 
                 // response.output_item.added (message)
                 let item_added = serde_json::json!({
-                    "output_index": self.output_index,
+                    "output_index": output_index,
                     "item": {
-                        "id": self.current_item_id,
+                        "id": &item_id,
                         "type": "message",
                         "role": "assistant",
                         "content": [],
@@ -106,22 +175,29 @@ impl AnthropicToResponsesStream {
                 });
                 out.push(Self::make_event("response.output_item.added", &item_added));
 
-                self.current_text.clear();
-
                 // response.content_part.added
                 let part_added = serde_json::json!({
-                    "item_id": self.current_item_id,
-                    "output_index": self.output_index,
-                    "content_index": self.content_index,
+                    "item_id": &item_id,
+                    "output_index": output_index,
+                    "content_index": 0,
                     "part": {
                         "type": "output_text",
                         "text": "",
                     }
                 });
                 out.push(Self::make_event("response.content_part.added", &part_added));
+
+                self.active_items.insert(
+                    block_index,
+                    ActiveOutputItem::Message {
+                        item_id,
+                        output_index,
+                        text: String::new(),
+                    },
+                );
             }
             "tool_use" => {
-                self.current_item_id = format!("fc_{}", uuid::Uuid::new_v4().simple());
+                let item_id = format!("fc_{}", uuid::Uuid::new_v4().simple());
                 let call_id = cb
                     .get("id")
                     .and_then(|v| v.as_str())
@@ -132,19 +208,49 @@ impl AnthropicToResponsesStream {
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
+                let initial_arguments = cb
+                    .get("input")
+                    .filter(|v| {
+                        !v.is_null() && !v.as_object().is_some_and(serde_json::Map::is_empty)
+                    })
+                    .and_then(|v| serde_json::to_string(v).ok())
+                    .unwrap_or_default();
 
                 let item_added = serde_json::json!({
-                    "output_index": self.output_index,
+                    "output_index": output_index,
                     "item": {
-                        "id": self.current_item_id,
+                        "id": &item_id,
                         "type": "function_call",
-                        "call_id": call_id,
-                        "name": name,
+                        "call_id": &call_id,
+                        "name": &name,
                         "arguments": "",
                         "status": "in_progress",
                     }
                 });
                 out.push(Self::make_event("response.output_item.added", &item_added));
+
+                if !initial_arguments.is_empty() {
+                    let event_data = serde_json::json!({
+                        "item_id": &item_id,
+                        "output_index": output_index,
+                        "delta": &initial_arguments,
+                    });
+                    out.push(Self::make_event(
+                        "response.function_call_arguments.delta",
+                        &event_data,
+                    ));
+                }
+
+                self.active_items.insert(
+                    block_index,
+                    ActiveOutputItem::FunctionCall {
+                        item_id,
+                        output_index,
+                        call_id,
+                        name,
+                        arguments: initial_arguments,
+                    },
+                );
             }
             _ => {}
         }
@@ -156,27 +262,44 @@ impl AnthropicToResponsesStream {
         let json: serde_json::Value = serde_json::from_str(data).ok()?;
         let delta = json.get("delta")?;
         let delta_type = delta.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let block_index = json.get("index").and_then(|v| v.as_u64())? as u32;
 
-        match delta_type {
-            "text_delta" => {
+        match (delta_type, self.active_items.get_mut(&block_index)?) {
+            (
+                "text_delta",
+                ActiveOutputItem::Message {
+                    item_id,
+                    output_index,
+                    text: current_text,
+                },
+            ) => {
                 let text = delta.get("text").and_then(|v| v.as_str()).unwrap_or("");
-                self.current_text.push_str(text);
+                current_text.push_str(text);
                 let event_data = serde_json::json!({
-                    "item_id": self.current_item_id,
-                    "output_index": self.output_index,
-                    "content_index": self.content_index,
+                    "item_id": &*item_id,
+                    "output_index": *output_index,
+                    "content_index": 0,
                     "delta": text,
                 });
                 Some(Self::make_event("response.output_text.delta", &event_data))
             }
-            "input_json_delta" => {
+            (
+                "input_json_delta",
+                ActiveOutputItem::FunctionCall {
+                    item_id,
+                    output_index,
+                    arguments,
+                    ..
+                },
+            ) => {
                 let partial = delta
                     .get("partial_json")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
+                arguments.push_str(partial);
                 let event_data = serde_json::json!({
-                    "item_id": self.current_item_id,
-                    "output_index": self.output_index,
+                    "item_id": &*item_id,
+                    "output_index": *output_index,
                     "delta": partial,
                 });
                 Some(Self::make_event(
@@ -188,67 +311,99 @@ impl AnthropicToResponsesStream {
         }
     }
 
-    fn handle_content_block_stop(&mut self, _data: &str) -> Vec<Bytes> {
+    fn handle_content_block_stop(&mut self, data: &str) -> Vec<Bytes> {
         let mut out = Vec::new();
-
-        // Determine if this was text or tool_use based on current_item_id prefix
-        if self.current_item_id.starts_with("msg_") {
-            // response.output_text.done — carries the full accumulated text.
-            let text_done = serde_json::json!({
-                "item_id": self.current_item_id,
-                "output_index": self.output_index,
-                "content_index": self.content_index,
-                "text": self.current_text,
-            });
-            out.push(Self::make_event("response.output_text.done", &text_done));
-
-            // response.content_part.done
-            let part_done = serde_json::json!({
-                "item_id": self.current_item_id,
-                "output_index": self.output_index,
-                "content_index": self.content_index,
-                "part": { "type": "output_text", "text": self.current_text },
-            });
-            out.push(Self::make_event("response.content_part.done", &part_done));
-        } else if self.current_item_id.starts_with("fc_") {
-            // response.function_call_arguments.done
-            let args_done = serde_json::json!({
-                "item_id": self.current_item_id,
-                "output_index": self.output_index,
-            });
-            out.push(Self::make_event(
-                "response.function_call_arguments.done",
-                &args_done,
-            ));
-        }
-
-        // Build the completed item once — carried both in `output_item.done` and
-        // in the final `response.output` so the client can render the message.
-        let item = if self.current_item_id.starts_with("fc_") {
-            serde_json::json!({
-                "id": self.current_item_id,
-                "type": "function_call",
-                "status": "completed",
-            })
-        } else {
-            serde_json::json!({
-                "id": self.current_item_id,
-                "type": "message",
-                "role": "assistant",
-                "status": "completed",
-                "content": [{ "type": "output_text", "text": self.current_text }],
-            })
+        let json: serde_json::Value = match serde_json::from_str(data) {
+            Ok(v) => v,
+            Err(_) => return out,
+        };
+        let Some(block_index) = json.get("index").and_then(|v| v.as_u64()).map(|v| v as u32) else {
+            return out;
+        };
+        let Some(item_state) = self.active_items.remove(&block_index) else {
+            return out;
         };
 
-        let item_done = serde_json::json!({
-            "output_index": self.output_index,
-            "item": item.clone(),
-        });
-        out.push(Self::make_event("response.output_item.done", &item_done));
-        self.output_items.push(item);
+        match item_state {
+            ActiveOutputItem::Message {
+                item_id,
+                output_index,
+                text,
+            } => {
+                // response.output_text.done — carries the full accumulated text.
+                let text_done = serde_json::json!({
+                    "item_id": &item_id,
+                    "output_index": output_index,
+                    "content_index": 0,
+                    "text": &text,
+                });
+                out.push(Self::make_event("response.output_text.done", &text_done));
 
-        self.output_index += 1;
-        self.current_text.clear();
+                // response.content_part.done
+                let part_done = serde_json::json!({
+                    "item_id": &item_id,
+                    "output_index": output_index,
+                    "content_index": 0,
+                    "part": { "type": "output_text", "text": &text },
+                });
+                out.push(Self::make_event("response.content_part.done", &part_done));
+
+                let item = serde_json::json!({
+                    "id": item_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{ "type": "output_text", "text": text }],
+                });
+                let item_done = serde_json::json!({
+                    "output_index": output_index,
+                    "item": item.clone(),
+                });
+                out.push(Self::make_event("response.output_item.done", &item_done));
+                self.output_items.push((output_index, item));
+            }
+            ActiveOutputItem::FunctionCall {
+                item_id,
+                output_index,
+                call_id,
+                name,
+                arguments,
+            } => {
+                let arguments = if arguments.is_empty() {
+                    "{}".to_string()
+                } else {
+                    arguments
+                };
+
+                // Codex finalizes the tool call from this event, so include the
+                // consolidated arguments, not just the item/index identifiers.
+                let args_done = serde_json::json!({
+                    "item_id": &item_id,
+                    "output_index": output_index,
+                    "arguments": &arguments,
+                });
+                out.push(Self::make_event(
+                    "response.function_call_arguments.done",
+                    &args_done,
+                ));
+
+                let item = serde_json::json!({
+                    "id": item_id,
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": arguments,
+                    "status": "completed",
+                });
+                let item_done = serde_json::json!({
+                    "output_index": output_index,
+                    "item": item.clone(),
+                });
+                out.push(Self::make_event("response.output_item.done", &item_done));
+                self.output_items.push((output_index, item));
+            }
+        }
+
         out
     }
 
@@ -260,6 +415,7 @@ impl AnthropicToResponsesStream {
 
         match event_type {
             "message_start" => {
+                self.capture_usage(&event.data, "/message/usage");
                 let in_progress = serde_json::json!({
                     "response": self.response_object("in_progress", serde_json::json!([])),
                 });
@@ -274,10 +430,18 @@ impl AnthropicToResponsesStream {
                 .into_iter()
                 .collect(),
             "content_block_stop" => self.handle_content_block_stop(&event.data),
+            "message_delta" => {
+                self.capture_usage(&event.data, "/usage");
+                Vec::new()
+            }
             "message_stop" => {
-                let output = serde_json::Value::Array(std::mem::take(&mut self.output_items));
+                let mut output_items = std::mem::take(&mut self.output_items);
+                output_items.sort_by_key(|(idx, _)| *idx);
+                let output = serde_json::Value::Array(
+                    output_items.into_iter().map(|(_, item)| item).collect(),
+                );
                 let completed =
-                    serde_json::json!({ "response": self.response_object("completed", output) });
+                    serde_json::json!({ "response": self.completed_response_object(output) });
                 vec![
                     Self::make_event("response.completed", &completed),
                     Bytes::from("data: [DONE]\n\n"),
@@ -307,6 +471,27 @@ impl AnthropicToResponsesStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn event(event: &str, data: &str) -> SseEvent {
+        SseEvent {
+            event: Some(event.to_string()),
+            data: data.to_string(),
+        }
+    }
+
+    fn append_events(out: &mut String, events: Vec<Bytes>) {
+        for bytes in events {
+            out.push_str(std::str::from_utf8(&bytes).unwrap());
+        }
+    }
+
+    fn json_events(output: &str, event_name: &str) -> Vec<serde_json::Value> {
+        parse_sse_events(output)
+            .into_iter()
+            .filter(|event| event.event.as_deref() == Some(event_name))
+            .map(|event| serde_json::from_str(&event.data).unwrap())
+            .collect()
+    }
 
     #[test]
     fn message_start_emits_response_created() {
@@ -347,6 +532,13 @@ mod tests {
     #[test]
     fn text_delta_emits_output_text_delta() {
         let mut stream = AnthropicToResponsesStream::new("gpt-5.4".to_string());
+        let start = SseEvent {
+            event: Some("content_block_start".to_string()),
+            data: r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#
+                .to_string(),
+        };
+        stream.transform_event(&start);
+
         let event = SseEvent {
             event: Some("content_block_delta".to_string()),
             data: r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#
@@ -388,6 +580,73 @@ mod tests {
     }
 
     #[test]
+    fn message_then_tool_call_preserves_arguments_in_done_and_completed() {
+        let mut stream = AnthropicToResponsesStream::new("gpt-5.5".to_string());
+        let mut out = String::new();
+
+        for ev in [
+            event(
+                "message_start",
+                r#"{"type":"message_start","message":{"id":"msg_1","model":"gpt-5.5"}}"#,
+            ),
+            event(
+                "content_block_start",
+                r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+            ),
+            event(
+                "content_block_delta",
+                r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'll run that."}}"#,
+            ),
+            event(
+                "content_block_stop",
+                r#"{"type":"content_block_stop","index":0}"#,
+            ),
+            event(
+                "content_block_start",
+                r#"{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call_exec","name":"exec_command","input":{}}}"#,
+            ),
+            event(
+                "content_block_delta",
+                r#"{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"cmd\":\""}}"#,
+            ),
+            event(
+                "content_block_delta",
+                r#"{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"ls\"}"}}"#,
+            ),
+            event(
+                "content_block_stop",
+                r#"{"type":"content_block_stop","index":1}"#,
+            ),
+            event("message_stop", r#"{"type":"message_stop"}"#),
+        ] {
+            append_events(&mut out, stream.transform_event(&ev));
+        }
+
+        let args_done = json_events(&out, "response.function_call_arguments.done");
+        assert_eq!(args_done.len(), 1);
+        assert_eq!(args_done[0]["output_index"], 1);
+        assert_eq!(args_done[0]["arguments"], r#"{"cmd":"ls"}"#);
+
+        let tool_done = json_events(&out, "response.output_item.done")
+            .into_iter()
+            .find(|event| event["item"]["type"] == "function_call")
+            .expect("function_call output_item.done");
+        assert_eq!(tool_done["output_index"], 1);
+        assert_eq!(tool_done["item"]["call_id"], "call_exec");
+        assert_eq!(tool_done["item"]["name"], "exec_command");
+        assert_eq!(tool_done["item"]["arguments"], r#"{"cmd":"ls"}"#);
+
+        let completed = json_events(&out, "response.completed")
+            .pop()
+            .expect("response.completed");
+        let output = completed["response"]["output"].as_array().unwrap();
+        assert_eq!(output[0]["type"], "message");
+        assert_eq!(output[1]["type"], "function_call");
+        assert_eq!(output[1]["call_id"], "call_exec");
+        assert_eq!(output[1]["arguments"], r#"{"cmd":"ls"}"#);
+    }
+
+    #[test]
     fn message_stop_emits_completed_and_done() {
         let mut stream = AnthropicToResponsesStream::new("gpt-5.4".to_string());
         let event = SseEvent {
@@ -400,5 +659,32 @@ mod tests {
         let s1 = std::str::from_utf8(&result[1]).unwrap();
         assert!(s0.contains("response.completed"));
         assert!(s1.contains("[DONE]"));
+    }
+
+    #[test]
+    fn response_completed_includes_usage_from_message_delta() {
+        let mut stream = AnthropicToResponsesStream::new("gpt-5.5".to_string());
+        let mut out = String::new();
+
+        for ev in [
+            event(
+                "message_start",
+                r#"{"type":"message_start","message":{"usage":{"input_tokens":123,"output_tokens":0}}}"#,
+            ),
+            event(
+                "message_delta",
+                r#"{"type":"message_delta","usage":{"input_tokens":456,"output_tokens":78}}"#,
+            ),
+            event("message_stop", r#"{"type":"message_stop"}"#),
+        ] {
+            append_events(&mut out, stream.transform_event(&ev));
+        }
+
+        let completed = json_events(&out, "response.completed")
+            .pop()
+            .expect("response.completed");
+        assert_eq!(completed["response"]["usage"]["input_tokens"], 456);
+        assert_eq!(completed["response"]["usage"]["output_tokens"], 78);
+        assert_eq!(completed["response"]["usage"]["total_tokens"], 534);
     }
 }

--- a/src/server/responses_compat/transform.rs
+++ b/src/server/responses_compat/transform.rs
@@ -25,6 +25,8 @@ fn extract_input_text(content: &InputContent) -> String {
             .iter()
             .map(|p| match p {
                 InputContentPart::InputText { text } => text.as_str(),
+                InputContentPart::OutputText { text } => text.as_str(),
+                InputContentPart::Other => "",
             })
             .collect::<Vec<_>>()
             .join("\n"),
@@ -203,6 +205,14 @@ pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<Canonic
                             });
                         }
                     }
+                    InputItem::Reasoning { .. } => {
+                        // Model's internal reasoning trace: not part of the
+                        // canonical conversation; intentionally dropped.
+                    }
+                    InputItem::Other => {
+                        // Unmodelled item type (e.g. local_shell_call); skipped
+                        // for forward compatibility with richer Codex payloads.
+                    }
                 }
             }
         }
@@ -216,6 +226,9 @@ pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<Canonic
         reasoning_effort: req.reasoning.as_ref().and_then(|r| r.effort.clone()),
         parallel_tool_calls: req.parallel_tool_calls,
         service_tier: req.service_tier,
+        // This path only runs for Codex CLI (Responses API) requests, so its
+        // `instructions` are the authoritative Codex agent prompt.
+        codex_native: true,
         ..Default::default()
     };
 
@@ -378,6 +391,58 @@ mod tests {
         assert_eq!(canonical.messages[0].role, "user");
         assert_eq!(canonical.messages[1].role, "assistant");
         assert_eq!(canonical.messages[2].role, "user");
+    }
+
+    #[test]
+    fn codex_multiturn_items_are_tolerated_and_marked_native() {
+        let req: ResponsesRequest = serde_json::from_value(serde_json::json!({
+            "model": "gpt-5.5",
+            "instructions": "Codex agent prompt",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": []
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        { "type": "output_text", "text": "Previously said." }
+                    ]
+                },
+                {
+                    "type": "local_shell_call",
+                    "id": "call_local"
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        { "type": "input_text", "text": "Continue." }
+                    ]
+                }
+            ],
+            "reasoning": { "effort": "xhigh" },
+            "parallel_tool_calls": true,
+            "service_tier": "priority"
+        }))
+        .unwrap();
+
+        let canonical = transform_responses_to_canonical(req).unwrap();
+        assert!(canonical.extensions.codex_native);
+        assert_eq!(
+            canonical.extensions.reasoning_effort.as_deref(),
+            Some("xhigh")
+        );
+        assert_eq!(canonical.extensions.parallel_tool_calls, Some(true));
+        assert_eq!(
+            canonical.extensions.service_tier.as_deref(),
+            Some("priority")
+        );
+        assert_eq!(canonical.messages.len(), 2);
+        assert_eq!(canonical.messages[0].role, "assistant");
+        assert_eq!(canonical.messages[1].role, "user");
     }
 
     #[test]

--- a/src/server/responses_compat/types.rs
+++ b/src/server/responses_compat/types.rs
@@ -95,6 +95,20 @@ pub enum InputItem {
         /// Function execution result as a string.
         output: String,
     },
+    /// Model reasoning trace echoed back on multi-turn requests (Codex, o-series).
+    ///
+    /// Carries the model's internal chain-of-thought, not user-visible content,
+    /// so it is dropped when mapping to the canonical conversation.
+    #[serde(rename = "reasoning")]
+    Reasoning {
+        /// Reasoning item identifier (e.g. "rs_..."); other fields are ignored.
+        #[serde(default)]
+        id: Option<String>,
+    },
+    /// Any other item type (e.g. `local_shell_call`) the canonical format does
+    /// not model. Tolerated and skipped so multi-turn Codex payloads do not 422.
+    #[serde(other)]
+    Other,
 }
 
 /// Content of an input message: plain text or structured parts.
@@ -117,6 +131,16 @@ pub enum InputContentPart {
         /// The text content.
         text: String,
     },
+    /// Assistant output text echoed back on multi-turn requests (Codex).
+    #[serde(rename = "output_text")]
+    OutputText {
+        /// The previously generated assistant text.
+        text: String,
+    },
+    /// Any other content part type (e.g. `input_image`) not modelled here.
+    /// Tolerated and skipped so multi-turn Codex payloads do not 422.
+    #[serde(other)]
+    Other,
 }
 
 /// Reasoning configuration for o-series and thinking models.

--- a/src/shared/message_tracing/mod.rs
+++ b/src/shared/message_tracing/mod.rs
@@ -6,6 +6,7 @@
 use crate::cli::TracingConfig;
 use crate::models::{CanonicalRequest, RouteType};
 use crate::providers::ProviderResponse;
+use crate::traits::StreamTraceUsage;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use std::fs::{self, File, OpenOptions};
@@ -48,6 +49,35 @@ struct ResponseTrace {
     input_tokens: u32,
     output_tokens: u32,
     content: serde_json::Value,
+}
+
+/// A trace entry for a streamed response chunk.
+#[derive(Serialize)]
+struct StreamChunkTrace {
+    ts: DateTime<Utc>,
+    dir: &'static str,
+    id: String,
+    seq: u64,
+    bytes: usize,
+    data: String,
+}
+
+/// A trace entry for streamed response completion.
+#[derive(Serialize)]
+struct StreamEndTrace {
+    ts: DateTime<Utc>,
+    dir: &'static str,
+    id: String,
+    chunks: u64,
+    bytes: usize,
+    latency_ms: u64,
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total_tokens: Option<u32>,
 }
 
 /// A trace entry for an error
@@ -226,6 +256,54 @@ impl MessageTracer {
         self.write_trace(&trace, file_mutex);
     }
 
+    /// Traces one streamed response chunk.
+    pub fn trace_stream_chunk(&self, id: &str, seq: u64, chunk: &[u8]) {
+        let Some(ref file_mutex) = self.file else {
+            return;
+        };
+
+        let trace = StreamChunkTrace {
+            ts: Utc::now(),
+            dir: "res_chunk",
+            id: id.to_string(),
+            seq,
+            bytes: chunk.len(),
+            data: String::from_utf8_lossy(chunk).into_owned(),
+        };
+
+        self.write_trace(&trace, file_mutex);
+    }
+
+    /// Traces streamed response completion.
+    pub fn trace_stream_end(
+        &self,
+        id: &str,
+        chunk_count: u64,
+        byte_count: usize,
+        latency_ms: u64,
+        status: &str,
+        usage: Option<StreamTraceUsage>,
+    ) {
+        let Some(ref file_mutex) = self.file else {
+            return;
+        };
+
+        let trace = StreamEndTrace {
+            ts: Utc::now(),
+            dir: "res_end",
+            id: id.to_string(),
+            chunks: chunk_count,
+            bytes: byte_count,
+            latency_ms,
+            status: status.to_string(),
+            input_tokens: usage.map(|u| u.input_tokens),
+            output_tokens: usage.map(|u| u.output_tokens),
+            total_tokens: usage.map(StreamTraceUsage::total_tokens),
+        };
+
+        self.write_trace(&trace, file_mutex);
+    }
+
     /// Returns `true` when tracing is active (the trace file is open).
     pub fn is_enabled(&self) -> bool {
         self.file.is_some()
@@ -315,6 +393,22 @@ impl crate::traits::Tracer for MessageTracer {
         latency_ms: u64,
     ) {
         self.trace_response(id, response, latency_ms);
+    }
+
+    fn trace_stream_chunk(&self, id: &str, seq: u64, chunk: &[u8]) {
+        self.trace_stream_chunk(id, seq, chunk);
+    }
+
+    fn trace_stream_end(
+        &self,
+        id: &str,
+        chunk_count: u64,
+        byte_count: usize,
+        latency_ms: u64,
+        status: &str,
+        usage: Option<StreamTraceUsage>,
+    ) {
+        self.trace_stream_end(id, chunk_count, byte_count, latency_ms, status, usage);
     }
 
     fn trace_error(&self, id: &str, error: &str) {

--- a/src/shared/pid.rs
+++ b/src/shared/pid.rs
@@ -58,9 +58,39 @@ pub fn cleanup_pid() -> io::Result<()> {
     Ok(())
 }
 
-/// Check if a grob process is running at the given PID.
-/// On Linux, additionally verifies via /proc that the process is actually grob
-/// (guards against stale PID files after PID reuse).
+/// Removes the PID file only if it still belongs to the current process.
+///
+/// Hot upgrades briefly run two Grob processes on the same port. The new process
+/// writes its PID before the old process finishes draining, so shutdown cleanup
+/// must not blindly delete a PID file that has already been claimed by the new
+/// instance.
+pub fn cleanup_pid_if_current() -> io::Result<()> {
+    let pid_file = pid_file_path();
+    let current_pid = std::process::id();
+
+    match read_pid() {
+        Ok(pid) if pid == current_pid => {
+            fs::remove_file(&pid_file)?;
+            tracing::info!("PID file removed: {:?}", pid_file);
+        }
+        Ok(pid) => {
+            tracing::debug!(
+                "PID file {:?} belongs to {}, not {}; leaving it in place",
+                pid_file,
+                pid,
+                current_pid
+            );
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+
+    Ok(())
+}
+
+/// Check if a Grob process is running at the given PID.
+/// On Unix platforms, additionally verifies the command identity where the OS
+/// exposes it (guards against stale PID files after PID reuse).
 #[cfg(feature = "unix-signals")]
 pub fn is_process_running(pid: u32) -> bool {
     use nix::sys::signal::kill;
@@ -71,20 +101,60 @@ pub fn is_process_running(pid: u32) -> bool {
         return false;
     }
 
-    // On Linux, verify cmdline contains "grob" to detect PID reuse
     #[cfg(target_os = "linux")]
     {
         let cmdline_path = format!("/proc/{}/cmdline", pid);
         if let Ok(cmdline) = fs::read(&cmdline_path) {
-            // /proc/*/cmdline uses NUL separators; convert to readable string
             let cmdline_str = String::from_utf8_lossy(&cmdline);
-            if !cmdline_str.contains("grob") {
+            if !command_invokes_grob(&cmdline_str) {
                 return false;
             }
+        } else {
+            return false;
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let output = std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "command="])
+            .output();
+        match output {
+            Ok(output) if output.status.success() => {
+                let command = String::from_utf8_lossy(&output.stdout);
+                if !command_invokes_grob(&command) {
+                    return false;
+                }
+            }
+            _ => return false,
         }
     }
 
     true
+}
+
+#[cfg(feature = "unix-signals")]
+fn command_invokes_grob(command: &str) -> bool {
+    let first_arg = command
+        .split('\0')
+        .find(|part| !part.trim().is_empty())
+        .or_else(|| command.split_whitespace().next())
+        .unwrap_or_default()
+        .trim();
+    let executable = std::path::Path::new(first_arg)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(first_arg);
+
+    if executable == "grob" {
+        return true;
+    }
+
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.file_name().map(|name| name.to_owned()))
+        .and_then(|name| name.to_str().map(str::to_owned))
+        .is_some_and(|current| executable == current)
 }
 
 /// Fallback when nix is unavailable: only our own PID is considered valid.
@@ -105,5 +175,20 @@ pub fn is_process_running(pid: u32) -> bool {
             !stdout.contains("No tasks")
         }
         Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "unix-signals")]
+    use super::command_invokes_grob;
+
+    #[cfg(feature = "unix-signals")]
+    #[test]
+    fn command_identity_accepts_only_grob_executable() {
+        assert!(command_invokes_grob("/Users/me/bin/grob\0start\0"));
+        assert!(!command_invokes_grob("/tmp/grob-upgrade --config x"));
+        assert!(!command_invokes_grob("/usr/bin/python /tmp/grob.py"));
+        assert!(!command_invokes_grob("/usr/bin/agrob-helper"));
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -98,6 +98,23 @@ pub trait RequestRouter: Send + Sync {
 
 // ── Tracer ──
 
+/// Provider-reported token usage observed at the end of a streamed response.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StreamTraceUsage {
+    /// Tokens consumed by the request input.
+    pub input_tokens: u32,
+    /// Tokens produced by the streamed response.
+    pub output_tokens: u32,
+}
+
+impl StreamTraceUsage {
+    /// Returns `input_tokens + output_tokens`, saturating on overflow.
+    #[must_use]
+    pub fn total_tokens(self) -> u32 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+}
+
 /// Traces requests/responses to a persistent log.
 pub trait Tracer: Send + Sync {
     /// Generates a new trace identifier.
@@ -115,6 +132,21 @@ pub trait Tracer: Send + Sync {
 
     /// Records a response trace entry.
     fn trace_response(&self, id: &str, response: &ProviderResponse, latency_ms: u64);
+
+    /// Records one streamed response chunk exactly as it is sent to the client.
+    fn trace_stream_chunk(&self, _id: &str, _seq: u64, _chunk: &[u8]) {}
+
+    /// Records streamed response completion.
+    fn trace_stream_end(
+        &self,
+        _id: &str,
+        _chunk_count: u64,
+        _byte_count: usize,
+        _latency_ms: u64,
+        _status: &str,
+        _usage: Option<StreamTraceUsage>,
+    ) {
+    }
 
     /// Records an error trace entry.
     fn trace_error(&self, id: &str, error: &str);


### PR DESCRIPTION
## Summary
- preserve OpenAI Responses/Codex stream metadata and tool-call events through Grob
- trace /v1/responses sessions with real request ids so trace.jsonl is populated
- normalize Claude Code Read tool arguments from Codex streams, including pages, offset, and limit
- harden hot upgrade/pid handling and provider retry behavior touched by the debug session

## Checks
- cargo fmt --all -- --check
- git diff --check
- cargo test --lib read_tool_
- cargo test --lib --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- pre-commit hooks on commit and push