### PR TITLE
fix(deny): re-add the rustls-pemfile unmaintained ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,11 @@ ignore = [
     # via age → i18n-embed-fl. Compile-time only (not in the runtime binary), no
     # safe upgrade available. Drop when age/i18n-embed-fl migrate off it.
     "RUSTSEC-2026-0173",
+    # rustls-pemfile: unmaintained (PEM parsing folded into rustls-pki-types).
+    # Pulled transitively via axum-server and rustls-acme; certificate/key PEM
+    # parsing only, no security vulnerability. Surfaces under `--all-features`
+    # (the CI cargo-deny invocation). Drop when those migrate off it.
+    "RUSTSEC-2025-0134",
 ]
 
 # ── Licenses ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
RUSTSEC-2025-0134 resurfaces under `--all-features`: `axum-server` and `rustls-acme` pull `rustls-pemfile` 2.2.0, flagged unmaintained with no safe upgrade available.

The ignore was dropped as stale in #409, but `deny.toml` is not covered by the CI path filters, so the Cargo Deny job was skipped on that PR and the removal was never actually verified. Verified locally on the current tree:

- `cargo deny --all-features check advisories` **without** the ignore → `advisories FAILED` (rustls-pemfile 2.2.0 via axum-server / rustls-acme)
- **with** the ignore → `advisories ok`

Re-adding it keeps cargo-deny green for the next rust-touching PR, and aligns `deny.toml` with #410, clearing its merge conflict.