### PR TITLE
chore: release v0.36.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.79](https://github.com/azerozero/grob/compare/v0.36.78...v0.36.79) - 2026-07-24
+
+### Added
+
+- *(openai)* replay encrypted reasoning across Codex turns
+
+### Other
+
+- repoint two rotted external links
+- untrack the local debug config that reached main in #410
+
 ## [0.36.78](https://github.com/azerozero/grob/compare/v0.36.77...v0.36.78) - 2026-07-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.78"
+version = "0.36.79"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.78"
+version = "0.36.79"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.78 -> 0.36.79

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.79](https://github.com/azerozero/grob/compare/v0.36.78...v0.36.79) - 2026-07-24

### Added

- *(openai)* replay encrypted reasoning across Codex turns

### Other

- repoint two rotted external links
- untrack the local debug config that reached main in #410
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).