### PR TITLE
chore: release v0.36.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.68](https://github.com/azerozero/grob/compare/v0.36.67...v0.36.68) - 2026-06-12
+
+### Added
+
+- *(auth)* adopt OAuth credentials from co-installed CLIs
+
+### Fixed
+
+- *(deny)* sync advisory ignores with main
+- *(auth)* gate the Claude keychain helpers to macOS
+
 ## [0.36.67](https://github.com/azerozero/grob/compare/v0.36.66...v0.36.67) - 2026-06-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.67"
+version = "0.36.68"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.67"
+version = "0.36.68"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.67 -> 0.36.68

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.68](https://github.com/azerozero/grob/compare/v0.36.67...v0.36.68) - 2026-06-12

### Added

- *(auth)* adopt OAuth credentials from co-installed CLIs

### Fixed

- *(deny)* sync advisory ignores with main
- *(auth)* gate the Claude keychain helpers to macOS
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).