### PR TITLE
fix: unblock beta/nightly clippy and patch RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/security/audit_log.rs
+++ b/src/security/audit_log.rs
@@ -483,7 +483,7 @@ impl AuditLog {
 
     /// Builds the Merkle tree, signs the root, and writes all buffered entries.
     fn flush_batch(&self, state: &mut AuditLogState) -> Result<()> {
-        let batch: Vec<PendingEntry> = state.batch_buffer.drain(..).collect();
+        let batch: Vec<PendingEntry> = std::mem::take(&mut state.batch_buffer);
         state.batch_start = Instant::now();
 
         if batch.is_empty() {


### PR DESCRIPTION
## What

Two independent hygiene fixes surfaced by the scheduled workflows.

### 1. `clippy::drain_collect` breaks beta and nightly (#455)

`src/security/audit_log.rs:486` used `state.batch_buffer.drain(..).collect()`.
Stable clippy does not lint this yet; beta and nightly do, so every one of the
six `Nightly Toolchain Check` matrix jobs (beta/nightly x ubuntu/macos/windows)
has failed on `-D warnings` since at least 2026-07-19. Beta failing is a release
blocker per the issue template.

Replaced with `std::mem::take(&mut state.batch_buffer)` — same move semantics,
no intermediate reallocation.

### 2. `crossbeam-epoch` 0.9.18 -> 0.9.20 (#456)

RUSTSEC-2026-0204: invalid pointer dereference in the `fmt::Pointer` impl for
`Atomic`/`Shared`. Reached transitively via `moka` and
`metrics-exporter-prometheus` (runtime) plus the dev-only `rayon`/`ignore`
chains. Patch-level lockfile bump, no API change.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --all-features audit_log` — 15 passed

The beta-specific lint could not be reproduced locally (stable toolchain only);
the fix is clippy's own suggested rewrite. The `Nightly Toolchain Check`
workflow will confirm on its next scheduled run.

Closes #455
Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)