### PR TITLE
fix(status): read OAuth tokens from the encrypted store in status + setup

### DIFF
--- a/src/preset/credentials.rs
+++ b/src/preset/credentials.rs
@@ -179,27 +179,15 @@ pub fn load_oauth_provider_list_pub() -> Vec<String> {
 }
 
 /// Load the list of OAuth provider IDs that have tokens stored.
+///
+/// Reads the encrypted GrobStore — the same backend the server, `grob doctor`
+/// and `grob connect` use. This once read a plaintext `~/.grob/oauth_tokens.json`
+/// that modern installs never write, so `grob status` and the `setup` wizard
+/// reported every OAuth provider as unauthenticated even with a valid token in
+/// the store.
 fn load_oauth_provider_list() -> Vec<String> {
-    let grob_dir = match crate::grob_home() {
-        Some(d) => d,
-        None => return vec![],
-    };
-    let tokens_path = grob_dir.join("oauth_tokens.json");
-    if !tokens_path.exists() {
-        return vec![];
-    }
-    let content = match std::fs::read_to_string(&tokens_path) {
-        Ok(c) => c,
-        Err(_) => return vec![],
-    };
-    // oauth_tokens.json is { "provider-id": { ... }, ... }
-    let parsed: serde_json::Value = match serde_json::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return vec![],
-    };
-    parsed
-        .as_object()
-        .map(|obj| obj.keys().cloned().collect())
+    crate::storage::GrobStore::open(&crate::storage::GrobStore::default_path())
+        .map(|store| store.all_oauth_tokens().into_keys().collect())
         .unwrap_or_default()
 }
 
@@ -370,4 +358,62 @@ pub fn setup_credentials_interactive_filtered(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serializes the GROB_HOME-mutating test so it cannot clobber another
+    // test's environment when the suite runs in parallel.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Regression guard: `load_oauth_provider_list` once read a plaintext
+    /// `~/.grob/oauth_tokens.json` that modern installs never write, so
+    /// `grob status` and the `setup` wizard reported OAuth providers as
+    /// unauthenticated even with a valid token in the encrypted store. It must
+    /// read the same GrobStore the server and `grob doctor` use.
+    #[test]
+    fn load_oauth_provider_list_reads_the_encrypted_store() {
+        use crate::auth::token_store::OAuthToken;
+        use secrecy::SecretString;
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let home =
+            std::env::temp_dir().join(format!("grob-oauth-list-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("GROB_HOME", &home);
+        }
+
+        let store =
+            crate::storage::GrobStore::open(&crate::storage::GrobStore::default_path()).unwrap();
+        store
+            .save_oauth_token(&OAuthToken {
+                provider_id: "openai-codex".to_string(),
+                access_token: SecretString::new("a".to_string()),
+                refresh_token: SecretString::new("r".to_string()),
+                expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                enterprise_url: None,
+                project_id: None,
+                needs_reauth: None,
+            })
+            .unwrap();
+
+        let list = load_oauth_provider_list();
+
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var("GROB_HOME");
+        }
+        let _ = std::fs::remove_dir_all(&home);
+
+        assert!(
+            list.contains(&"openai-codex".to_string()),
+            "must list OAuth providers from the encrypted GrobStore, not legacy JSON"
+        );
+    }
 }


### PR DESCRIPTION
## Found by auditing for the `grob validate` bug's class

After fixing #469 (validate read the legacy plaintext token file), I swept the
codebase for the same pattern — a credential surface reading
`~/.grob/oauth_tokens.json` instead of the encrypted GrobStore — and found a
second one.

`load_oauth_provider_list()` decides which OAuth providers are authenticated for
**`grob status`** (offline path) and the **`setup` wizard** (`check_credentials`).
It read the plaintext `oauth_tokens.json` that modern installs never write, so
both reported a false negative:

```
grob status (offline):   chatgpt-codex   (openai)  needs auth      ← token IS present
setup wizard:            No OAuth token for 'openai-codex' — run grob start
```

`grob doctor` was unaffected — it uses a different function (`detect_credentials`
via `TokenStore::with_store`), which is why doctor said "usable" while status
said "needs auth" for the same account.

## Fix

`load_oauth_provider_list` now reads `GrobStore::all_oauth_tokens()`, the same
backend the server, `grob doctor` and `grob connect` use. One function, three
lines.

## Verification

Live, offline path, same machine and store:

```
before (0.36.79):  chatgpt-codex  needs auth  /  anthropic  needs auth
after:             chatgpt-codex  oauth ok    /  anthropic  oauth ok
```

**Regression guard** (`load_oauth_provider_list_reads_the_encrypted_store`): a
`GROB_HOME`-isolated test saves a token through a `GrobStore` and asserts the
function returns it. Confirmed it **fails** when reverted to the legacy JSON
reader.

- `cargo test --lib preset::credentials` — passes
- full local prek gate — clean

## Audit note

With this and #469, the two remaining live readers of the legacy plaintext
`oauth_tokens.json` are gone. The only references left are `TokenStore::new()`
(legacy JSON constructor, still used by tests) and `at_default_path()` (now zero
callers — a footgun candidate for removal, flagged on #469).

🤖 Generated with [Claude Code](https://claude.com/claude-code)