### PR TITLE
chore(license): relicense core to Apache-2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,7 +812,7 @@ jobs:
               --annotation org.opencontainers.image.description="Multi-provider LLM routing proxy with automatic fallback" \
               --annotation org.opencontainers.image.source="https://github.com/${{ github.repository }}" \
               --annotation org.opencontainers.image.version="${VERSION#v}" \
-              --annotation org.opencontainers.image.licenses="AGPL-3.0-only"
+              --annotation org.opencontainers.image.licenses="Apache-2.0"
           done
 
           # Create multi-arch manifest list
@@ -886,7 +886,7 @@ jobs:
             desc "High-performance LLM routing proxy with built-in DLP"
             homepage "https://github.com/azerozero/grob"
             version "${V}"
-            license "AGPL-3.0-only"
+            license "Apache-2.0"
 
             on_macos do
               if Hardware::CPU.arm?

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -171,7 +171,7 @@ jobs:
                 body: [
                   `Thank you for your contribution! Before we can merge this PR, you need to sign our [Contributor License Agreement](${CLA_URL}).`,
                   '',
-                  'The CLA ensures that A00 SASU can distribute your contribution under both the AGPL-3.0 and our commercial license. **You retain full copyright** on your contributions.',
+                  'The CLA ensures that A00 SASU can distribute your contribution under Apache-2.0 and, when needed, under commercial or proprietary licenses. **You retain full copyright** on your contributions.',
                   '',
                   'To sign, please post a comment with exactly the following text:',
                   '',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Multi-provider LLM routing proxy that sits between AI coding assistants and LLM 
 - **Allocator**: jemalloc on non-MSVC targets
 - **CI**: GitHub Actions (fmt, clippy, nextest, coverage, cargo-audit, cargo-deny, cargo-hack, cargo-machete)
 - **Container**: Multi-stage build, `FROM scratch` (~6 MB image)
-- **License**: AGPL-3.0 with commercial dual-licensing
+- **License**: Apache-2.0 core with commercial Admin/Enterprise products
 
 ## Architecture
 

--- a/CLA.md
+++ b/CLA.md
@@ -51,15 +51,16 @@ Contribution shall terminate as of the date such litigation is filed.
 As a condition on the exercise of the rights granted in Sections 1
 and 2, We agree to license Your Contribution:
 
-(a) under the terms of the GNU Affero General Public License
-    version 3.0 (AGPL-3.0) as currently used for the Material; and
+(a) under the terms of the Apache License, Version 2.0
+    (Apache-2.0) as currently used for the Material; and
 
 (b) under any other license, including commercial and proprietary
     licenses, that We may use to distribute the Material.
 
-This means We may distribute Your Contribution under the AGPL-3.0,
-under a commercial license, or under both simultaneously. This is the
-mechanism that enables dual licensing of the Grob project.
+This means We may distribute Your Contribution under Apache-2.0,
+under a commercial or proprietary license, or under both simultaneously.
+This is the mechanism that keeps Grob Core permissive while allowing
+commercial products and managed offerings.
 
 ## 4. Moral Rights
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,10 @@ Report unacceptable behaviour to `conduct@a00.fr`.
 
 ## License and CLA
 
-Grob is licensed under AGPL-3.0. By submitting a pull request you agree
-to the [Contributor License Agreement](CLA.md), which grants A00 SASU
-the right to distribute your contributions under both AGPL-3.0 and the
-commercial licence.
+Grob Core is licensed under Apache-2.0. By submitting a pull request you
+agree to the [Contributor License Agreement](CLA.md), which grants A00 SASU
+the right to distribute your contributions under Apache-2.0 and, when needed,
+under commercial or proprietary licenses for paid products.
 
 ## Getting started
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "grob"
 version = "0.36.75"
 edition = "2021"
-license = "AGPL-3.0-only"
+license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"
 repository = "https://github.com/azerozero/grob"
 keywords = ["llm", "proxy", "router", "openai", "anthropic"]
@@ -117,7 +117,7 @@ include_dir = "0.7"
 # JWT Auth
 jsonwebtoken = { version = "10", default-features = false, features = ["use_pem", "rust_crypto"] }
 
-# Security (HDS/PCI/SecNumCloud compliance)
+# Security controls for HDS/PCI/SecNumCloud-style audit evidence
 p256 = { version = "0.13", features = ["ecdsa"] }   # ECDSA P-256 for audit signing
 ecdsa = "0.16"                                       # ECDSA traits
 ed25519-dalek = { version = "2", features = ["rand_core"] }  # Ed25519 for audit signing

--- a/Containerfile
+++ b/Containerfile
@@ -36,7 +36,7 @@ FROM scratch
 LABEL org.opencontainers.image.title="grob"
 LABEL org.opencontainers.image.description="LLM Routing Proxy with DLP and compliance"
 LABEL org.opencontainers.image.source="https://github.com/azerozero/grob"
-LABEL org.opencontainers.image.licenses="AGPL-3.0"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 # Copy CA certificates for TLS (from builder)
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/LICENSE
+++ b/LICENSE
@@ -1,685 +1,201 @@
-Grob - High-performance LLM routing proxy
-Copyright (C) 2025-2026 A00 SASU
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, version 3 of the License.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
----
-
-Commercial licensing is available for organizations that cannot comply
-with AGPL-3.0 terms. See LICENSING.md for details.
-
-Originally forked from claude-code-mux by Eli Dickinson (MIT License).
-
----
-
-                    GNU AFFERO GENERAL PUBLIC LICENSE
-                       Version 3, 19 November 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-                            Preamble
-
-  The GNU Affero General Public License is a free, copyleft license for
-software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.
-
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-our General Public Licenses are intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.
-
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
-
-  Developers that use our General Public Licenses protect your rights
-with two steps: (1) assert copyright on the software, and (2) offer
-you this License which gives you legal permission to copy, distribute
-and/or modify the software.
-
-  A secondary benefit of defending all users' freedom is that
-improvements made in alternate versions of the program, if they
-receive widespread use, become available for other developers to
-incorporate.  Many developers of free software are heartened and
-encouraged by the resulting cooperation.  However, in the case of
-software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and
-letting the public access it on a server without ever releasing its
-source code to the public.
-
-  The GNU Affero General Public License is designed specifically to
-ensure that, in such cases, the modified source code becomes available
-to the community.  It requires the operator of a network server to
-provide the source code of the modified version running there to the
-users of that server.  Therefore, public use of a modified version, on
-a publicly accessible server, gives the public access to the source
-code of the modified version.
-
-  An older license, called the Affero General Public License and
-published by Affero, was designed to accomplish similar goals.  This is
-a different license, not a version of the Affero GPL, but Affero has
-released a new version of the Affero GPL which permits relicensing under
-this license.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.
-
-                       TERMS AND CONDITIONS
-
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU Affero General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-  13. Remote Network Interaction; Use with the GNU General Public License.
-
-  Notwithstanding any other provision of this License, if you modify the
-Program, your modified version must prominently offer all users
-interacting with it remotely through a computer network (if your version
-supports such interaction) an opportunity to receive the Corresponding
-Source of your version by providing access to the Corresponding Source
-from a network server at no charge, through some standard or customary
-means of facilitating copying of software.  This Corresponding Source
-shall include the Corresponding Source for any work covered by version 3
-of the GNU General Public License that is incorporated pursuant to the
-following paragraph.
-
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the work with which it is combined will remain governed by version
-3 of the GNU General Public License.
-
-  14. Revised Versions of this License.
-
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time.  Such new versions
-will be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU Affero General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU Affero General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-  If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-  15. Disclaimer of Warranty.
-
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source.  For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code.  There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
-<http://www.gnu.org/licenses/>.
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,127 +1,119 @@
 # Grob Licensing
 
-Grob Core is dual-licensed:
+Grob Core is licensed under the **Apache License 2.0**.
 
-1. **GNU Affero General Public License v3.0 (AGPL-3.0)**
-2. A **commercial license** from A00 SASU
+The public gateway, CLI, provider adapters, OpenAI/Anthropic compatibility
+layers, MCP integration, DLP primitives, signed audit foundations, policy
+engine primitives, presets, deployment manifests, and documentation in this
+repository are open source and may be used commercially under Apache-2.0.
 
-The AGPL-3.0 applies by default to the public source code. A commercial license
-is an alternative for organizations that do not want AGPL-3.0 obligations, need
-to keep modifications private, embed Grob in a proprietary product, require
-support / SLA / procurement terms, or need the Enterprise / Admin editions.
+Historical releases keep the license they were published under. Releases before
+the Apache-2.0 relicensing remain available under their original AGPL-3.0 /
+commercial terms.
 
-> The AGPL-3.0 edition is fully functional and suitable for self-managed use.
-> **It is not limited by company size or user count** — open source rights cannot
-> be restricted that way. User counts and deployment scope only size the
-> commercial tiers below.
+## Open Source License: Apache-2.0
 
-## Open Source License: AGPL-3.0
+Apache-2.0 lets you use, copy, modify, distribute, sublicense, and sell Grob
+Core, including in commercial and proprietary products, as long as you comply
+with the license notice and attribution requirements.
 
-You may use, study, modify, and distribute Grob Core under AGPL-3.0, **at any
-scale**.
+Apache-2.0 also includes an explicit patent license from contributors, which is
+important for infrastructure software deployed inside companies.
 
-- If you modify Grob and let users interact with the modified version over a
-  network, AGPL-3.0 **§13** requires you to offer those users the *Corresponding
-  Source* of your modified version.
-- Derivative works are licensed under AGPL-3.0.
-- See the [LICENSE](LICENSE) file for the full legal text.
+See the [LICENSE](LICENSE) file for the full legal text and [NOTICE](NOTICE) for
+project attribution.
 
-## Commercial Licensing
+## Commercial Products
 
-A commercial license grants the right to use Grob outside AGPL-3.0 terms, under a
-separate agreement. Depending on the tier, you are buying: the AGPL waiver, the
-right to keep modifications private, redistribution / OEM rights, support & SLA,
-procurement-friendly terms (warranty / indemnity / SBOM / provenance), the
-Enterprise modules, the Admin console, and managed hosting.
+The open-source core is the data plane. Advanced packaged products and managed
+offerings may be commercial:
 
-Recommended when you need: proprietary deployment, private modifications,
-regulated environments, managed services, redistribution, OEM embedding,
-enterprise support, enterprise modules, air-gapped deployment, or non-AGPL
-procurement terms.
-
-## Editions
-
-| Edition | License | Includes |
+| Product | License | Includes |
 |---------|---------|----------|
-| **Grob Core** | AGPL-3.0 *or* commercial | LLM gateway & routing, OpenAI-compatible API, providers, DLP, signed audit log, policy engine, HIT approval (single-level), basic RBAC, compliance foundations (EU AI Act audit, GDPR/region flags, risk classification), CLI, OIDC, JSONL audit export, Helm chart |
-| **Grob Commercial** | Commercial | Grob Core under commercial terms — AGPL waiver, private modifications, support |
-| **Grob Enterprise** | Commercial | Enterprise modules: HA / clustering / active-active, multi-region, advanced SIEM connectors (Splunk/Sentinel/Elastic/QRadar), turnkey compliance packs (NIS2/DORA/ISO 27001/AI Act), advanced RBAC, multi-level approval, air-gap bundle, long-term retention |
-| **Grob Admin** | Commercial | Web console: policy builder, audit explorer, compliance dashboard, fleet & tenant management, GitOps manifest generation, license management, multi-instance health |
+| **Grob Core** | Apache-2.0 | LLM gateway and routing, OpenAI/Anthropic-compatible APIs, providers, DLP primitives, signed audit log foundations, policy engine primitives, HIT approval primitives, CLI, OIDC, JSONL audit export, presets, Helm chart |
+| **Grob Admin** | Commercial | Web console: policy builder, audit explorer, compliance evidence dashboard, fleet and tenant management, GitOps manifest generation, license management, multi-instance health |
+| **Grob Enterprise** | Commercial | HA / clustering / active-active, multi-region operations, advanced SIEM connectors, turnkey policy packs, advanced RBAC, multi-level approval, air-gap bundle, signed long-term retention |
 | **Grob Cloud** | Commercial SaaS | Dedicated hosted instance-per-tenant, Admin included, managed operations |
+| **Grob Trace-to-Automation** | Commercial or source-available | Advanced trace replay, workflow synthesis, production evidence packs, and automation templates |
 
 The Core / Enterprise / Admin boundary follows
-[ADR-0028](docs/decisions/0028-open-core-boundary.md): security **primitives and
-foundations** are open (AGPL); **packaged products, advanced tiers, and the web
-console** are commercial.
+[ADR-0029](docs/decisions/0029-relicense-core-apache.md): primitives and
+interfaces belong in the open-source core; turnkey packaged workflows, managed
+operations, advanced UI, and long-term compliance evidence products can be
+commercial.
 
 ## Pricing (indicative)
 
 | Plan | Use case | Starting price |
 |------|----------|---------------:|
 | **Developer** | Local workstation, evaluation, development | Free |
-| **Community** | AGPL-3.0 self-managed use, any size | Free |
-| **Pro** | Small production deployment under commercial terms | 5 000 EUR/year |
-| **Business** | Production deployment with support | 12 000 EUR/year |
+| **Community** | Apache-2.0 self-managed use, any size | Free |
+| **Pro** | Small production deployment with support | 5 000 EUR/year |
+| **Business** | Production deployment with support and procurement terms | 12 000 EUR/year |
 | **Enterprise** | Regulated or larger deployments + Enterprise modules | from 25 000 EUR/year |
 | **Regulated / Defense** | Source review under NDA, air-gap, security package | from 40 000 EUR/year |
 | **Integrator** | Deploy Grob for end clients (ESN / MSSP) | from 20 000 EUR/year + per-client terms |
-| **OEM** | Embed Grob in a third-party product | from 50 000 EUR/year |
+| **OEM** | Embed Grob with redistribution and support terms | from 50 000 EUR/year |
 | **Grob Cloud** | Dedicated hosted tenant | from 1 000 EUR/month |
 
 Prices are indicative and may vary with deployment size, support level,
-regulatory requirements, and redistribution rights. Quoted prices are locked for
-12 months from contract signature.
+regulatory requirements, managed operations, and redistribution rights. Quoted
+prices are locked for 12 months from contract signature.
 
-## Personal / local use
+## Compliance Wording
 
-For a single user on their own workstation (localhost), Grob is **free** under
-either:
+Grob does not make an organization compliant by itself and is not a substitute
+for legal review, certification, or provider due diligence.
 
-- the **AGPL-3.0**, or
-- a **free commercial grant for localhost-only use** (no AGPL obligations).
+The accurate claim is:
 
-No license key, no sign-up.
+> Grob provides compliance controls and audit evidence mapping for EU AI Act,
+> GDPR/RGPD, NIS2/DORA, and HDS/PCI-style audit requirements. Grob is not
+> certified by default.
+
+Operators still need to enable and configure the relevant controls, choose
+providers whose contractual and regional guarantees match their obligations,
+and validate the full deployment.
 
 ## Contributor License Agreement
 
 Contributions are accepted under the [Grob CLA](CLA.md). The CLA lets A00 SASU
-distribute contributed code under **both** the AGPL-3.0 and the commercial
-license; contributors retain copyright in their contributions. It is enforced by
-the `cla-check` job in CI, and is what makes dual-licensing possible.
+distribute contributed code under Apache-2.0 and, when needed, under commercial
+or proprietary licenses for paid products. Contributors retain copyright in
+their contributions.
+
+The CLA is enforced by the `cla-check` job in CI. The separate
+`origin/cla-signatures` branch stores signature evidence and should not be
+deleted as routine branch cleanup.
 
 ## FAQ
 
-### Can I use Grob internally under AGPL-3.0?
-Yes, at any scale. Running unmodified Grob internally under AGPL-3.0 is fine. If
-you **modify** Grob and let users interact with the modified version **over a
-network**, §13 requires you to offer those users the *Corresponding Source* of
-your modified version. Organizations that do not want to manage AGPL obligations
-can buy a commercial license.
+### Can I use Grob internally for free?
 
-### Do I have to publish my private internal modifications to the world?
-No. AGPL-3.0 requires offering source to users who **interact with the modified
-software over a network** — it does not, by itself, turn every private
-modification into a public release. For confidential, regulated, or proprietary
-deployments, a commercial license removes the obligation entirely.
+Yes. Grob Core is Apache-2.0 and can be used internally or commercially without
+a license key.
+
+### Do I need to publish private modifications?
+
+No. Apache-2.0 does not require publishing private modifications or network
+service source code.
+
+### Do I need a commercial license to embed Grob?
+
+Not for Grob Core. Apache-2.0 permits commercial embedding. A commercial
+agreement may still be useful for support, warranty, indemnity, redistribution
+terms, managed deployments, Enterprise modules, or Admin/Cloud products.
 
 ### Is the free edition limited by company size or user count?
-No. The AGPL-3.0 edition has **no** user-count or company-size limit — open
-source rights cannot be restricted that way. User counts only size the
-**commercial** tiers.
 
-### Do I need a commercial license to use Grob with Claude Code locally?
-No. Local single-user use on your own workstation is free (AGPL-3.0, or the free
-local commercial grant). No license key, no sign-up.
-
-### I'm a developer — can I use Grob for free?
-Yes. On your own machine (localhost) it is free, even for commercial work, under
-the AGPL-3.0 or the free local commercial grant.
+No. Apache-2.0 places no company-size or user-count limit on Grob Core.
 
 ### We are a defense contractor and need to audit the code.
+
 The **Regulated / Defense** tier provides source review under NDA, an air-gap
-bundle, and a security package (SBOM / signatures / offline updates), without
-AGPL redistribution obligations. Contact licensing@a00.fr.
+bundle, and a security package (SBOM / signatures / offline updates). Contact
+licensing@a00.fr.
 
 ## Contact
 
-For commercial licensing: **licensing@a00.fr**
+For commercial products, support, or licensing terms: **licensing@a00.fr**

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Grob
+Copyright 2025-2026 A00 SASU
+
+This product includes work originally forked from claude-code-mux by
+Eli Dickinson, licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/azerozero/grob/actions/workflows/ci.yml"><img src="https://github.com/azerozero/grob/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
     <a href="https://github.com/azerozero/grob/releases"><img src="https://img.shields.io/github/v/release/azerozero/grob" alt="Release"></a>
     <a href="https://github.com/azerozero/grob/releases"><img src="https://img.shields.io/github/downloads/azerozero/grob/total" alt="Downloads"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" alt="License: Apache-2.0"></a>
   </p>
 </p>
 
@@ -171,7 +171,7 @@ Presets configure everything in one command:
 | **perf** | Pure Anthropic OAuth (Pro/Max) — auto-maps `claude-*` to native | Max subscription |
 | **ultra-cheap** | Stacked free tiers (Groq + Cerebras + Z.ai + OpenRouter `:free`) | ~€0-2/month |
 | **gdpr** | EU-only routing — Mistral, Scaleway, OVH (`region = "eu"`) | Pay-as-you-go |
-| **eu-ai-act** | EU AI Act compliant — EU providers + transparency headers + risk classification | Pay-as-you-go |
+| **eu-ai-act** | EU AI Act controls — EU providers + transparency headers + risk classification | Pay-as-you-go |
 | **eu-eco** | Strict-EU sovereign, budget — Scaleway FR + Nebius `eu-north1` | Pay-as-you-go |
 | **eu-pro** | Strict-EU sovereign, balanced — Hermes-4-405B + Qwen3.5-397B | Pay-as-you-go |
 | **eu-max** | Strict-EU sovereign, premium — preemptive 397B/405B everywhere | Pay-as-you-go |
@@ -228,19 +228,21 @@ strategy = "fan_out"
 mode = "fastest"   # or "best_quality", "weighted"
 ```
 
-## Regulatory compliance
+## Compliance controls
 
-Grob maps its features to specific regulatory articles. Every claim is [verified against the codebase](docs/reference/features.md#implementation-verification-audited-2026-03-18).
+Grob maps technical controls to regulatory evidence needs. It does not certify
+your organization by itself; operators still need legal review, provider due
+diligence, and a hardened configuration. Every implementation claim is [verified against the codebase](docs/reference/features.md#implementation-verification-audited-2026-03-18).
 
 | Regulation | Coverage |
 |------------|----------|
 | **EU AI Act** | Art. 12 (signed audit log with model/tokens), Art. 14 (risk scoring + escalation webhook), Art. 15 (injection detection, 28 languages), Art. 52 (transparency headers) |
 | **GDPR/RGPD** | PII redaction, name pseudonymization, EU-only provider routing (`gdpr = true`), canary tokens for leak detection |
-| **HDS/PCI DSS/SecNumCloud** | Hash-chained audit entries, Merkle batch signing, classification NC/C1/C2/C3, AES-256-GCM credentials at rest |
+| **HDS/PCI-style evidence** | Hash-chained audit entries, Merkle batch signing, classification NC/C1/C2/C3, AES-256-GCM credentials at rest |
 | **NIS2/DORA** | Multi-provider resilience, escalation webhooks, zero-downtime upgrades |
 
 ```bash
-grob preset apply eu-ai-act   # EU AI Act + GDPR in one command
+grob preset apply eu-ai-act   # EU AI Act + GDPR-oriented controls
 grob preset apply gdpr        # EU-only routing + DLP
 ```
 
@@ -429,6 +431,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and PR gu
 
 ## License
 
-[AGPL-3.0](LICENSE) -- Commercial licensing available. See [LICENSING.md](LICENSING.md).
+[Apache-2.0](LICENSE). Commercial Admin, Enterprise, Cloud, and support products
+are described in [LICENSING.md](LICENSING.md).
 
 Built in Rust. Copyright (c) 2025-2026 [A00 SASU](https://github.com/azerozero).

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,4 @@
-# cargo-deny configuration for Grob (AGPL-3.0-only)
+# cargo-deny configuration for Grob (Apache-2.0)
 # https://embarkstudios.github.io/cargo-deny/
 
 # ── Advisories ───────────────────────────────────────────────────────────────
@@ -27,8 +27,8 @@ ignore = [
 ]
 
 # ── Licenses ─────────────────────────────────────────────────────────────────
-# Grob is AGPL-3.0-only. We allow permissive licenses (always compatible),
-# copyleft licenses compatible with AGPL-3.0, and a handful of special-purpose
+# Grob is Apache-2.0. We allow permissive licenses, weak-copyleft licenses that
+# are acceptable for this distribution model, and a handful of special-purpose
 # licenses commonly found in the Rust ecosystem.
 [licenses]
 version = 2
@@ -52,13 +52,7 @@ allow = [
     "Unlicense",
     "CC0-1.0",
 
-    # ── Copyleft (compatible with AGPL-3.0) ──
-    "AGPL-3.0-only",
-    "AGPL-3.0-or-later",
-    "GPL-3.0-only",
-    "GPL-3.0-or-later",
-    "LGPL-3.0-only",
-    "LGPL-3.0-or-later",
+    # ── Weak copyleft ──
     "MPL-2.0",
 
     # ── Ecosystem one-offs ──
@@ -66,12 +60,6 @@ allow = [
 ]
 # Minimum confidence for SPDX license detection.
 confidence-threshold = 0.8
-
-# The grob crate itself is AGPL-3.0-only; list it as an explicit exception
-# so cargo-deny never flags the workspace root.
-[[licenses.exceptions]]
-allow = ["AGPL-3.0-only"]
-name = "grob"
 
 # ── Bans ─────────────────────────────────────────────────────────────────────
 [bans]

--- a/deploy/demo/Containerfile
+++ b/deploy/demo/Containerfile
@@ -54,7 +54,7 @@ RUN TARGET="$(rustc -vV | sed -n 's/^host: //p')" && \
 FROM scratch
 LABEL org.opencontainers.image.title="grob-demo"
 LABEL org.opencontainers.image.description="Local patched grob for the governance demo"
-LABEL org.opencontainers.image.licenses="AGPL-3.0"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /grob /grob
 COPY --from=builder /runtime/var/lib/grob /var/lib/grob

--- a/docs/decisions/0028-open-core-boundary.md
+++ b/docs/decisions/0028-open-core-boundary.md
@@ -1,14 +1,18 @@
 ---
-status: accepted
+status: superseded
 date: 2026-06-14
 deciders: [azerozero]
 consulted: []
 informed: []
 supersedes: []
+superseded_by: [0029-relicense-core-apache]
 related: [0024-preset-as-compliance-template]
 ---
 
 # ADR-0028: Open-Core Boundary — AGPL Core vs Commercial Modules
+
+> Superseded by [ADR-0029](0029-relicense-core-apache.md), which relicenses
+> Grob Core to Apache-2.0 while keeping the open-core product boundary.
 
 ## Context and Problem Statement
 

--- a/docs/decisions/0029-relicense-core-apache.md
+++ b/docs/decisions/0029-relicense-core-apache.md
@@ -1,0 +1,137 @@
+---
+status: accepted
+date: 2026-06-18
+deciders: [azerozero]
+consulted: []
+informed: []
+supersedes: [0028-open-core-boundary]
+related: [0024-preset-as-compliance-template]
+---
+
+# ADR-0029: Relicense Grob Core to Apache-2.0
+
+## Context and Problem Statement
+
+Grob is infrastructure software: it sits in the request path between coding
+agents and LLM providers. The core adoption goal is broad deployment by
+individual developers, platform teams, regulated teams, integrators, and
+vendors who may embed the gateway in their own systems.
+
+The previous public core license was AGPL-3.0 with a commercial alternative.
+That protected against private SaaS modifications, but it also created legal
+friction for the exact enterprise and platform users Grob needs to reach.
+
+The strongest moat for Grob is not the network copyleft clause. It is the Rust
+single binary, provider compatibility, DLP-first request path, signed audit
+evidence, air-gap friendliness, deployment quality, trust, and commercial
+control-plane products.
+
+## Decision Drivers
+
+- Maximize adoption of the public gateway and CLI.
+- Make the core acceptable for enterprise infrastructure review.
+- Keep an explicit patent grant for contributors and users.
+- Preserve a clear open-core product boundary.
+- Avoid claiming that historical AGPL releases were never AGPL.
+- Keep commercial value in advanced packaged products, managed operations, and
+  support, not in blocking core gateway use.
+
+## Considered Options
+
+1. **Keep AGPL-3.0 + commercial license.**
+2. **Relicense Grob Core to MIT.**
+3. **Relicense Grob Core to Apache-2.0 and keep advanced products commercial.**
+4. **Move to a source-available license.**
+
+## Decision Outcome
+
+Chosen: **Option 3 — Grob Core is Apache-2.0**.
+
+From this decision forward, the public repository is licensed under
+Apache-2.0. Historical releases keep their original published license. Older
+AGPL-3.0 / commercial releases remain historical artifacts; they are not
+retroactively rewritten.
+
+### Public core
+
+The following remain in the open-source Apache-2.0 core:
+
+- Gateway and routing data plane.
+- CLI and local daemon workflows.
+- OpenAI, Anthropic, and Responses API compatibility layers.
+- Provider adapters and OpenAI-compatible provider support.
+- DLP primitives, request/response scanning, and redaction/blocking actions.
+- Signed audit foundations, hash chains, Merkle batching, and JSONL export.
+- Policy engine primitives, HIT approval primitives, fixed RBAC primitives.
+- Presets, SDK examples, MCP adapters, Helm and deployment manifests.
+- Documentation and compliance-control mappings.
+
+### Commercial products
+
+Commercial products may include:
+
+- Grob Admin web console.
+- HA / clustering / active-active and multi-region operations.
+- Advanced SIEM connectors and long-term signed audit retention.
+- Turnkey policy packs and compliance evidence packs.
+- Advanced RBAC, multi-level approval, fleet and tenant management.
+- Air-gap appliance, managed deployments, support, warranty, and indemnity.
+- Trace-to-automation products.
+
+### Compliance wording
+
+Grob must not claim that installing the core makes an organization compliant.
+The correct public wording is:
+
+> Grob provides compliance controls and audit evidence mapping for EU AI Act,
+> GDPR/RGPD, NIS2/DORA, and HDS/PCI-style audit requirements. Grob is not
+> certified by default.
+
+Operators must enable the relevant controls, configure providers and regions,
+and validate the full deployment against their obligations.
+
+### Contributor licensing
+
+The CLA remains in place. It lets A00 SASU distribute contributions under
+Apache-2.0 and, when needed, under commercial or proprietary licenses for paid
+products. Contributors retain copyright in their contributions.
+
+The `origin/cla-signatures` branch stores CLA evidence and is not a routine
+stale branch.
+
+## Consequences
+
+### Positive
+
+- Lower legal friction for platform teams and integrators.
+- Explicit Apache patent grant for infrastructure users.
+- Easier commercial embedding of the public gateway.
+- Clearer distinction between the open data plane and paid control plane.
+
+### Negative
+
+- Private SaaS modifications no longer trigger AGPL source obligations.
+- Competitors can reuse the public data plane under a permissive license.
+- The commercial boundary must be maintained by product discipline and private
+  repositories, not by core copyleft.
+
+## Guardrail
+
+Primitives and interfaces belong in the Apache-2.0 core. Turnkey packaged
+workflows, managed operations, advanced UI, multi-level enterprise governance,
+and long-term compliance evidence products may live in commercial repositories.
+
+When a feature is ambiguous, default to:
+
+- **Core**: protocol compatibility, security primitives, audit primitives,
+  policy primitives, local CLI ergonomics, deployment manifests.
+- **Commercial**: hosted/admin UI, fleet management, packaged compliance
+  reports, advanced integrations, managed operations, support commitments.
+
+## Confirmation
+
+- `LICENSE` contains Apache-2.0.
+- `Cargo.toml` declares `license = "Apache-2.0"`.
+- OCI and Homebrew metadata declare Apache-2.0.
+- Public docs avoid "Grob is GDPR/HDS/PCI compliant" claims.
+- The CLA bot still enforces contribution licensing.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -126,7 +126,7 @@ flowchart TB
 | `security::audit_log` | `src/security/audit_log.rs` | Signed audit log with ECDSA P-256 |
 | `security::cache` | `src/security/cache.rs` | Response caching (moka) |
 | `security::provider_scorer` | `src/security/provider_scorer.rs` | Adaptive provider scoring (EWMA latency, success rate) |
-| `security::risk` | `src/security/risk.rs` | Risk assessment for EU AI Act compliance |
+| `security::risk` | `src/security/risk.rs` | Risk assessment for EU AI Act controls |
 | `storage` | `src/storage/mod.rs` | Persistent storage layer: atomic files, JSONL journals (GrobStore) |
 | `storage::migrate` | `src/storage/migrate.rs` | Storage migrations |
 | `models` | `src/models/mod.rs` | Anthropic request/response types, route types |

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -115,16 +115,16 @@ This feature is opt-in because it changes the provider selection order within a 
 
 When `[cache] enabled = true`, Grob caches responses for deterministic requests (temperature=0). Cache keys are computed from the tenant ID, model, messages, and tools. The cache uses moka (concurrent, TTL-evicting) with configurable capacity and TTL. Cache hits bypass the entire provider pipeline, returning instantly with `x-grob-cache: hit`. Only non-streaming requests are cached.
 
-## EU AI Act compliance
+## EU AI Act controls
 
-The `[compliance]` section enables features required by the EU AI Act:
+The `[compliance]` section enables controls that support EU AI Act evidence needs:
 
 - **Transparency headers**: `X-AI-Provider`, `X-AI-Model`, `X-AI-Generated`, `X-Grob-Audit-Id` on every response (Article 50)
 - **Audit enrichment**: Model name and token counts recorded in audit entries (Article 12)
 - **Risk classification**: Requests scored by DLP trigger count, block status, injection detection, and PII presence (Article 14)
 - **Escalation**: High-risk events dispatched to a configured webhook for human review
 
-The `eu-ai-act` preset enables all compliance features in one command.
+The `eu-ai-act` preset enables the related controls in one command.
 
 ## Network binding
 

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -67,4 +67,4 @@ Pull requests run:
 
 ## License
 
-Grob is licensed under AGPL-3.0. By submitting a pull request, you agree to the [CLA](../../CLA.md), which grants A00 SASU the right to distribute your contributions under both AGPL-3.0 and the commercial license.
+Grob Core is licensed under Apache-2.0. By submitting a pull request, you agree to the [CLA](../../CLA.md), which grants A00 SASU the right to distribute your contributions under Apache-2.0 and, when needed, under commercial or proprietary licenses for paid products.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7,8 +7,8 @@ info:
     format translation, streaming, tool calling, budget enforcement, and DLP.
   version: "0.9.0"
   license:
-    name: AGPL-3.0-only
-    url: https://www.gnu.org/licenses/agpl-3.0.html
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
   contact:
     name: Grob
     url: https://github.com/azerozero/grob

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -404,7 +404,7 @@ Only deterministic requests (temperature=0) are cached. Cache hits return instan
 
 ```toml
 [compliance]
-enabled = false                    # Enable EU AI Act compliance features
+enabled = false                    # Enable EU AI Act control features
 transparency_headers = false       # Add X-AI-Provider, X-AI-Model, X-AI-Generated headers
 audit_model_name = false           # Record model name in audit entries (Article 12)
 audit_token_counts = false         # Record token counts in audit entries (Article 12)

--- a/docs/reference/dci-report-responses-compat.md
+++ b/docs/reference/dci-report-responses-compat.md
@@ -17,7 +17,7 @@
 | 7 | Deployment / operations | 3 | N/A | Module-level, not independently deployed |
 | 8 | Contributing guide | 2 | 0.5 | Source file table provided; project-level guide exists |
 | 9 | Changelog | 2 | 0.25 | Part of project-level changelog |
-| 10 | License | 1 | 1.0 | Project-level AGPL-3.0 |
+| 10 | License | 1 | 1.0 | Project-level Apache-2.0 |
 | 11 | CI/CD | 2 | N/A | Covered by project CI |
 | 12 | Security | 3 | 0.5 | DLP applies to all endpoints; no module-specific security doc |
 | 13 | LLM context (AGENTS.md) | 3 | 0.75 | Added to AGENTS.md and CLAUDE.md module table |

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -130,7 +130,7 @@ Grob maps its features to specific regulatory requirements. The table below show
 | Data classification | Audit entry classification levels: NC, C1, C2, C3 | `src/security/audit_log.rs` |
 | Credentials at rest | AES-256-GCM encryption for all stored secrets | `src/storage/encrypt.rs` |
 | Key management | File-based key with owner-only permissions (cross-platform) | `src/auth/token_store.rs` |
-| Security headers | OWASP-compliant HTTP response headers | `src/security/headers.rs` |
+| Security headers | OWASP-aligned HTTP response headers | `src/security/headers.rs` |
 
 ### SOC 2 / ISO 27001 / HIPAA
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -11,8 +11,8 @@ Grob ships with 7 built-in presets. Apply with `grob preset apply <name>`.
 | `eu-eco` | Strict-EU sovereign, budget — ~75% SWE-V | Scaleway FR + Nebius eu-north1 |
 | `eu-pro` | Strict-EU sovereign, balanced — ~82% SWE-V | Hermes-4-405B + Qwen3.5-397B |
 | `eu-max` | Strict-EU sovereign, premium — ~85% SWE-V | preemptive 397B/405B everywhere |
-| `gdpr` | EU-only GDPR compliant | Mistral, Scaleway, OVH (region=eu) |
-| `eu-ai-act` | EU AI Act compliant | EU providers + transparency headers + risk classification |
+| `gdpr` | EU-only GDPR-oriented routing | Mistral, Scaleway, OVH (region=eu) |
+| `eu-ai-act` | EU AI Act controls | EU providers + transparency headers + risk classification |
 
 ### Preset management commands
 

--- a/docs/reference/owasp-llm-top10.md
+++ b/docs/reference/owasp-llm-top10.md
@@ -170,9 +170,9 @@ monthly_limit_usd = 100.0
 warning_threshold = 0.8  # Warn at 80% spend
 ```
 
-## Audit and EU AI Act compliance
+## Audit and EU AI Act controls
 
-The `[compliance]` section enables features for the EU AI Act and enterprise audit requirements:
+The `[compliance]` section enables technical controls for EU AI Act and enterprise audit evidence needs:
 
 | Feature | EU AI Act article | Config key |
 |---------|------------------|------------|
@@ -181,7 +181,7 @@ The `[compliance]` section enables features for the EU AI Act and enterprise aud
 | Risk classification (Low/Medium/High/Critical) | Article 14 | `risk_classification` |
 | Escalation webhook for high-risk events | Article 14 | `escalation_webhook` |
 
-Audit entries are cryptographically signed (ECDSA P-256 or HMAC-SHA256) and hash-chained. Each entry includes a SHA-256 digest of the previous entry, making log tampering detectable. This supports HDS, PCI DSS, and SecNumCloud compliance frameworks.
+Audit entries are cryptographically signed (ECDSA P-256 or HMAC-SHA256) and hash-chained. Each entry includes a SHA-256 digest of the previous entry, making log tampering detectable. This supports HDS, PCI DSS, and SecNumCloud-style audit evidence.
 
 ## Defense-in-depth diagram
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -1,6 +1,6 @@
 # Security Reference
 
-Complete configuration reference for Grob's security middleware: rate limiting, circuit breakers, OWASP headers, audit logging, adaptive scoring, and EU AI Act compliance.
+Complete configuration reference for Grob's security middleware: rate limiting, circuit breakers, OWASP headers, audit logging, adaptive scoring, and EU AI Act controls.
 
 All settings live under the `[security]` section of `config.toml`.
 
@@ -120,7 +120,7 @@ When set, requests exceeding the limit are rejected with HTTP `413 Payload Too L
 
 ## Audit logging
 
-Signed, hash-chained audit log for compliance (HDS, PCI DSS, SecNumCloud, EU AI Act).
+Signed, hash-chained audit log for HDS, PCI DSS, SecNumCloud, and EU AI Act-style evidence.
 
 ```toml
 [security]

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -59,7 +59,7 @@ Presets are pre-built configurations that set up providers, models, and routing 
 | `perf` | Pure Anthropic OAuth (Pro/Max), auto-maps `claude-*` to native | Subscription only |
 | `ultra-cheap` | Stacked free tiers (Groq + Cerebras + Z.ai + OpenRouter `:free`) | ~€0-2/month |
 | `gdpr` | EU-only routing (Mistral, Scaleway, OVH) + DLP | Pay-as-you-go |
-| `eu-ai-act` | EU AI Act compliant (EU providers + transparency headers) | Pay-as-you-go |
+| `eu-ai-act` | EU AI Act controls (EU providers + transparency headers) | Pay-as-you-go |
 | `eu-eco` / `eu-pro` / `eu-max` | Strict-EU sovereign tiers (budget / balanced / premium) | Pay-as-you-go |
 
 Apply the `perf` preset (simplest — one Anthropic subscription, no fallbacks):

--- a/llms.txt
+++ b/llms.txt
@@ -70,8 +70,8 @@
 
 - [README](README.md): Project overview, install, quick start
 - [Changelog](CHANGELOG.md): Release history
-- [License](LICENSE): AGPL-3.0-only
-- [Licensing](LICENSING.md): Dual-license tiers and commercial options
+- [License](LICENSE): Apache-2.0
+- [Licensing](LICENSING.md): Apache-2.0 core and commercial product options
 - [Contributing](CONTRIBUTING.md): How to contribute (redirect to full guide)
 - [CLA](CLA.md): Contributor License Agreement
 - [AI Agent Context](AGENTS.md): Project context optimized for AI coding agents

--- a/presets/eu-ai-act.toml
+++ b/presets/eu-ai-act.toml
@@ -1,12 +1,13 @@
 [meta]
-description = "EU AI Act compliant — EU providers + transparency headers + risk classification"
+description = "EU AI Act controls — EU providers + transparency headers + risk classification"
 
-# Preset: eu-ai-act - EU AI Act compliant
-# EU-only providers with full compliance features enabled
+# Preset: eu-ai-act - EU AI Act controls
+# EU-only providers with audit and transparency controls enabled
 # Requires: MISTRAL_API_KEY (+ optionally SCALEWAY_API_KEY)
 #
 # Enables transparency headers, model/token audit logging,
-# risk classification, and DLP for full EU AI Act compliance.
+# risk classification, and DLP. This is technical evidence support,
+# not certification or legal compliance by itself.
 
 [router]
 default = "eu-default"

--- a/presets/gdpr.toml
+++ b/presets/gdpr.toml
@@ -1,12 +1,12 @@
 [meta]
-description = "EU-only GDPR compliant — Mistral, Scaleway, OVH (region=eu)"
+description = "EU-only GDPR-oriented routing — Mistral, Scaleway, OVH (region=eu)"
 
-# Preset: gdpr - EU-only GDPR compliant
+# Preset: gdpr - EU-only GDPR-oriented routing
 # Routes only through EU-hosted providers (Mistral, Scaleway, OVH)
 # Requires: MISTRAL_API_KEY (+ optionally SCALEWAY_API_KEY, OVH_API_KEY)
 #
-# All providers in this preset host data exclusively in the EU.
-# No data leaves European jurisdiction.
+# This preset keeps configured provider routing in the EU. Verify provider
+# contracts, subprocessors, and deployment settings for your compliance scope.
 
 [router]
 default = "eu-default"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // Grob - High-performance LLM routing proxy
 // Copyright (c) 2025-2026 A00 SASU
-// License: AGPL-3.0-only
+// License: Apache-2.0
 // See LICENSE for details
 
 #[cfg(feature = "jemalloc")]


### PR DESCRIPTION
Relicense Grob Core to Apache-2.0, update package and release metadata, and tighten public compliance wording around controls and audit evidence. Historical AGPL references stay only in superseded ADRs and changelog history.