### PR TITLE
chore: release v0.36.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.77](https://github.com/azerozero/grob/compare/v0.36.76...v0.36.77) - 2026-07-24
+
+### Fixed
+
+- *(deps)* bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204
+- *(security)* take the audit batch buffer instead of draining it
+
 ## [0.36.76](https://github.com/azerozero/grob/compare/v0.36.75...v0.36.76) - 2026-07-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.76"
+version = "0.36.77"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.76"
+version = "0.36.77"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.76 -> 0.36.77

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.77](https://github.com/azerozero/grob/compare/v0.36.76...v0.36.77) - 2026-07-24

### Fixed

- *(deps)* bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204
- *(security)* take the audit batch buffer instead of draining it
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).