### PR TITLE
chore: release v0.36.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.74](https://github.com/azerozero/grob/compare/v0.36.73...v0.36.74) - 2026-06-15
+
+### Added
+
+- *(api)* add context-window compact guard
+
+### Other
+
+- *(demo)* wire governance dashboards
+
 ## [0.36.73](https://github.com/azerozero/grob/compare/v0.36.72...v0.36.73) - 2026-06-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.73"
+version = "0.36.74"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.73"
+version = "0.36.74"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.73 -> 0.36.74

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.74](https://github.com/azerozero/grob/compare/v0.36.73...v0.36.74) - 2026-06-15

### Added

- *(api)* add context-window compact guard

### Other

- *(demo)* wire governance dashboards
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).