### PR TITLE
chore: release v0.36.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.78](https://github.com/azerozero/grob/compare/v0.36.77...v0.36.78) - 2026-07-24
+
+### Fixed
+
+- *(deps)* bump age to 0.12 to drop the unmaintained proc-macro-error2
+- *(deps)* bump the OpenTelemetry stack to 0.32 for GHSA-w9wp-h8wv-79jx
+
+### Other
+
+- Merge pull request #460 from azerozero/chore/otel-0-32
+- *(security)* drop advisory ignores no longer matching any crate
+
 ## [0.36.77](https://github.com/azerozero/grob/compare/v0.36.76...v0.36.77) - 2026-07-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.77"
+version = "0.36.78"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.77"
+version = "0.36.78"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.77 -> 0.36.78

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.78](https://github.com/azerozero/grob/compare/v0.36.77...v0.36.78) - 2026-07-24

### Fixed

- *(deps)* bump age to 0.12 to drop the unmaintained proc-macro-error2
- *(deps)* bump the OpenTelemetry stack to 0.32 for GHSA-w9wp-h8wv-79jx

### Other

- Merge pull request #460 from azerozero/chore/otel-0-32
- *(security)* drop advisory ignores no longer matching any crate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).