### PR TITLE
feat(cli): expose credential adoption as --adopt-from-system

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -122,6 +122,13 @@ pub enum Commands {
         /// Internal: allow binding beside an existing SO_REUSEPORT listener.
         #[arg(long, hide = true)]
         hot_upgrade: bool,
+        /// Adopt and self-heal OAuth tokens from co-installed CLIs (Codex,
+        /// Claude Code), as if `[auth] adopt_from_system = true`.
+        ///
+        /// Applies to this invocation only; `grob restart` falls back to the
+        /// config file value.
+        #[arg(long)]
+        adopt_from_system: bool,
     },
     /// Stop the router service
     Stop,
@@ -159,6 +166,10 @@ pub enum Commands {
         /// Emit structured JSON logs instead of human-readable
         #[arg(long, env = "GROB_JSON_LOGS")]
         json_logs: bool,
+        /// Adopt and self-heal OAuth tokens from co-installed CLIs (Codex,
+        /// Claude Code), as if `[auth] adopt_from_system = true` (env: GROB_ADOPT_FROM_SYSTEM)
+        #[arg(long, env = "GROB_ADOPT_FROM_SYSTEM")]
+        adopt_from_system: bool,
     },
     /// Launch a command behind the Grob proxy (auto-starts/stops service)
     ///
