### PR TITLE
docs: clarify launch positioning and context errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <strong>Your LLM traffic leaks data. Grob stops it.</strong>
   </p>
   <p align="center">
-    The only LLM proxy with built-in DLP, written in Rust, deployable air-gapped.
+    A Rust LLM control plane with inline DLP, routing, budgets, and signed audit logs.
   </p>
   <p align="center">
     <a href="https://github.com/azerozero/grob/actions/workflows/ci.yml"><img src="https://github.com/azerozero/grob/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -16,7 +16,7 @@
 
 ---
 
-**Grob** is a high-performance LLM routing proxy that sits between your AI tools and your providers. It redacts secrets before they reach the API, fails over transparently when a provider goes down, and fits in a 6 MB container with zero dependencies.
+**Grob** is a high-performance LLM control plane that sits between your AI tools and your providers. It redacts secrets before they reach the API, fails over transparently when a provider goes down, enforces budgets, records signed audit logs, and fits in a 6 MB container with zero dependencies.
 
 > **~90 µs pure overhead** with full DLP + routing + caching + rate limiting -- [40x faster than LiteLLM, every feature measured individually](docs/reference/benchmarks.md).
 
@@ -42,6 +42,7 @@ flowchart LR
 | Provider goes down during a coding session | **Multi-provider failover** with circuit breakers and exponential backoff. Zero client changes |
 | No visibility into what your AI tools send | **`grob watch`** -- live TUI showing every request, response, DLP action, and fallback in real time |
 | Bill shock from runaway LLM usage | **Spend tracking** with per-tenant budgets, monthly caps, and alerts at 80% |
+| Agent context grows until providers return opaque 5xx errors | **Context-window guard** estimates input tokens before dispatch, returns `context_length_exceeded`, and tells Codex/Claude to compact |
 | AI agent executes destructive tool calls without review | **HIT Gateway** -- intercepts every `tool_use` block, enforces per-policy approval rules (auto-approve / require human / deny), supports multisig and quorum |
 | Deploying in air-gapped / sovereign environments | **Single binary, 6 MB, zero dependencies** -- no Python, no PostgreSQL, no Redis |
 
@@ -97,7 +98,7 @@ enabled = true
 action = "block"             # Data exfiltration URLs → stripped
 ```
 
-No other LLM proxy does this. LiteLLM, Bifrost, Portkey, Kong -- none have inline DLP on the hot path.
+Most LLM proxies focus on routing and spend. Grob keeps inline DLP on the hot path, so sensitive data can be redacted or blocked before it reaches a provider.
 
 ## Live traffic inspector
 
@@ -221,6 +222,7 @@ grob preset apply gdpr        # EU-only routing + DLP
 - **Response caching** -- Dedup temperature=0 requests (saves tokens and money)
 - **Native TLS + ACME** -- Built-in HTTPS with Let's Encrypt auto-certificates
 - **Three API endpoints** -- `/v1/messages` (Anthropic), `/v1/chat/completions` (OpenAI), `/v1/responses` (Codex CLI)
+- **Context-window guard** -- pre-dispatch compact hints and OpenAI/Anthropic-compatible `context_length_exceeded` errors
 - **Prometheus + OpenTelemetry** -- `/metrics` endpoint, OTLP distributed tracing
 - **MCP tool matrix** -- JSON-RPC server for tool-calling orchestration
 
@@ -242,6 +244,7 @@ api_key = "$OPENROUTER_API_KEY"
 
 [[models]]
 name = "default"
+context_window_tokens = 200000
 [[models.mappings]]
 provider = "anthropic"
 actual_model = "claude-sonnet-4-6"

--- a/docs/how-to/providers.md
+++ b/docs/how-to/providers.md
@@ -241,7 +241,7 @@ The OpenAI-compat endpoint accepts a few GLM-specific request fields that grob d
 - `request_id: string` — user-provided trace ID.
 - `tool_stream: bool` — streaming for function calls (GLM-4.6+).
 
-Grob requests pass through without these fields, which is harmless: the server applies its defaults. Error response shape (`{ code, message }` instead of OpenAI's `{ error: { message, type, code } }`) and finish reasons (`sensitive`, `model_context_window_exceeded`, `network_error`) are normalized into grob's standard error envelope at the dispatch layer.
+Grob requests pass through without these fields, which is harmless: the server applies its defaults. Error response shape (`{ code, message }` instead of OpenAI's `{ error: { message, type, code } }`) and finish reasons (`sensitive`, `model_context_window_exceeded`, `network_error`) are normalized into grob's standard error envelope at the dispatch layer. Context-window overflows are normalized further to HTTP `400` with `context_length_exceeded` and compact hint headers so clients can retry after `/compact`.
 
 If you need GLM thinking control end-to-end, use the Anthropic-compatible path — `provider_type = "z.ai"` + Anthropic `thinking` blocks map cleanly to GLM's reasoning mode at the upstream.
 

--- a/docs/reference/api-compatibility.md
+++ b/docs/reference/api-compatibility.md
@@ -483,6 +483,7 @@ All three endpoints return errors in OpenAI format when accessed via an OpenAI-c
   "error": {
     "message": "Error description",
     "type": "error_type",
+    "param": "optional_param",
     "code": "error_code"
   }
 }
@@ -498,6 +499,13 @@ All three endpoints return errors in OpenAI format when accessed via an OpenAI-c
   }
 }
 ```
