### PR TITLE
fix(security): empty the advisory ignore list (drop rsa, rustls-pemfile, spin)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,6 @@
-# Review date: 2026-07-24 — re-check if upstream fixed these.
-# Kept in sync with the `ignore` list in deny.toml.
+# Review date: 2026-07-24 — the ignore list is empty and should stay that way.
+# Kept in sync with the `ignore` list in deny.toml. Prefer moving off an
+# affected crate over adding an entry here; an ignore is a standing decision
+# that nobody re-reads.
 [advisories]
-ignore = [
-    # rsa: Marvin Attack (timing sidechannel on PKCS#1 v1.5 decryption).
-    # No impact: grob only uses RSA for JWT signature verification, not decryption.
-    "RUSTSEC-2023-0071",
-    # rustls-pemfile: unmaintained, pulled transitively by axum-server 0.7.
-    # axum-server 0.8 migrates to rustls-pki-types, but rustls-acme 0.12 pins 0.7.
-    # Track: https://github.com/tokio-rs/axum/issues — bump when rustls-acme supports 0.8.
-    "RUSTSEC-2025-0134",
-]
+ignore = []

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -464,12 +465,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http",
  "http-body",
@@ -477,7 +479,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1834,6 +1835,7 @@ dependencies = [
  "arc-swap",
  "async-stream",
  "async-trait",
+ "aws-lc-rs",
  "axum",
  "axum-server",
  "base64",
@@ -1880,7 +1882,6 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-acme",
- "rustls-pemfile",
  "secrecy 0.8.0",
  "serde",
  "serde_json",
@@ -2681,19 +2682,13 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.6",
- "rsa",
  "serde",
  "serde_json",
- "sha2",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -2763,9 +2758,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -3093,22 +3085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,24 +3111,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3291,18 +3255,6 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -3555,17 +3507,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
 ]
 
 [[package]]
