### PR TITLE
chore: release v0.36.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.76](https://github.com/azerozero/grob/compare/v0.36.75...v0.36.76) - 2026-07-02
+
+### Fixed
+
+- *(deps)* bump anyhow 1.0.103 and quinn-proto 0.11.15 for RUSTSEC advisories
+
+### Other
+
+- *(readme)* soften absolute claims and de-recycle benchmark headline
+- *(licensing)* replace indicative pricing grid with contact
+- split classify mutation shard
+- *(license)* relicense core to Apache-2.0
+- tighten demo gif crop
+- crop readme demo gif
+- add demo gif to readme
+- add local demo to readme
+- polish demo visuals and governance copy
+
 ## [0.36.75](https://github.com/azerozero/grob/compare/v0.36.74...v0.36.75) - 2026-06-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.75"
+version = "0.36.76"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.75"
+version = "0.36.76"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.75 -> 0.36.76

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.76](https://github.com/azerozero/grob/compare/v0.36.75...v0.36.76) - 2026-07-02

### Fixed

- *(deps)* bump anyhow 1.0.103 and quinn-proto 0.11.15 for RUSTSEC advisories

### Other

- *(readme)* soften absolute claims and de-recycle benchmark headline
- *(licensing)* replace indicative pricing grid with contact
- split classify mutation shard
- *(license)* relicense core to Apache-2.0
- tighten demo gif crop
- crop readme demo gif
- add demo gif to readme
- add local demo to readme
- polish demo visuals and governance copy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).