### PR TITLE
fix(audit): ignore the proc-macro-error2 unmaintained advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
-# Review date: 2026-04-15 — re-check if upstream fixed these.
+# Review date: 2026-06-13 — re-check if upstream fixed these.
+# Kept in sync with the `ignore` list in deny.toml.
 [advisories]
 ignore = [
     # aws-lc-sys: CRL bypass + X.509 CN bypass. Blocked by rustls -> aws-lc-rs
@@ -16,4 +17,8 @@ ignore = [
     # rand: Unsound with custom logger calling rand::rng() (RUSTSEC-2026-0097).
     # No impact: grob does not define a custom logger accessing ThreadRng.
     "RUSTSEC-2026-0097",
+    # proc-macro-error2: unmaintained build-time proc-macro, pulled transitively
+    # via age -> i18n-embed-fl. Compile-time only (not in the runtime binary), no
+    # safe upgrade available. Drop when age/i18n-embed-fl migrate off it.
+    "RUSTSEC-2026-0173",
 ]


### PR DESCRIPTION
## Root cause of the red Security Audit / Required checks on main

`cargo audit` finds **0 vulnerabilities**. The job fails for a config-drift reason:

- `proc-macro-error2` went unmaintained on 2026-06-07 (RUSTSEC-2026-0173), pulled transitively via `age → i18n-embed-fl`.
- It was added to `deny.toml`'s ignore in #411, but **not** to `.cargo/audit.toml` — the two advisory lists drifted.
- The unmaintained warning makes `rustsec/audit-check` try to POST a check-run annotation, which the workflow's hardened `permissions: read-all` token cannot (`Resource not accessible by integration`), so the step errors out.

Syncing the ignore list (now annotated `Kept in sync with deny.toml`) clears the warning, so the action posts nothing and the job passes. This also turns **Required checks** green (its aggregator gates on `audit`).

Compile-time only crate, no runtime impact, no safe upgrade available — same rationale as deny.toml.