### PR TITLE
chore(demo): wire OTel trace export so audit logs link to Tempo

### DIFF
--- a/deploy/demo/Containerfile
+++ b/deploy/demo/Containerfile
@@ -37,10 +37,12 @@ COPY . .
 #     `gcc` so both host build-scripts and the target binary link.
 # The binary lands under target/<triple>/release; copy it to a fixed path for
 # the scratch stage, which has no shell to compute the triple.
+# --features otel: adds the OTLP trace exporter so the demo correlates audit
+# logs to traces in Tempo (the audit line carries the OTel trace_id).
 RUN TARGET="$(rustc -vV | sed -n 's/^host: //p')" && \
     LINKER_VAR="CARGO_TARGET_$(echo "$TARGET" | tr 'a-z-' 'A-Z_')_LINKER" && \
     export "${LINKER_VAR}=gcc" && \
-    cargo build --release --locked --target "$TARGET" && \
+    cargo build --release --locked --target "$TARGET" --features otel && \
     cp "target/${TARGET}/release/grob" /grob && \
     strip /grob && \
     mkdir -p /runtime/var/lib/grob /runtime/tmp

--- a/deploy/demo/audit-loki.sh
+++ b/deploy/demo/audit-loki.sh
@@ -57,6 +57,12 @@ tenant_of() {
   printf '%s' "$1" | sed -n 's/.*"tenant_id":"\([^"]*\)".*/\1/p'
 }
 
+# Extrait le trace_id OTel (présent quand grob tourne avec --features otel et
+# [otel].enabled). Vide sinon (ligne sans trace, ex. attestation au démarrage).
+trace_of() {
+  printf '%s' "$1" | sed -n 's/.*"trace_id":"\([^"]*\)".*/\1/p'
+}
+
 # Dérive un NIVEAU de log (level) de la ligne d'audit, depuis son action et sa
 # classification. Sans niveau explicite, Loki affiche « detected_level=unknown »
 # (il ne sait pas deviner la gravité d'une ligne JSON métier). En émettant un
