### PR TITLE
feat(translation): preserve prompt caching across Codex/Claude × OpenAI/Anthropic

### DIFF
--- a/src/models/extensions.rs
+++ b/src/models/extensions.rs
@@ -39,6 +39,25 @@ pub struct RequestExtensions {
     /// Optional author names for canonical messages, indexed by message position.
     pub openai_message_names: Vec<Option<String>>,
 
+    /// Verbatim Responses-API request body from a native client (Codex CLI).
+    ///
+    /// When set, the OpenAI Responses backend forwards this body unchanged
+    /// (only the `model` is swapped to the resolved upstream model) instead of
+    /// rebuilding it from the canonical request. Round-tripping flattens typed
+    /// `input` content, reorders the `tools` shape, and replaces the client's
+    /// `prompt_cache_key` — all of which change the token prefix and defeat the
+    /// backend's prompt cache (gpt-5.5 returns zero cached tokens). Forwarding
+    /// the exact bytes keeps the cache warm.
+    pub responses_passthrough_body: Option<serde_json::Value>,
+
+    /// Set when the request was translated from a non-Anthropic client
+    /// (OpenAI/Codex), which has no `cache_control` concept. The Anthropic
+    /// provider then injects an ephemeral `cache_control` breakpoint on the
+    /// system prefix so the large stable prompt is cached instead of re-billed
+    /// every turn. Left `false` for Anthropic-native clients, which manage their
+    /// own breakpoints.
+    pub inject_anthropic_cache: bool,
+
     // Routing hints.
     /// Set when the request originates from the Codex CLI (Responses API).
     ///

--- a/src/providers/anthropic_compatible.rs
+++ b/src/providers/anthropic_compatible.rs
@@ -8,7 +8,9 @@ use super::{
     LlmProvider, ProviderResponse, StreamResponse,
 };
 use crate::auth::OAuthConfig;
-use crate::models::{CanonicalRequest, CountTokensRequest, CountTokensResponse};
+use crate::models::{
+    CanonicalRequest, CountTokensRequest, CountTokensResponse, SystemBlock, SystemPrompt,
+};
 use async_trait::async_trait;
 use std::collections::HashMap;
 
@@ -172,6 +174,16 @@ impl AnthropicCompatibleProvider {
         auth_value: &str,
         request: &CanonicalRequest,
     ) -> Result<reqwest::Response, ProviderError> {
+        // Wire-debug: verbatim outbound body (canonical == Anthropic shape).
+        // Enabled by `log_level = "debug"`; pairs with the inbound `📥` log.
+        if tracing::event_enabled!(tracing::Level::DEBUG) {
+            tracing::debug!(
+                target: "grob::wire",
+                "📤 Outbound to {}:\n{}",
+                url,
+                serde_json::to_string_pretty(request).unwrap_or_default()
+            );
+        }
         let response = self
             .build_anthropic_request(url, auth_value, request.extensions.client_beta.as_deref())
             .timeout(self.base.api_timeout)
@@ -290,8 +302,44 @@ impl AnthropicCompatibleProvider {
             sanitize_tool_use_ids(request, &mut id_map);
             strip_non_anthropic_thinking(request);
         }
+        inject_anthropic_cache_control(request);
         let auth_value = self.base.resolve_auth(OAuthConfig::anthropic).await?;
         Ok((&self.messages_url, auth_value, is_anthropic, id_map))
+    }
+}
+
+/// Marks the system prefix cacheable when a non-Anthropic client was translated.
+///
+/// OpenAI and Codex clients have no `cache_control` concept, so a request
+/// translated from those surfaces reaches Anthropic with no breakpoint and its
+/// large, stable system prompt is re-billed every turn. When
+/// [`RequestExtensions::inject_anthropic_cache`] is set, this places an
+/// ephemeral breakpoint on the last system block (caching the tools + system
+/// prefix). Anthropic-native requests leave the flag unset and keep full control
+/// of their own breakpoints; an existing breakpoint is always respected.
+fn inject_anthropic_cache_control(request: &mut CanonicalRequest) {
+    if !request.extensions.inject_anthropic_cache {
+        return;
+    }
+    let ephemeral = serde_json::json!({ "type": "ephemeral" });
+    match request.system.take() {
+        Some(SystemPrompt::Text(text)) if !text.is_empty() => {
+            request.system = Some(SystemPrompt::Blocks(vec![SystemBlock {
+                r#type: "text".to_string(),
+                text,
+                cache_control: Some(ephemeral),
+            }]));
+        }
+        Some(SystemPrompt::Blocks(mut blocks)) => {
+            let has_breakpoint = blocks.iter().any(|b| b.cache_control.is_some());
+            if !has_breakpoint {
+                if let Some(last) = blocks.last_mut() {
+                    last.cache_control = Some(ephemeral);
+                }
+            }
+            request.system = Some(SystemPrompt::Blocks(blocks));
+        }
+        other => request.system = other,
     }
 }
 

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -408,10 +408,13 @@ impl LlmProvider for OpenAIProvider {
             {
                 // Verbatim passthrough: keep the native client's exact prefix
                 // (typed content, tool shape, prompt_cache_key) so the backend's
-                // prompt cache stays warm. Only the model is swapped to the
-                // resolved upstream model.
+                // prompt cache stays warm. Swap the model to the resolved upstream
+                // model and enforce the ChatGPT Codex contract (store=false, and
+                // grob always streams upstream) in case the client omitted them.
                 if let Some(obj) = raw.as_object_mut() {
                     obj.insert("model".to_string(), serde_json::json!(request.model));
+                    obj.insert("store".to_string(), serde_json::json!(false));
+                    obj.insert("stream".to_string(), serde_json::json!(true));
                 }
                 raw
             } else {

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -404,15 +404,30 @@ impl LlmProvider for OpenAIProvider {
                 endpoint,
                 request.model
             );
-            let tuning = transform::CodexTuning::from_options(
-                &self.base.codex,
-                self.base.reasoning_effort.as_deref(),
-                self.base.service_tier.as_deref(),
-            );
-            let responses_request =
-                transform::transform_to_responses_request(&request, CODEX_INSTRUCTIONS, &tuning)?;
-            let body = serde_json::to_value(&responses_request)
-                .map_err(ProviderError::SerializationError)?;
+            let body = if let Some(mut raw) = request.extensions.responses_passthrough_body.clone()
+            {
+                // Verbatim passthrough: keep the native client's exact prefix
+                // (typed content, tool shape, prompt_cache_key) so the backend's
+                // prompt cache stays warm. Only the model is swapped to the
+                // resolved upstream model.
+                if let Some(obj) = raw.as_object_mut() {
+                    obj.insert("model".to_string(), serde_json::json!(request.model));
+                }
+                raw
+            } else {
+                let tuning = transform::CodexTuning::from_options(
+                    &self.base.codex,
+                    self.base.reasoning_effort.as_deref(),
+                    self.base.service_tier.as_deref(),
+                );
+                let responses_request = transform::transform_to_responses_request(
+                    &request,
+                    CODEX_INSTRUCTIONS,
+                    &tuning,
+                )?;
+                serde_json::to_value(&responses_request)
+                    .map_err(ProviderError::SerializationError)?
+            };
             (format!("{}{}", base_url, endpoint), body)
         } else {
             let openai_request = transform::transform_request(&request)?;
@@ -420,6 +435,18 @@ impl LlmProvider for OpenAIProvider {
                 serde_json::to_value(&openai_request).map_err(ProviderError::SerializationError)?;
             (format!("{}/chat/completions", base_url), body)
         };
+
+        // Wire-debug: the verbatim outbound body sent upstream. Enabled by
+        // `log_level = "debug"`; serialization is gated so it costs nothing
+        // otherwise. Pair with the inbound `📥` log to diff prompt-cache prefixes.
+        if tracing::event_enabled!(tracing::Level::DEBUG) {
+            tracing::debug!(
+                target: "grob::wire",
+                "📤 Outbound to {}:\n{}",
+                url,
+                serde_json::to_string_pretty(&request_body).unwrap_or_default()
+            );
+        }
 
         let mut req_builder = self
             .base

--- a/src/providers/openai/transform.rs
+++ b/src/providers/openai/transform.rs
@@ -1,5 +1,5 @@
 use super::types::*;
-use crate::models::{CanonicalRequest, MessageContent};
+use crate::models::{CanonicalRequest, Message, MessageContent};
 use crate::providers::error::ProviderError;
 use crate::providers::streaming::parse_sse_events;
 use crate::providers::{CodexOptions, ContentBlock, KnownContentBlock, ProviderResponse, Usage};
@@ -1015,7 +1015,7 @@ pub(crate) fn transform_to_responses_request(
         if let Some(ref system) = request.system {
             items.push(OpenAIResponsesItem::Message {
                 role: "user".to_string(),
-                content: Some(system.to_text()),
+                content: Some(responses_message_content("user", system.to_text())),
             });
         }
     }
@@ -1033,13 +1033,27 @@ pub(crate) fn transform_to_responses_request(
         match &msg.content {
             MessageContent::Text(text) => items.push(OpenAIResponsesItem::Message {
                 role: role.to_string(),
-                content: Some(text.clone()),
+                content: Some(responses_message_content(role, text.clone())),
             }),
             MessageContent::Blocks(blocks) => {
                 push_blocks_as_items(&mut items, role, blocks)?;
             }
         }
     }
+
+    // Derive the cache key from the reusable prefix BEFORE `tools` is moved into
+    // the request below.
+    let prompt_cache_key =
+        derive_prompt_cache_key(&instructions, tools.as_deref(), request.messages.first());
+
+    let reasoning = resolve_reasoning_effort(request, tuning)
+        .map(|effort| serde_json::json!({ "effort": effort }));
+    // Reasoning models only engage prompt caching under `store = false` when the
+    // request opts into encrypted reasoning state (Codex CLI does this); without
+    // it gpt-5.5 returns zero cached tokens.
+    let include = reasoning
+        .is_some()
+        .then(|| vec!["reasoning.encrypted_content".to_string()]);
 
     Ok(OpenAIResponsesRequest {
         model: request.model.clone(),
@@ -1052,10 +1066,55 @@ pub(crate) fn transform_to_responses_request(
         tool_choice,
         parallel_tool_calls: tools.as_ref().map(|_| true),
         tools,
-        reasoning: resolve_reasoning_effort(request, tuning)
-            .map(|effort| serde_json::json!({ "effort": effort })),
+        reasoning,
         service_tier: resolve_service_tier(request, tuning),
+        prompt_cache_key: Some(prompt_cache_key),
+        include,
     })
+}
+
+/// Derives a stable `prompt_cache_key` from a request's reusable prefix.
+///
+/// OpenAI's prompt cache matches on the longest common token prefix of a
+/// request; the `prompt_cache_key` routes requests that share that prefix to the
+/// same cache node, which lifts hit rates on agent loops. Anthropic's surface
+/// expresses this through explicit `cache_control` breakpoints, which the
+/// Responses translation drops — so grob reconstructs an equivalent here.
+///
+/// The key hashes the parts that stay constant across one conversation's turns —
+/// the resolved `instructions`, the tool definitions, and the first message —
+/// so every turn of a session sends the same key while distinct sessions stay
+/// separated. SHA-256 with a fixed truncation keeps it deterministic across
+/// process restarts, preserving cache continuity.
+fn derive_prompt_cache_key(
+    instructions: &str,
+    tools: Option<&[serde_json::Value]>,
+    first_message: Option<&Message>,
+) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write as _;
+
+    let mut hasher = Sha256::new();
+    hasher.update(instructions.as_bytes());
+    if let Some(tools) = tools {
+        if let Ok(bytes) = serde_json::to_vec(tools) {
+            hasher.update(&bytes);
+        }
+    }
+    if let Some(message) = first_message {
+        if let Ok(bytes) = serde_json::to_vec(message) {
+            hasher.update(&bytes);
+        }
+    }
+
+    // 128 bits of hex is collision-safe for cache routing and stays well under
+    // the backend's key-length limit.
+    let digest = hasher.finalize();
+    let mut key = String::from("grob-");
+    for byte in &digest[..16] {
+        let _ = write!(key, "{byte:02x}");
+    }
+    key
 }
 
 /// Resolves the Codex `service_tier` (processing speed) for a request.
@@ -1215,9 +1274,24 @@ fn flush_text_item(items: &mut Vec<OpenAIResponsesItem>, role: &str, text: &mut 
     if !text.is_empty() {
         items.push(OpenAIResponsesItem::Message {
             role: role.to_string(),
-            content: Some(std::mem::take(text)),
+            content: Some(responses_message_content(role, std::mem::take(text))),
         });
     }
+}
+
+/// Builds Responses-API typed message content (`[{"type":…,"text":…}]`).
+///
+/// The backend's prompt cache only matches when message content uses the
+/// structured parts; a flat string defeats caching for reasoning models like
+/// gpt-5.5. Assistant turns use `output_text`; every other role uses
+/// `input_text`.
+fn responses_message_content(role: &str, text: String) -> serde_json::Value {
+    let part_type = if role == "assistant" {
+        "output_text"
+    } else {
+        "input_text"
+    };
+    serde_json::json!([{ "type": part_type, "text": text }])
 }
 
 /// Transforms Anthropic tool definitions into Responses-API (flattened) tools.
@@ -1438,10 +1512,10 @@ mod tests {
 
         // No system-role items survive (the Codex backend rejects them)...
         assert!(input.iter().all(|i| i["role"] != "system"));
-        // ...but the content is preserved as a user item.
-        assert!(input
-            .iter()
-            .any(|i| i["role"] == "user" && i["content"] == "be terse"));
+        // ...but the content is preserved as a user item (typed-parts form).
+        assert!(input.iter().any(|i| i["role"] == "user"
+            && i["content"][0]["type"] == "input_text"
+            && i["content"][0]["text"] == "be terse"));
     }
 
     #[test]
@@ -1481,10 +1555,11 @@ mod tests {
         let input = json["input"].as_array().unwrap();
         assert_eq!(input.len(), 1);
         assert_eq!(input[0]["role"], "user");
-        assert_eq!(input[0]["content"], "run ls");
+        assert_eq!(input[0]["content"][0]["type"], "input_text");
+        assert_eq!(input[0]["content"][0]["text"], "run ls");
         assert!(!input
             .iter()
-            .any(|item| item["content"] == "FULL CODEX CLI PROMPT"));
+            .any(|item| item["content"][0]["text"] == "FULL CODEX CLI PROMPT"));
     }
 
     #[test]
