### PR TITLE
chore: gitignore the local grob-chatgpt.toml config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ LICENSE-IDENTIFICATION.md
 cleancode-plan.md
 # Local personal grob config (committed example lives in docs/examples/)
 grob-openai.toml
+grob-chatgpt.toml
 codeql-db/
 codeql-results.sarif
 codeql-db/


### PR DESCRIPTION
A local copy of the committed `docs/examples/chatgpt-codex-oauth.toml` example tends to sit at the repo root during dev. Ignore it alongside the existing `grob-openai.toml` entry so it never lands in a commit by accident — the canonical version stays in `docs/examples/`.