### PR TITLE
chore: release v0.36.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.70](https://github.com/azerozero/grob/compare/v0.36.69...v0.36.70) - 2026-06-14
+
+### Added
+
+- *(translation)* preserve prompt caching across Codex/Claude × OpenAI/Anthropic
+
+### Fixed
+
+- *(translation)* enforce store=false and stream on the Responses passthrough
+
+### Other
+
+- gitignore the local grob-chatgpt.toml config
+- *(examples)* trim the codex OAuth example to the essentials
+- *(dispatch)* kill three surviving mutants on main
+
 ## [0.36.69](https://github.com/azerozero/grob/compare/v0.36.68...v0.36.69) - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.69"
+version = "0.36.70"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.69"
+version = "0.36.70"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.69 -> 0.36.70

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.70](https://github.com/azerozero/grob/compare/v0.36.69...v0.36.70) - 2026-06-14

### Added

- *(translation)* preserve prompt caching across Codex/Claude × OpenAI/Anthropic

### Fixed

- *(translation)* enforce store=false and stream on the Responses passthrough

### Other

- gitignore the local grob-chatgpt.toml config
- *(examples)* trim the codex OAuth example to the essentials
- *(dispatch)* kill three surviving mutants on main
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).