### PR TITLE
feat(audit): add OpenTelemetry trace_id/span_id to audit entries

### DIFF
--- a/src/features/policies/stream/mod.rs
+++ b/src/features/policies/stream/mod.rs
@@ -199,6 +199,7 @@ pub(crate) fn write_hit_receipt(
         let Ok(receipt_json) = serde_json::to_string(&auth) else {
             return auth;
         };
+        let (trace_id, span_id) = crate::security::audit_log::current_trace_ids();
         let entry = AuditEntry {
             timestamp: chrono::Utc::now(),
             event_id: uuid::Uuid::new_v4().to_string(),
@@ -218,6 +219,8 @@ pub(crate) fn write_hit_receipt(
             input_tokens: None,
             output_tokens: None,
             risk_level: Some(RiskLevel::High),
+            trace_id,
+            span_id,
             batch_id: None,
             batch_index: None,
             merkle_root: None,

--- a/src/security/audit_log.rs
+++ b/src/security/audit_log.rs
@@ -142,6 +142,15 @@ pub struct AuditEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub risk_level: Option<RiskLevel>,
 
+    /// OpenTelemetry trace id (32-hex), captured from the current span when the
+    /// `otel` feature is active and tracing is enabled. Lets an audit line be
+    /// correlated to its distributed trace in Tempo. `None` when OTel is off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// OpenTelemetry span id (16-hex) of the request span. See [`AuditEntry::trace_id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
+
     // ── Merkle batch fields ──
     /// Batch ID (UUID v4). Present when batch_size > 1.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -155,6 +164,35 @@ pub struct AuditEntry {
     /// Inclusion proof from this leaf to the Merkle root.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub merkle_proof: Option<Vec<ProofStep>>,
+}
+
+/// Returns the current OpenTelemetry `(trace_id, span_id)` as lowercase hex.
+///
+/// Yields `(None, None)` when the `otel` feature is off or the current span
+/// carries no valid trace context (OTel disabled at runtime). Used to stamp
+/// [`AuditEntry`] for log↔trace correlation. The hex forms (32/16 chars) match
+/// what Tempo and Grafana's Loki→Tempo derived field expect.
+#[cfg(feature = "otel")]
+pub(crate) fn current_trace_ids() -> (Option<String>, Option<String>) {
+    use opentelemetry::trace::TraceContextExt;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    let cx = tracing::Span::current().context();
+    let span = cx.span();
+    let sc = span.span_context();
+    if sc.is_valid() {
+        (
+            Some(sc.trace_id().to_string()),
+            Some(sc.span_id().to_string()),
+        )
+    } else {
+        (None, None)
+    }
+}
+
+/// Returns `(None, None)`: trace correlation needs the `otel` build feature.
+#[cfg(not(feature = "otel"))]
+pub(crate) fn current_trace_ids() -> (Option<String>, Option<String>) {
+    (None, None)
 }
 
 /// Risk classification levels per EU AI Act Article 14.
@@ -552,6 +590,8 @@ mod tests {
             input_tokens: None,
             output_tokens: None,
             risk_level: None,
+            trace_id: None,
+            span_id: None,
             batch_id: None,
             batch_index: None,
             merkle_root: None,

--- a/src/server/audit.rs
+++ b/src/server/audit.rs
@@ -118,6 +118,9 @@ impl AuditEntryBuilder {
     pub fn build(self) -> crate::security::audit_log::AuditEntry {
         use crate::security::audit_log::AuditEntry;
         let classification = self.derive_classification();
+        // Stamp the current distributed-trace context so the audit line can be
+        // jumped to its trace in Tempo (no-op / None when OTel is off).
+        let (trace_id, span_id) = crate::security::audit_log::current_trace_ids();
         AuditEntry {
             timestamp: chrono::Utc::now(),
             event_id: uuid::Uuid::new_v4().to_string(),
@@ -137,6 +140,8 @@ impl AuditEntryBuilder {
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
             risk_level: self.risk_level,
+            trace_id,
+            span_id,
             batch_id: None,     // filled by batch flush
             batch_index: None,  // filled by batch flush
             merkle_root: None,  // filled by batch flush

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -822,6 +822,9 @@ pub(crate) fn emit_tee_attestation(
         input_tokens: None,
         output_tokens: None,
         risk_level: None,
+        // Startup attestation runs outside any request span → no trace context.
+        trace_id: None,
+        span_id: None,
         batch_id: None,
         batch_index: None,
         merkle_root: None,

--- a/tests/enterprise/property_audit_test.rs
+++ b/tests/enterprise/property_audit_test.rs
@@ -91,6 +91,8 @@ fn build_audit_entry(
         input_tokens: None,
         output_tokens: None,
         risk_level: None,
+        trace_id: None,
+        span_id: None,
         batch_id: None,
         batch_index: None,
         merkle_root: None,


### PR DESCRIPTION
Audit lines carried no trace context, so an audit entry couldn't be correlated to its distributed trace. This captures the current **OTel span's `trace_id`/`span_id`** (lowercase hex — the form Tempo and Grafana's Loki→Tempo derived field expect) when building an `AuditEntry`, behind the existing **`otel`** feature.

- `None` when OTel is off or the span has no valid context; serialized only when present (`skip_serializing_if`) → **non-otel builds and existing log lines are byte-unchanged**.
- Capture is centralised in `AuditEntryBuilder::build()` (covers every dispatch audit path) plus the HIT-approval receipt; startup attestation and tests pass `None`.
- The pair is correlation metadata — kept out of the integrity hash (like the batch fields) but still part of the signed serialized line.
- Reuses the exact span-context extraction pattern already used in `src/server/budget.rs` (`Span::current().context()` → `span_context().trace_id()/span_id()`).

Enables the governance demo to jump from an audit log line to its trace in Tempo (paired demo PR wires the OTLP export + sidecar).

**Verified:** compiles with and without `otel`; `clippy` clean both ways; audit + dispatch (76) and enterprise property-audit (5) tests pass; `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)