@@ -116,13 +122,23 @@ push_line() {
   tenant=$(tenant_of "$line")
   [ -n "$tenant" ] || tenant="unknown"
   lvl=$(level_of "$line")
+  tid=$(trace_of "$line")
   loki_ts            # met à jour TS (globale) sans sous-shell
   ts="$TS"
   esc=$(json_escape "$line")
+  # trace_id en STRUCTURED METADATA (3e élément du tuple values), pas en label :
+  # forte cardinalité (unique par requête) → jamais un label indexé. Le derived
+  # field Loki d'otel-lgtm (matcher sur trace_id) en fait un lien « Voir le trace »
+  # vers Tempo. Absent (otel off / ligne hors requête) → tuple à 2 éléments.
+  if [ -n "$tid" ]; then
+    values=$(printf '[["%s","%s",{"trace_id":"%s"}]]' "$ts" "$esc" "$tid")
+  else
+    values=$(printf '[["%s","%s"]]' "$ts" "$esc")
+  fi
   # `level` est une étiquette de stream standard : Loki la reconnaît comme
   # niveau (plus de detected_level=unknown) et Grafana colore le journal.
-  payload=$(printf '{"streams":[{"stream":{"service":"%s","tenant":"%s","level":"%s"},"values":[["%s","%s"]]}]}' \
-    "$SERVICE" "$tenant" "$lvl" "$ts" "$esc")
+  payload=$(printf '{"streams":[{"stream":{"service":"%s","tenant":"%s","level":"%s"},"values":%s}]}' \
+    "$SERVICE" "$tenant" "$lvl" "$values")
   # -s silencieux ; on ignore l'échec réseau ponctuel (la prochaine ligne suivra).
   curl -s -o /dev/null -X POST "$LOKI_URL" \
     -H 'Content-Type: application/json' \

--- a/deploy/demo/demo.kube.yaml
+++ b/deploy/demo/demo.kube.yaml
@@ -95,7 +95,15 @@ data:
     \ domaine d'exfil\n# factice en liste noire \u2014 toute URL vers ce domaine est\
     \ alors bloqu\xE9e.\n[dlp.url_exfil]\nenabled = true\naction = \"block\"\nscan_markdown_images\
     \ = true\nscan_markdown_links = true\nscan_raw_urls = true\nblacklist_domains\
-    \ = [\"evil.example.com\"]\ndomain_match_mode = \"suffix\"\n"
+    \ = [\"evil.example.com\"]\ndomain_match_mode = \"suffix\"\n\n# --- OpenTelemetry\
+    \ : export des traces vers Tempo (corr\xE9lation logs <-> traces) -\n# Active\
+    \ l'exportateur OTLP/gRPC (image construite avec --features otel). Chaque\n# requ\xEA\
+    te devient un trace export\xE9 vers le Tempo d'otel-lgtm ; la ligne d'audit\n\
+    # correspondante porte le meme trace_id (capt\xE9 du span courant), ce qui permet\
+    \ le\n# saut \"Voir le trace\" depuis le journal Loki (derived field pr\xE9-c\xE2\
+    bl\xE9 par\n# otel-lgtm). Endpoint = localhost car les conteneurs du pod partagent\
+    \ le netns.\n[otel]\nenabled = true\nendpoint = \"http://localhost:4317\"\nservice_name\
+    \ = \"grob\"\n"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -1840,50 +1848,61 @@ data:
     \ do\n  echo \"[audit-loki] attente de Loki\u2026\"\n  sleep 2\ndone\necho \"\
     [audit-loki] Loki pr\xEAt, d\xE9marrage du suivi.\"\n\n# Extrait la valeur de\
     \ tenant_id d'une ligne d'audit JSON (sans jq).\ntenant_of() {\n  printf '%s'\
-    \ \"$1\" | sed -n 's/.*\"tenant_id\":\"\\([^\"]*\\)\".*/\\1/p'\n}\n\n# D\xE9rive\
-    \ un NIVEAU de log (level) de la ligne d'audit, depuis son action et sa\n# classification.\
-    \ Sans niveau explicite, Loki affiche \xAB detected_level=unknown \xBB\n# (il\
-    \ ne sait pas deviner la gravit\xE9 d'une ligne JSON m\xE9tier). En \xE9mettant\
-    \ un\n# `level` standard, Grafana colore le journal par gravit\xE9 et la gravit\xE9\
-    \ \xE9pouse\n# le TYPE d'incident : injection bloqu\xE9e=critical, exfiltration\
-    \ bloqu\xE9e=error,\n# caviardage=warning, trafic normal=info.\n#   C3 (blocage\
-    \ + injection)  -> critical\n#   blocage DLP (C2 exfil)     -> error\n#   DLP_WARN\
-    \ (caviardage C1/C2)-> warning\n#   ERROR (\xE9chec dispatch)     -> error\n#\
-    \   reste (RESPONSE/NC, \u2026)     -> info\nlevel_of() {\n  l=\"$1\"\n  act=$(printf\
-    \ '%s' \"$l\" | sed -n 's/.*\"action\":\"\\([^\"]*\\)\".*/\\1/p')\n  cls=$(printf\
-    \ '%s' \"$l\" | sed -n 's/.*\"classification\":\"\\([^\"]*\\)\".*/\\1/p')\n  case\
-    \ \"$act\" in\n    *BLOCK*) [ \"$cls\" = \"C3\" ] && echo \"critical\" || echo\
-    \ \"error\" ;;\n    DLP_WARN) echo \"warning\" ;;\n    ERROR)    echo \"error\"\
-    \ ;;\n    *)        echo \"info\" ;;\n  esac\n}\n\n# \xC9chappe une ligne pour\
-    \ l'embarquer comme valeur de cha\xEEne JSON : antislash\n# d'abord, puis guillemets.\
-    \ (Les lignes d'audit n'ont ni saut de ligne ni\n# tabulation : une ligne JSONL\
-    \ = une ligne.)\njson_escape() {\n  printf '%s' \"$1\" | sed 's/\\\\/\\\\\\\\\
-    /g; s/\"/\\\\\"/g'\n}\n\n# Horodatage Loki en nanosecondes, monotone et unique\
-    \ par ligne. \xC9crit le\n# r\xE9sultat dans la variable GLOBALE TS au lieu de\
-    \ l'\xE9mettre sur stdout : appel\xE9\n# via $(...), le compteur SEQ vivrait dans\
-    \ un sous-shell et serait perdu, donc\n# toutes les lignes d'une m\xEAme seconde\
-    \ partageraient le m\xEAme horodatage \u2014 Loki\n# d\xE9dupliquerait alors et\
-    \ perdrait des lignes d'audit. En mutant une globale\n# (appel direct, sans substitution\
-    \ de commande), le compteur PERSISTE le long\n# de la boucle while-read continue.\n\
-    LAST_SEC=0\nSEQ=0\nTS=\"\"\nloki_ts() {\n  now=$(date +%s)\n  if [ \"$now\" =\
-    \ \"$LAST_SEC\" ]; then\n    SEQ=$((SEQ + 1))\n  else\n    LAST_SEC=\"$now\"\n\
-    \    SEQ=0\n  fi\n  # 9 chiffres de \xAB nanosecondes \xBB synth\xE9tiques (compteur\
-    \ intra-seconde).\n  TS=$(printf '%s%09d' \"$now\" \"$SEQ\")\n}\n\n# Pousse une\
-    \ ligne d'audit dans Loki, \xE9tiquet\xE9e par tenant.\npush_line() {\n  line=\"\
-    $1\"\n  [ -n \"$line\" ] || return 0\n  tenant=$(tenant_of \"$line\")\n  [ -n\
-    \ \"$tenant\" ] || tenant=\"unknown\"\n  lvl=$(level_of \"$line\")\n  loki_ts\
-    \            # met \xE0 jour TS (globale) sans sous-shell\n  ts=\"$TS\"\n  esc=$(json_escape\
-    \ \"$line\")\n  # `level` est une \xE9tiquette de stream standard : Loki la reconna\xEE\
-    t comme\n  # niveau (plus de detected_level=unknown) et Grafana colore le journal.\n\
-    \  payload=$(printf '{\"streams\":[{\"stream\":{\"service\":\"%s\",\"tenant\"\
-    :\"%s\",\"level\":\"%s\"},\"values\":[[\"%s\",\"%s\"]]}]}' \\\n    \"$SERVICE\"\
-    \ \"$tenant\" \"$lvl\" \"$ts\" \"$esc\")\n  # -s silencieux ; on ignore l'\xE9\
-    chec r\xE9seau ponctuel (la prochaine ligne suivra).\n  curl -s -o /dev/null -X\
-    \ POST \"$LOKI_URL\" \\\n    -H 'Content-Type: application/json' \\\n    --max-time\
-    \ 5 \\\n    --data-binary \"$payload\" || true\n}\n\n# Suit le journal en continu,\
-    \ historique inclus (-n +1), et pousse chaque ligne.\n# tail -F rouvre le fichier\
-    \ s'il est tourn\xE9/recr\xE9\xE9 (reset de la d\xE9mo).\ntail -n +1 -F \"$AUDIT_FILE\"\
-    \ 2>/dev/null | while IFS= read -r line; do\n  push_line \"$line\"\ndone\n"
+    \ \"$1\" | sed -n 's/.*\"tenant_id\":\"\\([^\"]*\\)\".*/\\1/p'\n}\n\n# Extrait\
+    \ le trace_id OTel (pr\xE9sent quand grob tourne avec --features otel et\n# [otel].enabled).\
+    \ Vide sinon (ligne sans trace, ex. attestation au d\xE9marrage).\ntrace_of()\
+    \ {\n  printf '%s' \"$1\" | sed -n 's/.*\"trace_id\":\"\\([^\"]*\\)\".*/\\1/p'\n\
+    }\n\n# D\xE9rive un NIVEAU de log (level) de la ligne d'audit, depuis son action\
+    \ et sa\n# classification. Sans niveau explicite, Loki affiche \xAB detected_level=unknown\
+    \ \xBB\n# (il ne sait pas deviner la gravit\xE9 d'une ligne JSON m\xE9tier). En\
+    \ \xE9mettant un\n# `level` standard, Grafana colore le journal par gravit\xE9\
+    \ et la gravit\xE9 \xE9pouse\n# le TYPE d'incident : injection bloqu\xE9e=critical,\
+    \ exfiltration bloqu\xE9e=error,\n# caviardage=warning, trafic normal=info.\n\
+    #   C3 (blocage + injection)  -> critical\n#   blocage DLP (C2 exfil)     -> error\n\
+    #   DLP_WARN (caviardage C1/C2)-> warning\n#   ERROR (\xE9chec dispatch)     ->\
+    \ error\n#   reste (RESPONSE/NC, \u2026)     -> info\nlevel_of() {\n  l=\"$1\"\
+    \n  act=$(printf '%s' \"$l\" | sed -n 's/.*\"action\":\"\\([^\"]*\\)\".*/\\1/p')\n\
+    \  cls=$(printf '%s' \"$l\" | sed -n 's/.*\"classification\":\"\\([^\"]*\\)\"\
+    .*/\\1/p')\n  case \"$act\" in\n    *BLOCK*) [ \"$cls\" = \"C3\" ] && echo \"\
+    critical\" || echo \"error\" ;;\n    DLP_WARN) echo \"warning\" ;;\n    ERROR)\
+    \    echo \"error\" ;;\n    *)        echo \"info\" ;;\n  esac\n}\n\n# \xC9chappe\
+    \ une ligne pour l'embarquer comme valeur de cha\xEEne JSON : antislash\n# d'abord,\
+    \ puis guillemets. (Les lignes d'audit n'ont ni saut de ligne ni\n# tabulation\
+    \ : une ligne JSONL = une ligne.)\njson_escape() {\n  printf '%s' \"$1\" | sed\
+    \ 's/\\\\/\\\\\\\\/g; s/\"/\\\\\"/g'\n}\n\n# Horodatage Loki en nanosecondes,\
+    \ monotone et unique par ligne. \xC9crit le\n# r\xE9sultat dans la variable GLOBALE\
+    \ TS au lieu de l'\xE9mettre sur stdout : appel\xE9\n# via $(...), le compteur\
+    \ SEQ vivrait dans un sous-shell et serait perdu, donc\n# toutes les lignes d'une\
+    \ m\xEAme seconde partageraient le m\xEAme horodatage \u2014 Loki\n# d\xE9dupliquerait\
+    \ alors et perdrait des lignes d'audit. En mutant une globale\n# (appel direct,\
+    \ sans substitution de commande), le compteur PERSISTE le long\n# de la boucle\
+    \ while-read continue.\nLAST_SEC=0\nSEQ=0\nTS=\"\"\nloki_ts() {\n  now=$(date\
+    \ +%s)\n  if [ \"$now\" = \"$LAST_SEC\" ]; then\n    SEQ=$((SEQ + 1))\n  else\n\
+    \    LAST_SEC=\"$now\"\n    SEQ=0\n  fi\n  # 9 chiffres de \xAB nanosecondes \xBB\
+    \ synth\xE9tiques (compteur intra-seconde).\n  TS=$(printf '%s%09d' \"$now\" \"\
+    $SEQ\")\n}\n\n# Pousse une ligne d'audit dans Loki, \xE9tiquet\xE9e par tenant.\n\
+    push_line() {\n  line=\"$1\"\n  [ -n \"$line\" ] || return 0\n  tenant=$(tenant_of\
+    \ \"$line\")\n  [ -n \"$tenant\" ] || tenant=\"unknown\"\n  lvl=$(level_of \"\
+    $line\")\n  tid=$(trace_of \"$line\")\n  loki_ts            # met \xE0 jour TS\
+    \ (globale) sans sous-shell\n  ts=\"$TS\"\n  esc=$(json_escape \"$line\")\n  #\
+    \ trace_id en STRUCTURED METADATA (3e \xE9l\xE9ment du tuple values), pas en label\
+    \ :\n  # forte cardinalit\xE9 (unique par requ\xEAte) \u2192 jamais un label index\xE9\
+    . Le derived\n  # field Loki d'otel-lgtm (matcher sur trace_id) en fait un lien\
+    \ \xAB Voir le trace \xBB\n  # vers Tempo. Absent (otel off / ligne hors requ\xEA\
+    te) \u2192 tuple \xE0 2 \xE9l\xE9ments.\n  if [ -n \"$tid\" ]; then\n    values=$(printf\
+    \ '[[\"%s\",\"%s\",{\"trace_id\":\"%s\"}]]' \"$ts\" \"$esc\" \"$tid\")\n  else\n\
+    \    values=$(printf '[[\"%s\",\"%s\"]]' \"$ts\" \"$esc\")\n  fi\n  # `level`\
+    \ est une \xE9tiquette de stream standard : Loki la reconna\xEEt comme\n  # niveau\
+    \ (plus de detected_level=unknown) et Grafana colore le journal.\n  payload=$(printf\
+    \ '{\"streams\":[{\"stream\":{\"service\":\"%s\",\"tenant\":\"%s\",\"level\":\"\
+    %s\"},\"values\":%s}]}' \\\n    \"$SERVICE\" \"$tenant\" \"$lvl\" \"$values\"\
+    )\n  # -s silencieux ; on ignore l'\xE9chec r\xE9seau ponctuel (la prochaine ligne\
+    \ suivra).\n  curl -s -o /dev/null -X POST \"$LOKI_URL\" \\\n    -H 'Content-Type:\
+    \ application/json' \\\n    --max-time 5 \\\n    --data-binary \"$payload\" ||\
+    \ true\n}\n\n# Suit le journal en continu, historique inclus (-n +1), et pousse\
+    \ chaque ligne.\n# tail -F rouvre le fichier s'il est tourn\xE9/recr\xE9\xE9 (reset\
+    \ de la d\xE9mo).\ntail -n +1 -F \"$AUDIT_FILE\" 2>/dev/null | while IFS= read\
+    \ -r line; do\n  push_line \"$line\"\ndone\n"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/demo/grob.config.toml
+++ b/deploy/demo/grob.config.toml
@@ -149,3 +149,14 @@ scan_markdown_links = true
 scan_raw_urls = true
 blacklist_domains = ["evil.example.com"]
 domain_match_mode = "suffix"
+
+# --- OpenTelemetry : export des traces vers Tempo (corrélation logs <-> traces) -
+# Active l'exportateur OTLP/gRPC (image construite avec --features otel). Chaque
+# requête devient un trace exporté vers le Tempo d'otel-lgtm ; la ligne d'audit
+# correspondante porte le meme trace_id (capté du span courant), ce qui permet le
+# saut "Voir le trace" depuis le journal Loki (derived field pré-câblé par
+# otel-lgtm). Endpoint = localhost car les conteneurs du pod partagent le netns.
+[otel]
+enabled = true
+endpoint = "http://localhost:4317"
+service_name = "grob"


### PR DESCRIPTION
## What

Wires the demo to demonstrate the audit↔trace correlation added in #433. The audit feature stamps each line with the OpenTelemetry `trace_id`, but the demo built grob *without* the `otel` feature and never enabled the exporter — so there was no trace to link to and no `trace_id` on the lines.

- **Containerfile**: build the demo image with `--features otel` (OTLP exporter).
- **grob.config.toml**: add an `[otel]` block — `enabled = true`, `endpoint = http://localhost:4317` (shared pod netns), `service_name = "grob"`.
- **audit-loki.sh**: lift the `trace_id` from each audit line and attach it as Loki **structured metadata** (3rd `values`-tuple element) — never a label, since one id per request is unbounded cardinality. Lines without a trace (otel off, startup attestation) keep the 2-element tuple, so nothing else changes.
- **demo.kube.yaml**: regenerated from source via `gen-kube.sh` (no hand-editing).

otel-lgtm's pre-wired Loki→Tempo derived field turns the `trace_id` structured metadata into a "View trace" jump.

## Verified end-to-end against a live `podman kube play` deploy

- grob logs: `OpenTelemetry enabled → http://localhost:4317 (service: grob)`, BatchSpanProcessor started.
- Audit file: 368 lines carrying lowercase 32-hex `trace_id`.
- Loki: `{service="grob-audit"} | trace_id != ""` returns lines with `trace_id` as structured metadata.
- Tempo: that same `trace_id` resolves to a trace with `service.name = grob`.

Depends on #433 (the source feature) for the `trace_id` to actually appear; no file overlap, so it merges independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)