@@ -4213,7 +4154,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4222,26 +4163,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "rust-embed"
@@ -4332,9 +4253,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-acme"
-version = "0.12.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f05935c0b1d7c5981c40b768c5d5ed96a43f5cb5166f8f5be09779c5825697"
+checksum = "b9c70a17ecb067d5067565a16a2e0f26a4a2ea0924f49739d558c45186facc75"
 dependencies = [
  "async-io",
  "async-trait",
@@ -4355,17 +4276,9 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "webpki-roots 0.26.11",
+ "tower-service",
+ "webpki-roots 1.0.7",
  "x509-parser",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -4387,7 +4300,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4763,12 +4676,6 @@ dependencies = [
  "rand 0.8.6",
  "sha1",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -5609,6 +5516,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ moka = { version = "0.12", features = ["future", "sync"] }
 include_dir = "0.7"
 
 # JWT Auth
-jsonwebtoken = { version = "10", default-features = false, features = ["use_pem", "rust_crypto"] }
+jsonwebtoken = { version = "10", default-features = false, features = ["use_pem", "aws_lc_rs"] }
 
 # Security controls for HDS/PCI/SecNumCloud-style audit evidence
 p256 = { version = "0.13", features = ["ecdsa"] }   # ECDSA P-256 for audit signing
@@ -142,12 +142,11 @@ crossterm = { version = "0.29", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 
 # TLS (optional, for native HTTPS without reverse proxy)
-axum-server = { version = "0.7", features = ["tls-rustls"], optional = true }
+axum-server = { version = "0.8", features = ["tls-rustls"], optional = true }
 rustls = { version = "0.23", optional = true }
-rustls-pemfile = { version = "2", optional = true }
 
 # ACME / Let's Encrypt auto-certificates (optional, requires tls feature)
-rustls-acme = { version = "0.12", features = ["axum"], optional = true }
+rustls-acme = { version = "0.15", features = ["axum"], optional = true }
 regex-syntax = "0.8.10"
 
 # Trace log compression (zstd for rotated trace files)
@@ -178,6 +177,10 @@ tracing-test = "0.2"       # Capture tracing logs in tests
 # Property Testing
 proptest = "1"
 rcgen = "0.13"             # Self-signed certs for TLS benchmarks
+# RSA keygen for the JWKS validation tests. Already in the tree via
+# jsonwebtoken's aws_lc_rs backend; `ring-io` exposes the (n, e) accessors the
+# JWKS path needs. Dev-only, so the release binary is unaffected.
+aws-lc-rs = { version = "1", features = ["ring-io"] }
 
 # Cucumber BDD (E2E)
 cucumber = "0.21"
@@ -238,7 +241,7 @@ otel = [
     "opentelemetry-appender-tracing",
     "metrics-util",
 ]
-tls = ["axum-server", "rustls", "rustls-pemfile"]
+tls = ["axum-server", "rustls"]
 acme = ["tls", "rustls-acme"]
 dlp = []
 oauth = []
@@ -252,10 +255,11 @@ test-util = []
 [package.metadata.cargo-machete]
 # ecdsa: trait crate required for p256::ecdsa::signature::Signer bounds
 # tower: required by tower-http for Service/Layer trait impls
-# rustls/rustls-pemfile: behind optional "tls" feature flag
+# rustls: behind optional "tls" feature flag
 # insta: snapshot testing — used incrementally as tests are converted
 # tracing-test: used via #[traced_test] attribute on individual tests
-ignored = ["ecdsa", "tower", "rustls", "rustls-pemfile", "rustls-acme", "insta", "tracing-test", "socket2", "tikv-jemallocator", "nix", "jsonrpsee"]
+# aws-lc-rs: dev-only, RSA keygen for the JWKS validation tests
+ignored = ["ecdsa", "tower", "rustls", "rustls-acme", "insta", "tracing-test", "socket2", "tikv-jemallocator", "nix", "jsonrpsee", "aws-lc-rs"]
 
 [profile.release]
 opt-level = 3

--- a/benches/http_overhead.rs
+++ b/benches/http_overhead.rs
@@ -141,14 +141,15 @@ fn get_server() -> &'static ServerState {
 
             let tls_app = Router::new().route("/health", get(health));
 
+            // axum-server 0.8 made `bind_rustls` generic over the address family
+            // (IP vs Unix), so the target type has to be spelled out.
+            let tls_addr: std::net::SocketAddr = format!("127.0.0.1:{}", tls_port).parse().unwrap();
+
             tokio::spawn(async move {
-                axum_server::bind_rustls(
-                    format!("127.0.0.1:{}", tls_port).parse().unwrap(),
-                    rustls_config,
-                )
-                .serve(tls_app.into_make_service())
-                .await
-                .unwrap();
+                axum_server::bind_rustls(tls_addr, rustls_config)
+                    .serve(tls_app.into_make_service())
+                    .await
+                    .unwrap();
             });
 
             // Wait for both servers

--- a/deny.toml
+++ b/deny.toml
@@ -6,18 +6,10 @@
 [advisories]
 version = 2
 # Fail CI on any known vulnerability.
-# Review date: 2026-07-24 — re-check if upstream fixed these.
-#
-# rsa: Marvin Attack (timing sidechannel on PKCS#1 v1.5 decryption). No impact:
-# grob only uses RSA for JWT signature verification, not decryption.
-ignore = [
-    "RUSTSEC-2023-0071",
-    # rustls-pemfile: unmaintained (PEM parsing folded into rustls-pki-types).
-    # Pulled transitively via axum-server and rustls-acme; certificate/key PEM
-    # parsing only, no security vulnerability. Surfaces under `--all-features`
-    # (the CI cargo-deny invocation). Drop when those migrate off it.
-    "RUSTSEC-2025-0134",
-]
+# Review date: 2026-07-24 — the ignore list is empty and should stay that way.
+# Prefer moving off an affected crate over adding an entry here; an ignore is a
+# standing decision that nobody re-reads.
+ignore = []
 
 # ── Licenses ─────────────────────────────────────────────────────────────────
 # Grob is Apache-2.0. We allow permissive licenses, weak-copyleft licenses that

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -484,4 +484,88 @@ mod tests {
         let token_bad = make_token(&claims_bad, "test-secret-256-bits-minimum!!");
         assert!(validator.validate(&token_bad).is_err());
     }
+
+    fn claims_for(sub: &str) -> GrobClaims {
+        GrobClaims {
+            sub: sub.to_string(),
+            tenant: None,
+            exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
+            iss: None,
+            aud: None,
+        }
+    }
+
+    /// Signs `claims` with a fresh RSA-2048 key, returning the RS256 token plus
+    /// the base64url `(n, e)` a JWKS endpoint would publish for it.
+    fn make_rs256_token(claims: &GrobClaims) -> (String, String, String) {
+        use aws_lc_rs::encoding::AsDer;
+        use aws_lc_rs::rsa::{KeyPair, KeySize, PublicKeyComponents};
+        use aws_lc_rs::signature::KeyPair as _;
+        use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+        use base64::Engine as _;
+        use jsonwebtoken::{encode, EncodingKey, Header};
+
+        let key_pair = KeyPair::generate(KeySize::Rsa2048).unwrap();
+
+        // `EncodingKey::from_rsa_der` expects PKCS#1, but aws-lc-rs serialises
+        // PKCS#8. Going through PEM lets jsonwebtoken unwrap it.
+        let pem = format!(
+            "-----BEGIN PRIVATE KEY-----\n{}\n-----END PRIVATE KEY-----\n",
+            STANDARD.encode(key_pair.as_der().unwrap().as_ref())
+        );
+        let token = encode(
+            &Header::new(Algorithm::RS256),
+            claims,
+            &EncodingKey::from_rsa_pem(pem.as_bytes()).unwrap(),
+        )
+        .unwrap();
+
+        let components: PublicKeyComponents<Vec<u8>> = key_pair.public_key().into();
+        (
+            token,
+            URL_SAFE_NO_PAD.encode(&components.n),
+            URL_SAFE_NO_PAD.encode(&components.e),
+        )
+    }
+
+    /// Guards the JWKS path against a silent break when the jsonwebtoken crypto
+    /// backend changes: `refresh_jwks` swallows `from_rsa_components` errors, so
+    /// a backend that rejected `(n, e)` keys would look like "no valid key found"
+    /// rather than a startup failure.
+    #[test]
+    fn jwks_rsa_components_validate_rs256_token() {
+        let validator = JwtValidator::from_config(&JwtConfig::default()).unwrap();
+        let claims = claims_for("svc-rsa");
+        let (token, n, e) = make_rs256_token(&claims);
+
+        let key = DecodingKey::from_rsa_components(&n, &e).unwrap();
+        validator
+            .jwks_rsa_keys
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(key);
+
+        let result = validator.validate(&token).unwrap();
+        assert_eq!(result.sub, "svc-rsa");
+    }
+
+    #[test]
+    fn jwks_rsa_components_reject_token_from_another_key() {
+        let validator = JwtValidator::from_config(&JwtConfig::default()).unwrap();
+        let (token, _, _) = make_rs256_token(&claims_for("svc-rsa"));
+        // Components of a different key pair than the one that signed the token.
+        let (_, n, e) = make_rs256_token(&claims_for("svc-rsa"));
+
+        let key = DecodingKey::from_rsa_components(&n, &e).unwrap();
+        validator
+            .jwks_rsa_keys
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(key);
+
+        assert!(matches!(
+            validator.validate(&token),
+            Err(AuthError::InvalidToken(_))
+        ));
+    }
 }

--- a/src/server/lifecycle.rs
+++ b/src/server/lifecycle.rs
@@ -1,8 +1,6 @@
 //! Server lifecycle: bind, serve, drain, and OAuth callback spawning.
 //!
-//! TLS uses axum-server with rustls. The `rustls-pemfile` transitive dep
-//! is tracked under RUSTSEC-2025-0134 until axum-server migrates to
-//! `rustls-pki-types`.
+//! TLS uses axum-server with rustls.
 
 use super::{oauth_handlers, AppState};
 use crate::config::AppConfig;
@@ -80,7 +78,7 @@ pub(super) async fn bind_and_serve(
             let acceptor = crate::shared::acme::build_acme_acceptor(&config.server.tls.acme)?;
             info!("Server listening on {} (ACME TLS, {})", addr, REUSE_LABEL);
             let std_listener = crate::shared::net::bind_reuseport_std(&addr)?;
-            axum_server::Server::from_tcp(std_listener)
+            axum_server::from_tcp(std_listener)?
                 .acceptor(acceptor)
                 .handle(handle)
                 .serve(app.into_make_service())
@@ -99,7 +97,7 @@ pub(super) async fn bind_and_serve(
             .await?;
             info!("Server listening on {} (TLS, {})", addr, REUSE_LABEL);
             let std_listener = crate::shared::net::bind_reuseport_std(&addr)?;
-            axum_server::from_tcp_rustls(std_listener, rustls_config)
+            axum_server::from_tcp_rustls(std_listener, rustls_config)?
                 .handle(handle)
                 .serve(app.into_make_service())
                 .await?;
@@ -112,7 +110,7 @@ pub(super) async fn bind_and_serve(
 #[cfg(any(feature = "tls", feature = "acme"))]
 fn spawn_axum_server_shutdown(
     shutdown_signal: impl Future<Output = ()> + Send + 'static,
-    handle: axum_server::Handle,
+    handle: axum_server::Handle<std::net::SocketAddr>,
 ) {
     tokio::spawn(async move {
         shutdown_signal.await;


### PR DESCRIPTION
## What

Both remaining advisory ignores turned out to be fixable rather than permanent,
so `deny.toml` and `.cargo/audit.toml` now carry `ignore = []`.

### rsa — RUSTSEC-2023-0071 (Marvin timing attack)

`jsonwebtoken` 10 ships an `aws_lc_rs` crypto backend alongside `rust_crypto`,
and `rust_crypto` was the only thing pulling `rsa` into the tree. grob already
links aws-lc-rs through rustls, so the swap adds nothing to the build.

It also removes **`spin` 0.9.8 (yanked)** as a side effect — that arrived via
`num-bigint-dig -> lazy_static/spin_no_std`, and `num-bigint-dig` was an `rsa`
dependency.

### rustls-pemfile — RUSTSEC-2025-0134 (unmaintained)

`axum-server` 0.7 -> **0.8** and `rustls-acme` 0.12 -> **0.15**; both migrated to
`rustls-pki-types`. grob also declared `rustls-pemfile` as a direct dependency
that no code ever used — removed, along with its `tls` feature entry and its
`cargo-machete` exemption.

## Behaviour changes worth knowing

1. **Sub-2048-bit RSA JWKS keys stop validating.** The aws-lc-rs verifier is
   `RSA_PKCS1_2048_8192_SHA256`; `rust_crypto` had no lower bound. A 1024-bit
   RSA key has no business signing tokens, so this is the intended direction —
   but it is a real change for anyone running such an IdP.
2. **axum-server 0.8 API.** `Handle`, `bind_rustls` and `from_tcp*` are now
   generic over the address family (IP vs Unix), and the constructors became
   fallible free functions. Updated `src/server/lifecycle.rs` and
   `benches/http_overhead.rs` accordingly.

## New tests

`refresh_jwks` swallows `from_rsa_components` errors (`if let Ok(dk)`), so a
backend that rejected `(n, e)` keys would have degraded *silently* into "No
valid key found for token" rather than failing at startup. That is exactly the
kind of regression a crypto-backend swap can introduce, and nothing covered it —
the existing JWT tests are all HS256.

Added two tests over the JWKS RS256 path, signing with a freshly generated
RSA-2048 key (via `aws-lc-rs`, dev-dependency only, already in the tree):
- `jwks_rsa_components_validate_rs256_token` — the matching key validates
- `jwks_rsa_components_reject_token_from_another_key` — a foreign key does not

## Verification

- `cargo audit` — **zero findings**, no allowed-warning line left
- `cargo deny --all-features check` — advisories ok, bans ok, licenses ok, sources ok, with empty ignore lists
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 1711 passed, 2 ignored
- `cargo bench --bench http_overhead --features tls -- --quick tls` — real TLS handshakes served by axum-server 0.8 (7.09 ms fresh handshake, 44.4 µs keep-alive)

The ACME path (`rustls-acme` 0.15, `src/shared/acme.rs`) is compile-verified
only — exercising it needs a live ACME endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)