### PR TITLE
fix: preserve context warnings on direct lookup

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -11,7 +11,7 @@ flowchart TB
     subgraph server["Axum HTTP Server"]
         direction TB
         mw1["1. Request ID<br/>Reads X-Request-Id or generates UUID v4"]
-        mw2["2. Body Size Limit<br/>Rejects payloads over max_body_size (10 MB)"]
+        mw2["2. Body Size Limit<br/>Optional max_body_size guard (disabled by default)"]
         mw3["3. Security Headers<br/>OWASP headers (X-Content-Type-Options, etc.)"]
         mw4["4. Rate Limiter<br/>Token-bucket per tenant/API-key/IP → 429"]
         mw5["5. Auth<br/>none / api_key / jwt"]

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -86,7 +86,7 @@ When enabled, Grob applies OWASP-recommended security headers to all responses:
 
 ### Request size limits
 
-Requests exceeding `max_body_size` (default: 10 MB) are rejected before parsing. This prevents memory exhaustion from oversized payloads.
+`max_body_size` defaults to `0`, which disables the body limit so large agent contexts are not rejected before parsing. Set a positive value to reject oversized payloads with HTTP `413` before parsing in multi-tenant or public deployments.
 
 ### Budget enforcement
 

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -1404,6 +1404,95 @@ actual_model = "beta"
         );
     }
 
+    #[tokio::test]
+    async fn dispatch_preserves_context_warning_on_direct_provider_lookup() {
+        use crate::models::{Message, MessageContent};
+
+        let toml = r#"
+[server]
+host = "127.0.0.1"
+port = 18098
+
+[router]
+default = "alpha"
+
+[[providers]]
+name = "mock"
+provider_type = "openai"
+auth_type = "apikey"
+api_key = "sk-test"
+base_url = "http://127.0.0.1:1"
+models = ["alpha"]
+
+[[models]]
+name = "alpha"
+mappings = []
+context_window_tokens = 100
+"#;
+        let config = crate::cli::AppConfig::from_content(toml, "dispatch_direct_lookup_guard_test")
+            .expect("config parses");
+        let mut registry = crate::providers::ProviderRegistry::new();
+        registry.insert_provider_for_test(
+            "mock",
+            Arc::new(crate::providers::mocks::MockLlmProvider::text(
+                "alpha", "ok",
+            )),
+        );
+        let state = crate::server::test_app_state(config, registry);
+        let inner = state.snapshot();
+        let dlp: Option<Arc<DlpEngine>> = None;
+        let headers = HeaderMap::new();
+        let ctx = DispatchContext {
+            state: &state,
+            inner: &inner,
+            dlp: &dlp,
+            model: "alpha".to_string(),
+            is_streaming: false,
+            tenant_id: None,
+            allowed_models: None,
+            allowed_providers: Vec::new(),
+            peer_ip: "127.0.0.1".to_string(),
+            req_id: "test-req",
+            start_time: std::time::Instant::now(),
+            headers: &headers,
+            trace_id: None,
+            audited: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            #[cfg(feature = "policies")]
+            resolved_policy: None,
+        };
+
+        let mut request = CanonicalRequest {
+            model: "alpha".to_string(),
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: MessageContent::Text("x".repeat(320)),
+            }],
+            max_tokens: 16,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            thinking: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            metadata: None,
+            extensions: Default::default(),
+        };
+
+        let result = dispatch(&ctx, &mut request)
+            .await
+            .expect("dispatch succeeds");
+        let DispatchResult::Complete { context_guard, .. } = result else {
+            panic!("expected non-streaming response");
+        };
+        let info = context_guard.expect("context warning must survive direct lookup");
+        assert_eq!(info.context_window, 100);
+        assert!(info.usage_ratio >= 0.80);
+        assert!(!info.should_compact);
+    }
+
     // ── SLICE 3: policy overrides (matching fix + budget + rate_limit) ──
 
     /// Config declaring one policy with a `route_type` condition plus the given

--- a/src/server/dispatch/provider_loop.rs
+++ b/src/server/dispatch/provider_loop.rs
@@ -200,7 +200,8 @@ pub(super) async fn dispatch_provider_loop(
     // If those mappings are skipped by circuit breaker / endpoint health, direct
     // lookup would bypass `actual_model` and send that alias upstream.
     if should_try_direct_lookup(effective_mappings.len(), &last_error) {
-        if let Some(result) = try_direct_provider_lookup(ctx, request, &decision.model_name).await?
+        if let Some(result) =
+            try_direct_provider_lookup(ctx, request, &decision.model_name, context_guard).await?
         {
             return Ok(result);
         }

--- a/src/server/dispatch/resolver.rs
+++ b/src/server/dispatch/resolver.rs
@@ -102,6 +102,7 @@ pub(super) async fn try_direct_provider_lookup(
     ctx: &DispatchContext<'_>,
     request: &crate::models::CanonicalRequest,
     model_name: &str,
+    context_guard: Option<crate::server::ContextGuardInfo>,
 ) -> Result<Option<DispatchResult>, RequestError> {
     let Ok(provider) = ctx.inner.provider_registry.provider_for_model(model_name) else {
         return Ok(None);
@@ -132,6 +133,6 @@ pub(super) async fn try_direct_provider_lookup(
         provider: model_name.to_string(),
         actual_model: model_name.to_string(),
         provider_duration_ms: 0,
-        context_guard: None,
+        context_guard,
     }))
 }


### PR DESCRIPTION
## Summary
- keep context-window compact warning metadata when dispatch falls back to legacy direct provider lookup
- add a regression test for the direct lookup path
- sync docs with the current max_body_size default

## Validation
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test --lib
- cargo test --doc
- markdownlint-cli2 docs/**/*.md README.md CLAUDE.md
- lychee docs/**/*.md README.md CLAUDE.md
- jq validation for Grafana dashboards