@@ -1678,6 +1753,76 @@ mod tests {
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["instructions"], "FULL CODEX PROMPT");
         assert!(json.get("tools").is_none() || json["tools"].is_null());
+    }
+
+    #[test]
+    fn prompt_cache_key_is_stable_across_message_tails() {
+        // The key must stay identical as a conversation grows, so every turn
+        // routes to the same OpenAI prompt-cache node and hits the shared prefix.
+        let opts = CodexOptions::default();
+        let key = |messages: Vec<Message>| {
+            let mut req = base_request();
+            req.system = None;
+            req.messages = messages;
+            serde_json::to_value(
+                transform_to_responses_request(
+                    &req,
+                    "INSTR",
+                    &CodexTuning::from_options(&opts, None, None),
+                )
+                .unwrap(),
+            )
+            .unwrap()["prompt_cache_key"]
+                .clone()
+        };
+        let user = |text: &str| Message {
+            role: "user".to_string(),
+            content: MessageContent::Text(text.to_string()),
+        };
+
+        let turn1 = key(vec![user("first prompt")]);
+        let turn2 = key(vec![
+            user("first prompt"),
+            Message {
+                role: "assistant".to_string(),
+                content: MessageContent::Text("reply".to_string()),
+            },
+            user("follow-up"),
+        ]);
+
+        assert!(turn1.as_str().unwrap().starts_with("grob-"));
+        assert_eq!(turn1, turn2, "key must be stable as the conversation grows");
+    }
+
+    #[test]
+    fn prompt_cache_key_separates_conversations_and_instructions() {
+        let opts = CodexOptions::default();
+        let key = |instructions: &str, first: &str| {
+            let mut req = base_request();
+            req.system = None;
+            req.messages = vec![Message {
+                role: "user".to_string(),
+                content: MessageContent::Text(first.to_string()),
+            }];
+            serde_json::to_value(
+                transform_to_responses_request(
+                    &req,
+                    instructions,
+                    &CodexTuning::from_options(&opts, None, None),
+                )
+                .unwrap(),
+            )
+            .unwrap()["prompt_cache_key"]
+                .clone()
+        };
+
+        // A different opening message means a different conversation → different key.
+        assert_ne!(
+            key("INSTR", "conversation A"),
+            key("INSTR", "conversation B")
+        );
+        // Different system instructions also separate the cache namespace.
+        assert_ne!(key("INSTR ONE", "same"), key("INSTR TWO", "same"));
     }
 
     #[test]