+
+Context-window overflow is a special 400 path on every endpoint. Grob estimates
+input tokens before provider dispatch, emits `x-grob-action: compact` and
+`x-grob-context-*` headers, and returns `code: context_length_exceeded` in the
+endpoint's native error envelope. Upstream provider messages such as OpenAI
+Responses `response.failed` context-window errors are normalized to the same
+shape.
 
 ## Source files
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -143,6 +143,7 @@ Models define named routing targets with priority-based fallback chains.
 [[models]]
 name = "default"                  # Model name used by the router
 budget_usd = 2.0                  # Monthly spend limit for this model (optional)
+context_window_tokens = 200000     # Optional hard-window hint for compact guard
 
 [[models.mappings]]
 provider = "anthropic"            # Provider name (must match a [[providers]] entry)
@@ -157,6 +158,8 @@ inject_continuation_prompt = false # Inject a continuation prompt for non-Anthro
 ```
 
 When a request arrives, Grob tries providers in priority order. If a provider returns an error or times out, Grob moves to the next priority.
+
+`context_window_tokens` lets Grob reject oversized agent contexts before provider dispatch. At 80% of the window, Grob adds `x-grob-action: compact` warning headers. At 95%, it returns HTTP `400` with `context_length_exceeded` in the endpoint's native error format.
 
 ### Model strategies
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -5,11 +5,11 @@
 | Code | Meaning | When returned |
 |------|---------|---------------|
 | 200 | Success | Successful non-streaming response |
-| 400 | Bad Request | Invalid request body, missing required fields, schema validation failure |
+| 400 | Bad Request | Invalid request body, missing required fields, schema validation failure, or context window exceeded |
 | 401 | Unauthorized | Missing or invalid `Authorization` header when `api_key` is configured |
 | 402 | Payment Required | Monthly budget exceeded (global, per-provider, or per-model) |
 | 404 | Not Found | Unknown endpoint |
-| 413 | Payload Too Large | Request body exceeds `max_body_size` (default: 10 MB) |
+| 413 | Payload Too Large | Request body exceeds `max_body_size` when that limit is enabled (`0` / unlimited by default) |
 | 429 | Too Many Requests | Grob-level rate limit exceeded. Includes `Retry-After` header. |
 | 502 | Bad Gateway | All providers failed for the requested model |
 | 504 | Gateway Timeout | Provider request timed out (default: 10 minutes) |
@@ -72,6 +72,47 @@ grob spend
 Too many requests per second from the same client. The `Retry-After` header indicates how long to wait.
 
 This is the Grob-level rate limit, not an upstream provider limit. Upstream 429s trigger fallback to the next provider.
+
+### `context_length_exceeded` (400)
+
+The input is too close to, or over, the configured context window for the selected logical model. Grob estimates input tokens before provider dispatch so tools see a user-actionable error instead of an opaque upstream 502.
+
+OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/responses`) return:
+
+```json
+{
+  "error": {
+    "message": "Input exceeds the configured context window. Compact the conversation and retry.",
+    "type": "invalid_request_error",
+    "param": "input",
+    "code": "context_length_exceeded"
+  }
+}
+```
+
+Anthropic-compatible `/v1/messages` returns:
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "invalid_request_error",
+    "message": "Input exceeds the configured context window. Compact the conversation and retry.\n\nSuggested action:\nRun /compact, then retry the last request.",
+    "code": "context_length_exceeded",
+    "param": "input"
+  }
+}
+```
+
+Responses include compact hints for clients and dashboards:
+
+| Header | Meaning |
+|--------|---------|
+| `x-grob-action: compact` | Client should compact before retrying |
+| `x-grob-context-used` | Estimated context usage ratio |
+| `x-grob-context-window` | Context window used for the decision |
+| `x-grob-context-estimated-input` | Estimated input tokens |
+| `x-grob-context-threshold` | `warn` or `hard` |
 
 ### `Circuit breaker open for provider "..."` (502 with fallback)
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -13,6 +13,7 @@ Exhaustive list of grob capabilities, extracted from the codebase. The current v
 | Prompt-based routing | Regex rules with capture groups route specific prompts | `[[router.prompt_rules]]` |
 | Auto-mapping | Regex model name transformation (e.g., `^claude-` → default) | `[router] auto_map_regex` |
 | Fan-out racing | Parallel dispatch: fastest, best_quality, or weighted selection | `strategy = "fan_out"` |
+| Context-window guard | Warn at 80% and block at 95% before provider dispatch, with compact hints | `context_window_tokens` |
 | Response caching | Dedup temperature=0 requests (moka LRU, configurable TTL) | `[cache] enabled = true` |
 | Streaming SSE | Full SSE streaming for all endpoints and providers | Built-in |
 | Tool calling | Function calling support across all providers | Built-in |

--- a/docs/reference/openai-compatibility.md
+++ b/docs/reference/openai-compatibility.md
@@ -195,10 +195,16 @@ Errors follow OpenAI's format:
   "error": {
     "message": "Error description",
     "type": "error_type",
+    "param": "optional_param",
     "code": "error_code"
   }
 }
 ```