@@ -178,6 +189,12 @@ pub enum Commands {
         /// Keep Grob running after the child command exits
         #[arg(long)]
         no_stop: bool,
+        /// Adopt and self-heal OAuth tokens from co-installed CLIs (Codex,
+        /// Claude Code) in the proxy started for this exec.
+        ///
+        /// No effect when an already-running instance is reused.
+        #[arg(long)]
+        adopt_from_system: bool,
         /// Command and arguments to execute behind the proxy
         #[arg(last = true, required = true)]
         cmd: Vec<String>,

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -173,6 +173,7 @@ fn daemon_command_args(
     port: Option<u16>,
     config: Option<String>,
     hot_upgrade: bool,
+    adopt_from_system: bool,
 ) -> Vec<String> {
     let mut args = Vec::new();
     if let Some(config) = config {
@@ -187,6 +188,9 @@ fn daemon_command_args(
     if hot_upgrade {
         args.push("--hot-upgrade".to_string());
     }
+    if adopt_from_system {
+        args.push("--adopt-from-system".to_string());
+    }
     args
 }
 
@@ -199,28 +203,38 @@ fn daemon_command_args(
 pub fn spawn_background_service(
     port: Option<u16>,
     config: Option<String>,
+    adopt_from_system: bool,
 ) -> anyhow::Result<Option<std::path::PathBuf>> {
-    spawn_background_service_with_mode(port, config, false)
+    spawn_background_service_with_mode(port, config, false, adopt_from_system)
 }
 
 /// Spawns a detached daemon for zero-downtime upgrade.
+///
+/// The upgraded daemon re-reads the config file, so credential adoption
+/// follows `[auth] adopt_from_system` rather than any per-invocation flag.
 pub fn spawn_upgrade_background_service(
     port: Option<u16>,
     config: Option<String>,
 ) -> anyhow::Result<Option<std::path::PathBuf>> {
-    spawn_background_service_with_mode(port, config, true)
+    spawn_background_service_with_mode(port, config, true, false)
 }
 
 fn spawn_background_service_with_mode(
     port: Option<u16>,
     config: Option<String>,
     hot_upgrade: bool,
+    adopt_from_system: bool,
 ) -> anyhow::Result<Option<std::path::PathBuf>> {
     use std::process::Stdio;
 
     let exe_path = std::env::current_exe()?;
     let mut cmd = Command::new(&exe_path);
-    cmd.args(daemon_command_args(port, config, hot_upgrade));
+    cmd.args(daemon_command_args(
+        port,
+        config,
+        hot_upgrade,
+        adopt_from_system,
+    ));
 
     #[cfg(all(unix, feature = "unix-signals"))]
     {
@@ -292,7 +306,12 @@ mod tests {
 
     #[test]
     fn daemon_args_with_config_parse_back_into_clap() {
-        let args = daemon_command_args(Some(13456), Some("/tmp/grob.toml".to_string()), false);
+        let args = daemon_command_args(
+            Some(13456),
+            Some("/tmp/grob.toml".to_string()),
+            false,
+            false,
+        );
 
         // The global flag must precede the subcommand.
         let start_idx = args.iter().position(|a| a == "start").unwrap();
@@ -309,14 +328,15 @@ mod tests {
             Some(Commands::Start {
                 port: Some(13456),
                 detach: false,
-                hot_upgrade: false
+                hot_upgrade: false,
+                adopt_from_system: false
             })
         ));
     }
 
     #[test]
     fn daemon_args_without_config_parse_back_into_clap() {
-        let args = daemon_command_args(None, None, false);
+        let args = daemon_command_args(None, None, false, false);
         let cli = parse(&args);
         assert_eq!(cli.config, None);
         assert!(matches!(
@@ -326,8 +346,22 @@ mod tests {
     }
 
     #[test]
+    fn daemon_args_forward_adopt_from_system_to_the_child() {
+        let args = daemon_command_args(None, None, false, true);
+        let cli = parse(&args);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Start {
+                adopt_from_system: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn daemon_args_for_upgrade_parse_with_hot_upgrade_flag() {
-        let args = daemon_command_args(Some(13456), Some("/tmp/grob.toml".to_string()), true);
+        let args =
+            daemon_command_args(Some(13456), Some("/tmp/grob.toml".to_string()), true, false);
         assert!(args.iter().any(|arg| arg == "--hot-upgrade"));
 
         let cli = parse(&args);
@@ -337,7 +371,8 @@ mod tests {
             Some(Commands::Start {
                 port: Some(13456),
                 detach: false,
-                hot_upgrade: true
+                hot_upgrade: true,
+                adopt_from_system: false
             })
         ));
     }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -7,6 +7,7 @@ pub async fn cmd_exec(
     config: &cli::AppConfig,
     port: Option<u16>,
     no_stop: bool,
+    adopt_from_system: bool,
     cmd: Vec<String>,
     cli_config: Option<String>,
 ) -> anyhow::Result<()> {
@@ -47,7 +48,8 @@ pub async fn cmd_exec(
             eprintln!("✅ Grob already running on port {}", effective_port);
         } else {
             eprintln!("Starting Grob on port {}...", effective_port);
-            let log_path = spawn_background_service(Some(effective_port), cli_config)?;
+            let log_path =
+                spawn_background_service(Some(effective_port), cli_config, adopt_from_system)?;
 
             if !poll_health(&base_url, HEALTH_POLL_MAX_ATTEMPTS, HEALTH_POLL_INTERVAL_MS).await {
                 eprintln!("❌ Grob failed to start within 5 seconds");

--- a/src/commands/restart.rs
+++ b/src/commands/restart.rs
@@ -41,7 +41,9 @@ pub async fn cmd_restart(
     if detach {
         println!("Starting service in background...");
         let port_from_config = Some(config.server.port.value());
-        let log_path = spawn_background_service(port_from_config, cli_config)?;
+        // Restart is config-driven: credential adoption follows the config
+        // file, not a remembered per-invocation flag.
+        let log_path = spawn_background_service(port_from_config, cli_config, false)?;
         let base_url = cli::format_base_url(&config.server.host, config.server.port.value());
 
         let verb = if was_running { "restarted" } else { "started" };

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -6,11 +6,15 @@ pub async fn cmd_run(
     config_source: cli::ConfigSource,
     port: Option<u16>,
     host: Option<String>,
+    adopt_from_system: bool,
 ) -> anyhow::Result<()> {
     if let Some(port) = port {
         config.server.port = Port::new(port).expect("valid port");
     }
     config.server.host = host.unwrap_or_else(|| "::".to_string());
+    if adopt_from_system {
+        config.auth.adopt_from_system = true;
+    }
 
     tracing::info!(
         "🐳 Container mode: {}:{}",

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -19,13 +19,20 @@ const MODEL_HINTS: &[(&str, &str)] = &[
 
 /// Starts the Grob service in foreground or detached background mode.
 pub async fn cmd_start(
-    config: cli::AppConfig,
+    mut config: cli::AppConfig,
     config_source: cli::ConfigSource,
     port: Option<u16>,
     detach: bool,
     cli_config: Option<String>,
     hot_upgrade: bool,
+    adopt_from_system: bool,
 ) -> anyhow::Result<()> {
+    // The flag covers the foreground path here; the detached child re-reads
+    // the config file, so the spawn below forwards it as argv instead.
+    if adopt_from_system {
+        config.auth.adopt_from_system = true;
+    }
+
     print_startup_warnings(&config);
 
     let effective_port = port.unwrap_or(config.server.port.value());
@@ -49,7 +56,7 @@ pub async fn cmd_start(
         }
         instance::cleanup_legacy_pid();
 
-        let log_path = spawn_background_service(port, cli_config)?;
+        let log_path = spawn_background_service(port, cli_config, adopt_from_system)?;
         let base_url = cli::format_base_url(&config.server.host, effective_port);
 
         // Wait for the listener to actually accept /health before claiming

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -153,7 +153,7 @@ async fn cmd_upgrade_windows(
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
     }
 
-    spawn_background_service(Some(config.server.port.value()), cli_config.clone())?;
+    spawn_background_service(Some(config.server.port.value()), cli_config.clone(), false)?;
     println!("   Spawned new process, waiting for health...");
 
     if !poll_health(base_url, HEALTH_POLL_MAX_ATTEMPTS, HEALTH_POLL_INTERVAL_MS).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,7 @@ async fn main() -> anyhow::Result<()> {
             port,
             detach,
             hot_upgrade,
+            adopt_from_system,
         } => {
             commands::start::cmd_start(
                 config,
@@ -164,6 +165,7 @@ async fn main() -> anyhow::Result<()> {
                 detach,
                 cli_args.config,
                 hot_upgrade,
+                adopt_from_system,
             )
             .await?;
         }
@@ -180,7 +182,8 @@ async fn main() -> anyhow::Result<()> {
             host,
             log_level: _,
             json_logs: _,
-        } => commands::run::cmd_run(config, config_source, port, host).await?,
+            adopt_from_system,
+        } => commands::run::cmd_run(config, config_source, port, host, adopt_from_system).await?,
         Commands::Preset { action } => match action {
             PresetAction::List => commands::preset::cmd_preset_list(&config).await,
             PresetAction::Info { name } => commands::preset::cmd_preset_info(&name),
@@ -204,8 +207,21 @@ async fn main() -> anyhow::Result<()> {
                 commands::config_promote::cmd_config_pull(&from, &save).await?;
             }
         },
-        Commands::Exec { port, no_stop, cmd } => {
-            commands::exec::cmd_exec(&config, port, no_stop, cmd, cli_args.config).await?;
+        Commands::Exec {
+            port,
+            no_stop,
+            adopt_from_system,
+            cmd,
+        } => {
+            commands::exec::cmd_exec(
+                &config,
+                port,
+                no_stop,
+                adopt_from_system,
+                cmd,
+                cli_args.config,
+            )
+            .await?;
         }
         Commands::Completions { shell } => commands::completions::cmd_completions::<Cli>(shell),
         Commands::SetupCompletions => commands::setup_completions::cmd_setup_completions::<Cli>()?,


### PR DESCRIPTION
Follow-up to #407: `[auth] adopt_from_system` shipped config-only. This surfaces it as a CLI flag on the three commands that boot the server:

| Command | Flag | Notes |
|---|---|---|
| `grob start --adopt-from-system` | per-invocation override | forwarded through the detached child's argv, since the daemon re-reads the config file |
| `grob run --adopt-from-system` | env: `GROB_ADOPT_FROM_SYSTEM` | container mode |
| `grob exec --adopt-from-system` | applies to the proxy it spawns | no effect when an instance is already running |

`restart` and hot-upgrade respawns stay config-driven, matching the existing `--port` semantics (restart does not remember per-invocation overrides). One-shot adoption already exists as `grob connect --from-system`.

Includes a `daemon_command_args` parse-back test proving the forwarded flag is a valid child invocation.