### PR TITLE
fix(deny): replace stale rustls-pemfile ignore with proc-macro-error2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,18 +6,19 @@
 [advisories]
 version = 2
 # Fail CI on any known vulnerability.
-# Review date: 2026-04-15 — re-check if upstream fixed these.
+# Review date: 2026-06-08 — re-check if upstream fixed these.
 #
-# rustls-pemfile: unmaintained, pulled by axum-server. Use rustls-pki-types
-# PemObject API when axum-server drops this dep.
 # rsa: Marvin Attack (timing sidechannel on PKCS#1 v1.5 decryption). No impact:
 # grob only uses RSA for JWT signature verification, not decryption.
 ignore = [
     "RUSTSEC-2023-0071",
-    "RUSTSEC-2025-0134",
     # rand: Unsound with custom logger calling rand::rng() (RUSTSEC-2026-0097).
     # No impact: grob does not define a custom logger accessing ThreadRng.
     "RUSTSEC-2026-0097",
+    # proc-macro-error2: unmaintained build-time proc-macro, pulled transitively
+    # via age → i18n-embed-fl. Compile-time only (not in the runtime binary), no
+    # safe upgrade available. Drop when age/i18n-embed-fl migrate off it.
+    "RUSTSEC-2026-0173",
 ]
 
 # ── Licenses ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`cargo deny check` (the pre-push hook) was failing on a freshly published advisory, forcing `--no-verify` on every push.

- **Add `RUSTSEC-2026-0173`** (proc-macro-error2 unmaintained) to the advisory ignore list. Build-time proc-macro pulled transitively via `age → i18n-embed-fl`, compile-time only (not in the runtime binary), no safe upgrade available — same rationale as the existing unmaintained-dep ignores.
- **Drop the stale `RUSTSEC-2025-0134`** (rustls-pemfile) ignore: the crate left the dependency tree, so the advisory no longer matches any crate (it was only an `advisory-not-detected` warning).

## Verification

`cargo deny check` → exit 0 (advisories, licenses, bans, sources). Pre-push hook green without `--no-verify`.