### PR TITLE
chore: release v0.36.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.75](https://github.com/azerozero/grob/compare/v0.36.74...v0.36.75) - 2026-06-16
+
+### Fixed
+
+- preserve context warnings on direct lookup
+
+### Other
+
+- sync body limit explanation
+- clarify launch positioning and context errors
+
 ## [0.36.74](https://github.com/azerozero/grob/compare/v0.36.73...v0.36.74) - 2026-06-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.74"
+version = "0.36.75"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.74"
+version = "0.36.75"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.74 -> 0.36.75

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.75](https://github.com/azerozero/grob/compare/v0.36.74...v0.36.75) - 2026-06-16

### Fixed

- preserve context warnings on direct lookup

### Other

- sync body limit explanation
- clarify launch positioning and context errors
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).