### PR TITLE
chore: release v0.36.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.72](https://github.com/azerozero/grob/compare/v0.36.71...v0.36.72) - 2026-06-14
+
+### Added
+
+- *(audit)* classify caviardages as C1/C2 in the audit log
+
+### Other
+
+- *(licensing)* fix AGPL framing, add edition matrix and §13 wording
+- *(adr)* add ADR-0028 open-core boundary (AGPL core vs commercial)
+
 ## [0.36.71](https://github.com/azerozero/grob/compare/v0.36.70...v0.36.71) - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.71"
+version = "0.36.72"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.71"
+version = "0.36.72"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.71 -> 0.36.72

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.72](https://github.com/azerozero/grob/compare/v0.36.71...v0.36.72) - 2026-06-14

### Added

- *(audit)* classify caviardages as C1/C2 in the audit log

### Other

- *(licensing)* fix AGPL framing, add edition matrix and §13 wording
- *(adr)* add ADR-0028 open-core boundary (AGPL core vs commercial)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).