### PR TITLE
chore: release v0.36.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.69](https://github.com/azerozero/grob/compare/v0.36.68...v0.36.69) - 2026-06-12
+
+### Fixed
+
+- *(openai)* codex streaming arg routing + SSE/routing/cache fixes + cli-cycle quality pass + cache-read pricing & tier-model validation ([#410](https://github.com/azerozero/grob/pull/410))
+
 ## [0.36.68](https://github.com/azerozero/grob/compare/v0.36.67...v0.36.68) - 2026-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.68"
+version = "0.36.69"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.68"
+version = "0.36.69"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.68 -> 0.36.69

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.69](https://github.com/azerozero/grob/compare/v0.36.68...v0.36.69) - 2026-06-12

### Fixed

- *(openai)* codex streaming arg routing + SSE/routing/cache fixes + cli-cycle quality pass + cache-read pricing & tier-model validation ([#410](https://github.com/azerozero/grob/pull/410))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).