### PR TITLE
chore: release v0.36.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.67](https://github.com/azerozero/grob/compare/v0.36.66...v0.36.67) - 2026-06-04
+
+### Fixed
+
+- *(openai)* preserve codex streams through grob
+
+### Other
+
+- exclude flaky public.cyber.mil link from lychee check
+- don't block Required checks / test gate on cancelled jobs
+
 ## [0.36.66](https://github.com/azerozero/grob/compare/v0.36.65...v0.36.66) - 2026-06-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.66"
+version = "0.36.67"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.66"
+version = "0.36.67"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.66 -> 0.36.67

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.67](https://github.com/azerozero/grob/compare/v0.36.66...v0.36.67) - 2026-06-04

### Fixed

- *(openai)* preserve codex streams through grob

### Other

- exclude flaky public.cyber.mil link from lychee check
- don't block Required checks / test gate on cancelled jobs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).