### PR TITLE
chore: release v0.36.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.73](https://github.com/azerozero/grob/compare/v0.36.72...v0.36.73) - 2026-06-15
+
+### Added
+
+- *(audit)* add OpenTelemetry trace_id/span_id to audit entries
+
+### Other
+
+- *(demo)* emit a Loki level so audit logs stop showing detected_level=unknown
+- *(demo)* make governance table fit narrow viewports in alert state
+- *(demo)* fix horizontal scrollbar on the governance table
+- *(demo)* polish governance + live-block UI (ui-ux-pro-max pass)
+- *(demo)* add RSSI / agent-governance showcase kit
+
 ## [0.36.72](https://github.com/azerozero/grob/compare/v0.36.71...v0.36.72) - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.72"
+version = "0.36.73"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.72"
+version = "0.36.73"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.72 -> 0.36.73

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.73](https://github.com/azerozero/grob/compare/v0.36.72...v0.36.73) - 2026-06-15

### Added

- *(audit)* add OpenTelemetry trace_id/span_id to audit entries

### Other

- *(demo)* emit a Loki level so audit logs stop showing detected_level=unknown
- *(demo)* make governance table fit narrow viewports in alert state
- *(demo)* fix horizontal scrollbar on the governance table
- *(demo)* polish governance + live-block UI (ui-ux-pro-max pass)
- *(demo)* add RSSI / agent-governance showcase kit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).