### PR TITLE
fix(validate): read OAuth tokens from the encrypted store, not legacy JSON

### DIFF
--- a/src/preset/validation.rs
+++ b/src/preset/validation.rs
@@ -63,13 +63,19 @@ impl ModelValidation {
 /// Returns an error if the token store, encrypted store, or provider
 /// registry cannot be built from the config.
 pub fn build_registry(config: &AppConfig) -> Result<(Arc<ProviderRegistry>, TokenStore)> {
-    let token_store = TokenStore::at_default_path()
-        .map_err(|e| anyhow::anyhow!("Failed to init token store: {}", e))?;
-
     let grob_store = Arc::new(
         GrobStore::open(&GrobStore::default_path())
             .map_err(|e| anyhow::anyhow!("Failed to open encrypted store: {}", e))?,
     );
+
+    // Read OAuth tokens from the encrypted GrobStore — the same backend the
+    // server, `grob doctor` and `grob connect` all use. The legacy
+    // `at_default_path()` reads a plaintext `~/.grob/oauth_tokens.json` that
+    // modern installs never write, so `grob validate` reported "no token found"
+    // for tokens `grob doctor` on the very same store reports as usable.
+    let token_store = TokenStore::with_store(grob_store.clone())
+        .map_err(|e| anyhow::anyhow!("Failed to init token store: {}", e))?;
+
     let secret_backend =
         crate::storage::secrets::build_backend(&config.secrets, grob_store.clone());
 
@@ -421,6 +427,84 @@ fn log_broken_mapping(m: &MappingResult) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Serializes the `GROB_HOME`-mutating tests below so they cannot clobber
+    // each other's environment when the suite runs in parallel.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Regression guard for the `grob validate` false negative: it built its
+    /// token store with the legacy `at_default_path()` (a plaintext
+    /// `oauth_tokens.json` modern installs never write), so it reported "no
+    /// token found" for OAuth tokens the encrypted store — and `grob doctor` —
+    /// saw as usable. `build_registry` must read the same GrobStore-backed
+    /// store as the server.
+    #[test]
+    fn build_registry_reads_oauth_tokens_from_the_encrypted_store() {
+        use crate::auth::token_store::OAuthToken;
+        use secrecy::SecretString;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let home =
+            std::env::temp_dir().join(format!("grob-validate-token-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("GROB_HOME", &home);
+        }
+
+        // Persist an OAuth token through the same encrypted store the server uses.
+        let store = Arc::new(
+            crate::storage::GrobStore::open(&crate::storage::GrobStore::default_path()).unwrap(),
+        );
+        store
+            .save_oauth_token(&OAuthToken {
+                provider_id: "test-oauth-provider".to_string(),
+                access_token: SecretString::new("access".to_string()),
+                refresh_token: SecretString::new("refresh".to_string()),
+                expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                enterprise_url: None,
+                project_id: None,
+                needs_reauth: None,
+            })
+            .unwrap();
+
+        let config: AppConfig = toml::from_str(
+            r#"
+                [router]
+                default = "m"
+
+                [[providers]]
+                name = "p"
+                provider_type = "openai"
+                auth_type = "oauth"
+                oauth_provider = "test-oauth-provider"
+                models = []
+
+                [[models]]
+                name = "m"
+                [[models.mappings]]
+                provider = "p"
+                actual_model = "gpt-5.5"
+                priority = 1
+            "#,
+        )
+        .unwrap();
+
+        let (_registry, token_store) = build_registry(&config).unwrap();
+
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var("GROB_HOME");
+        }
+        let _ = std::fs::remove_dir_all(&home);
+
+        assert!(
+            token_store.get("test-oauth-provider").is_some(),
+            "build_registry must read tokens from the encrypted GrobStore, not the legacy JSON file"
+        );
+    }
 
     // ── extract_http_code ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## The bug

`grob validate` reports, for every OAuth mapping:

```
❌ default-model [default] — 0/2 mappings healthy
  [1] chatgpt-codex/gpt-5.5: ❌ OAuth provider 'openai-codex' configured but no token found in store
  [2] anthropic/claude-opus-4-7: ❌ OAuth provider 'anthropic-max' configured but no token found in store
```

…while `grob doctor`, reading the same credentials, reports them usable and the
live endpoint answers. A false negative in the one command whose job is to tell
you your config actually works.

## Root cause

`build_registry` (the CLI validation path) built its token store with
`TokenStore::at_default_path()`, which reads a **plaintext**
`~/.grob/oauth_tokens.json`. Modern installs never write that file — OAuth
tokens live in the **encrypted GrobStore** (`~/.grob/tokens/*.json.enc`).

Everything else reads the encrypted store via `TokenStore::with_store`:

| Caller | Backend |
|---|---|
| server (`server/mod.rs`, `server/init.rs`) | `with_store` ✅ |
| `grob doctor` (`commands/doctor.rs:44`) | `with_store` ✅ |
| `grob connect` (`commands/connect.rs`) | `with_store` ✅ |
| **`grob validate` (`preset/validation.rs`)** | **`at_default_path` ❌** |

Validate was the sole outlier, looking in an empty legacy location.

## Fix

Build the token store from the `GrobStore` that `build_registry` already opens
for the secret backend — one line, and validate now resolves auth through the
exact path the running server uses.

## Verification

Live, same machine, same config:

```
before:  default-model 0/2 … no token found
after:   chatgpt-codex/gpt-5.5  ✅ OK (722ms)
         anthropic/claude-opus-4-7  ❌ 429  (token found and used — a real
                                             rate-limit, not a phantom auth error)
         All models have at least one healthy provider.
```

**Regression guard** (`build_registry_reads_oauth_tokens_from_the_encrypted_store`):
a `GROB_HOME`-isolated test saves a token through a `GrobStore`, calls
`build_registry`, and asserts the returned store finds it. Confirmed it **fails**
when the code is reverted to `at_default_path()`, so it genuinely pins the fix.

- `cargo test --lib preset::validation` — 14 passed
- full local prek gate (fmt, clippy, deny, machete, doc-coverage, audit) — clean

## Follow-up (not in this PR)

`TokenStore::at_default_path()` now has zero callers — it was the footgun here.
Removing it is a reasonable next step but is a public-API change, so I left it
out to keep this scoped to the fix. Flagging it for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)