### PR TITLE
test(dispatch): kill three surviving mutants on main

### DIFF
--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -342,14 +342,7 @@ pub(crate) async fn dispatch(
         request,
         &ctx.inner.config.tool_validation,
     ) {
-        Ok(stripped) => {
-            if !stripped.is_empty() {
-                tracing::warn!(
-                    tools = ?stripped,
-                    "tool validation: stripped malformed inbound tools"
-                );
-            }
-        }
+        Ok(stripped) => warn_stripped_tools(&stripped),
         Err(reason) => return Err(RequestError::BadRequest(reason)),
     }
 
@@ -672,6 +665,29 @@ fn should_escalate_compliance(enabled: bool, risk_classification: bool) -> bool 
     enabled && risk_classification
 }
 
+/// Returns `true` when DLP produced at least one redact/warn report.
+///
+/// Extracted so the trigger flag in [`scan_dlp_input`] is unit-testable
+/// without constructing a full [`DispatchContext`].
+#[inline]
+fn dlp_reports_triggered<T>(reports: &[T]) -> bool {
+    !reports.is_empty()
+}
+
+/// Logs a warning when tool validation stripped malformed inbound tools.
+///
+/// Extracted so the non-empty guard is unit-testable; the inline `if` was
+/// otherwise only reachable through the full `dispatch` pipeline.
+#[inline]
+fn warn_stripped_tools(stripped: &[String]) {
+    if !stripped.is_empty() {
+        tracing::warn!(
+            tools = ?stripped,
+            "tool validation: stripped malformed inbound tools"
+        );
+    }
+}
+
 /// DLP input scanning with risk assessment and audit logging.
 ///
 /// Returns `Ok(true)` when DLP acted on the request (one or more redact/warn
@@ -690,7 +706,7 @@ fn scan_dlp_input(
 
     match dlp_engine.sanitize_request_checked(request) {
         Ok(reports) => {
-            let triggered = !reports.is_empty();
+            let triggered = dlp_reports_triggered(&reports);
             ctx.emit_dlp_events(&reports, DlpDirection::Request);
             Ok(triggered)
         }
@@ -985,6 +1001,7 @@ async fn record_fan_out_costs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing_test::traced_test;
 
     // ── scan_dlp_input guards ──
 
@@ -1004,6 +1021,25 @@ mod tests {
         assert!(!should_escalate_compliance(true, false));
         assert!(!should_escalate_compliance(false, true));
         assert!(!should_escalate_compliance(false, false));
+    }
+
+    #[test]
+    fn dlp_reports_triggered_flags_nonempty_reports() {
+        // `!reports.is_empty()`: triggered only when DLP produced a report.
+        // The "delete !" mutant would invert both outcomes.
+        assert!(!dlp_reports_triggered::<()>(&[]));
+        assert!(dlp_reports_triggered(&[()]));
+    }
+
+    #[traced_test]
+    #[test]
+    fn warn_stripped_tools_logs_only_when_nonempty() {
+        // The "delete !" mutant would warn on an empty strip list and stay
+        // silent on a real one — assert both directions against the log.
+        warn_stripped_tools(&[]);
+        assert!(!logs_contain("stripped malformed inbound tools"));
+        warn_stripped_tools(&["bogus_tool".to_string()]);
+        assert!(logs_contain("stripped malformed inbound tools"));
     }
 
     // ── dispatch routing guards ──

--- a/src/server/dispatch/retry.rs
+++ b/src/server/dispatch/retry.rs
@@ -236,7 +236,7 @@ pub(super) async fn try_rotate_and_retry(
     // Walk the remaining pooled keys. `rotate_key_pool` marks the current key
     // exhausted and advances to the next non-exhausted one, returning false once
     // the whole pool is spent — so this loop is bounded by the pool size.
-    while !rotation_unavailable(provider.rotate_key_pool()) {
+    while rotation_available(provider.rotate_key_pool()) {
         info!(
             "Provider {} rate-limited, rotated to next pooled key — retrying",
             attempt.mapping.provider
@@ -412,6 +412,15 @@ fn try_rotation_on_rate_limit(rate_limited: bool, rotate: impl FnOnce() -> bool)
 #[inline]
 fn rotation_unavailable(rotated: bool) -> bool {
     !rotated
+}
+
+/// Returns `true` while the key pool yielded a fresh key to retry with.
+///
+/// Sibling of [`rotation_unavailable`], extracted so the loop-guard `!` in
+/// [`try_rotate_and_retry`] is unit-testable without a [`DispatchContext`].
+#[inline]
+fn rotation_available(rotated: bool) -> bool {
+    !rotation_unavailable(rotated)
 }
 
 /// Handle the non-streaming path with retry for a single provider.
@@ -1075,6 +1084,15 @@ mod tests {
         // actually succeeded (and proceed when it failed).
         assert!(rotation_unavailable(false));
         assert!(!rotation_unavailable(true));
+    }
+
+    #[test]
+    fn rotation_available_tracks_successful_rotation() {
+        // `!rotation_unavailable`: the `try_rotate_and_retry` loop continues
+        // while a fresh key was rotated in. The "delete !" mutant would loop
+        // only when rotation had already failed.
+        assert!(rotation_available(true));
+        assert!(!rotation_available(false));
     }
 
     // ── build_encrypted_content mode gate ──


### PR DESCRIPTION
The push-to-main mutation matrix (shards 5a/5c) flagged three MISSED `delete !` mutants in code merged via #410:

| Site | Negation | Meaning |
|---|---|---|
| `scan_dlp_input`:693 | `!reports.is_empty()` | DLP "triggered" flag |
| `dispatch`:346 | `!stripped.is_empty()` | tool-validation warn gate |
| `try_rotate_and_retry`:239 | `!rotation_unavailable(...)` | key-rotation loop guard |

These shards are `continue-on-error: true` (non-blocking), but they were showing red on main. Rather than excluding them in `mutants.toml`, this follows the module's **established pattern** — the same one already applied to `dlp_input_scan_disabled`, `should_escalate_compliance`, and `rotation_unavailable`: extract each `!` into a small `#[inline]` helper and unit-test both directions.

- `dlp_reports_triggered`, `rotation_available` (sibling of `rotation_unavailable`): pure boolean helpers, table-tested.
- `warn_stripped_tools`: isolates the log side-effect; tested with `tracing-test`'s `#[traced_test]` asserting the warning fires only on a non-empty strip list.

Each test was verified locally to **fail when its `!` is deleted**, proving it kills the mutant. No production behavior changes (pure refactor-extract + tests).