### PR TITLE
fix(deps): bump anyhow 1.0.103 and quinn-proto 0.11.15 for RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -3767,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

Lockfile-only dependency bumps clearing the two open RUSTSEC advisories with published fixes:

- **anyhow 1.0.102 → 1.0.103** — fixes RUSTSEC-2026-0190, an unsoundness in `Error::downcast_mut()` after `Error::context()`. anyhow is a direct dependency compiled into the binary.
- **quinn-proto 0.11.14 → 0.11.15** — fixes RUSTSEC-2026-0185, remote memory exhaustion from unbounded out-of-order stream reassembly. quinn-proto is only present in the lockfile through reqwest's disabled `http3` feature and is never compiled, so there is no runtime exposure; the bump clears the daily cargo-audit alert.

No source or manifest changes — `Cargo.lock` only.

Closes #450
Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)