### PR TITLE
fix(dlp): apply DLP redaction to the Responses passthrough path

### DIFF
--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -321,6 +321,16 @@ pub(crate) async fn dispatch(
     #[cfg_attr(not(feature = "policies"), allow(unused_variables))]
     let dlp_triggered = scan_dlp_input(ctx, request)?;
 
+    // Security: DLP sanitizes the canonical request in place. Drop any verbatim
+    // Responses passthrough body so the OpenAI provider rebuilds from the
+    // sanitized request — otherwise the original, un-redacted bytes would be
+    // forwarded upstream, bypassing DLP. The rebuild path stays cache-friendly
+    // (typed content + prompt_cache_key), so the only cost is a one-request cache
+    // miss when DLP actually fires.
+    if dlp_triggered {
+        request.extensions.responses_passthrough_body = None;
+    }
+
     // ── Step 1.4: Tool-call spike anomaly detection (T-AD1) ──
     // Runs after DLP so scoped DLP blocks take precedence, and before
     // routing so a runaway client cannot exhaust provider quotas before


### PR DESCRIPTION
## Security fix

The verbatim Responses passthrough added in #420 (`responses_passthrough_body`) forwards the **original inbound body**, which is captured in `handle_responses` **before** DLP runs. DLP sanitizes the *canonical* request in place, but the passthrough copy kept the **un-redacted bytes** — so on the `/v1/responses` path, secrets/PII that a DLP rule would redact were still sent upstream.

DLP otherwise correctly covers all providers (it runs on the canonical request before the provider loop); this gap was specific to the new passthrough shortcut.

## Fix

Drop `responses_passthrough_body` whenever DLP acts on the request, so the OpenAI provider rebuilds from the sanitized canonical instead of forwarding the raw bytes. The rebuild path is still cache-friendly (typed content + `prompt_cache_key`), so the only cost is a one-request cache miss when a DLP rule actually fires.

## Tests
- Full suite: 1389 lib + 271 + 26 integration pass; clippy `--all-targets` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)