+
+Context-window overflow is normalized to HTTP `400` with
+`code: context_length_exceeded` and `param: input`. Grob also adds
+`x-grob-action: compact` plus context-usage headers so Codex-compatible clients
+can compact and retry instead of surfacing an upstream 502.
 
 ## Source files
 

--- a/docs/reference/responses-api-compatibility.md
+++ b/docs/reference/responses-api-compatibility.md
@@ -277,6 +277,15 @@ The effort value is forwarded to providers that support it. Anthropic backends m
 | Response structure | `choices[].message` | `output[]` items |
 | Multi-turn state | Stateless | `previous_response_id` (accepted but ignored) |
 
+## Error handling
+
+The Responses endpoint uses the same OpenAI-compatible error envelope as
+`/v1/chat/completions`. Oversized agent histories are normalized to HTTP `400`
+with `code: context_length_exceeded`, `param: input`, and
+`x-grob-action: compact` headers. If a provider reports a terminal
+`response.failed` context-window error, Grob maps it to the same client-visible
+shape instead of returning a generic `502`.
+
 ## Source files
 
 | File | Purpose |


### PR DESCRIPTION
## Summary
- position Grob as an LLM control plane for launch/readme messaging
- document context_length_exceeded and compact headers across API docs
- update config/features references for context_window_tokens

## Checks
- npx markdownlint-cli2 "docs/**/*.md" README.md CLAUDE.md --config .markdownlint.json
- git diff --check