--- a/src/providers/openai/types.rs
+++ b/src/providers/openai/types.rs
@@ -77,6 +77,17 @@ pub(crate) struct OpenAIResponsesRequest {
     /// Processing tier, e.g. `"priority"` for faster handling.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
+    /// Stable per-conversation key that routes requests sharing a prefix to the
+    /// same OpenAI prompt-cache node, lifting cache-hit rates across agent-loop
+    /// turns. The Anthropic surface has no equivalent field, so grob derives it
+    /// from the reusable request prefix (see `derive_prompt_cache_key`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
+    /// Reasoning models need `["reasoning.encrypted_content"]` so the backend
+    /// returns (and caches) reasoning state under `store = false`. Codex CLI
+    /// sends this; without it gpt-5.5 gets zero prompt-cache hits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include: Option<Vec<String>>,
 }
 
 /// Input for Responses API is an array of typed items.
@@ -95,11 +106,13 @@ pub(crate) enum OpenAIResponsesInput {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum OpenAIResponsesItem {
-    /// A conversational message; `content` is plain text.
+    /// A conversational message. `content` is the Responses-API typed-parts
+    /// array (`[{"type":"input_text","text":…}]`); a flat string defeats the
+    /// backend prompt cache for reasoning models, so grob always emits parts.
     Message {
         role: String,
         #[serde(skip_serializing_if = "Option::is_none")]
-        content: Option<String>,
+        content: Option<serde_json::Value>,
     },
     /// An assistant tool call replayed from history.
     FunctionCall {

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -663,9 +663,17 @@ pub(crate) async fn handle_responses(
     vk_ctx: Option<axum::Extension<crate::auth::virtual_keys::VirtualKeyContext>>,
     axum::Extension(request_id): axum::Extension<RequestId>,
     headers: HeaderMap,
-    Json(responses_request): Json<responses_compat::ResponsesRequest>,
+    body_bytes: axum::body::Bytes,
 ) -> Result<Response, RequestError> {
     let _guard = ActiveRequestGuard::new(&state);
+    // Wire-debug: verbatim inbound Responses body (Codex CLI). Enabled by
+    // `log_level = "debug"`; pairs with the outbound `📤` log to diff the exact
+    // prompt-cache prefix the backend sees.
+    if tracing::event_enabled!(tracing::Level::DEBUG) {
+        tracing::debug!(target: "grob::wire", "📥 Inbound /v1/responses:\n{}", String::from_utf8_lossy(&body_bytes));
+    }
+    let responses_request: responses_compat::ResponsesRequest = serde_json::from_slice(&body_bytes)
+        .map_err(|e| RequestError::ParseError(format!("inbound responses parse: {e}")))?;
     let model = responses_request.model.clone();
     let is_streaming = responses_request.stream == Some(true);
 
@@ -691,6 +699,11 @@ pub(crate) async fn handle_responses(
         .map_err(|e| {
             RequestError::ParseError(format!("Failed to transform Responses request: {}", e))
         })?;
+    // Preserve the exact inbound body so an OpenAI Responses backend can forward
+    // it verbatim (keeping the prompt cache warm) instead of rebuilding it.
+    if let Ok(raw) = serde_json::from_slice::<serde_json::Value>(&body_bytes) {
+        request.extensions.responses_passthrough_body = Some(raw);
+    }
     forward_beta_header(&mut request, &headers);
 
     let start_time = std::time::Instant::now();

--- a/src/server/openai_compat/transform.rs
+++ b/src/server/openai_compat/transform.rs
@@ -282,6 +282,9 @@ pub fn transform_openai_to_canonical(
         service_tier: openai_req.service_tier,
         openai_system_name,
         openai_message_names,
+        responses_passthrough_body: None,
+        // OpenAI clients have no `cache_control`; let an Anthropic backend cache.
+        inject_anthropic_cache: true,
         codex_native: false,
     };
 

--- a/src/server/responses_compat/transform.rs
+++ b/src/server/responses_compat/transform.rs
@@ -229,6 +229,8 @@ pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<Canonic
         // This path only runs for Codex CLI (Responses API) requests, so its
         // `instructions` are the authoritative Codex agent prompt.
         codex_native: true,
+        // Codex has no `cache_control`; let an Anthropic backend cache the prefix.
+        inject_anthropic_cache: true,
         ..Default::default()
     };
 


### PR DESCRIPTION
## Problem

grob's format translation dropped prompt-cache primitives, so a translated request never hit the backend cache. **gpt-5.5 through grob returned 0 cached tokens where the native Codex CLI got 9088** — re-billing the full context every turn (an agentic session resends ~60k input tokens per turn).

Root cause: the Responses→canonical→Responses round-trip flattened typed `input.content` to a string and reformatted `tools`, changing the token prefix; and cross-format translation carried no cache directive at all.

## Fix — cache-aware in all 4 client×backend combinations (proven live)

| Direction | Mechanism | Proof (cached tokens) |
|---|---|---|
| Codex (Responses) → OpenAI | verbatim passthrough (`responses_passthrough_body`) | 9088 |
| Claude (Anthropic) → OpenAI | typed `input_text` content + `prompt_cache_key` + `include` | 11008 |
| Codex/OpenAI → Anthropic | inject ephemeral `cache_control` on system prefix (`inject_anthropic_cache`) | cache:99%, 11102 |
| Claude → Anthropic | native `cache_control` passthrough (unchanged) | 11102 |

Key finding: **gpt-5.5 only caches with typed content** (a flat string never matches) and a sufficiently large prefix.

## Wire debug mode

`log_level = "debug"` now logs verbatim inbound (📥) and outbound (📤) request bodies under the `grob::wire` tracing target — used to diff prompt-cache prefixes across the translation boundary.

## Notes
- `/v1/responses` cache reporting was verified intact: cache lands in `input_tokens_details.cached_tokens` (existing test `response_completed_includes_cached_token_details`).
- Anthropic-native clients keep full control of their own `cache_control` breakpoints (flag only set for cross-format translation).

## Tests
- 1389 lib tests pass; clippy/fmt clean.
- Updated 2 transform assertions for the typed-content shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)