### PR TITLE
chore: release v0.36.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.81](https://github.com/azerozero/grob/compare/v0.36.80...v0.36.81) - 2026-07-26
+
+### Fixed
+
+- *(status)* read OAuth tokens from the encrypted store in status + setup
+
 ## [0.36.80](https://github.com/azerozero/grob/compare/v0.36.79...v0.36.80) - 2026-07-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.80"
+version = "0.36.81"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.80"
+version = "0.36.81"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.80 -> 0.36.81

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.81](https://github.com/azerozero/grob/compare/v0.36.80...v0.36.81) - 2026-07-26

### Fixed

- *(status)* read OAuth tokens from the encrypted store in status + setup
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).