### PR TITLE
chore: release v0.36.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.80](https://github.com/azerozero/grob/compare/v0.36.79...v0.36.80) - 2026-07-25
+
+### Fixed
+
+- *(validate)* read OAuth tokens from the encrypted store, not legacy JSON
+
+### Other
+
+- *(routing)* kill 16 surviving mutants in the complexity classifier
+- run the local prek gate in CI instead of restating it
+
 ## [0.36.79](https://github.com/azerozero/grob/compare/v0.36.78...v0.36.79) - 2026-07-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.79"
+version = "0.36.80"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.79"
+version = "0.36.80"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.79 -> 0.36.80

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.80](https://github.com/azerozero/grob/compare/v0.36.79...v0.36.80) - 2026-07-25

### Fixed

- *(validate)* read OAuth tokens from the encrypted store, not legacy JSON

### Other

- *(routing)* kill 16 surviving mutants in the complexity classifier
- run the local prek gate in CI instead of restating it
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).