### PR TITLE
refactor(auth): remove the at_default_path token-store footgun

### DIFF
--- a/src/auth/token_store.rs
+++ b/src/auth/token_store.rs
@@ -154,30 +154,6 @@ impl TokenStore {
         })
     }
 
-    /// Gets the default token store path.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the home directory cannot be determined
-    /// or the config directory cannot be created.
-    pub fn default_path() -> Result<PathBuf> {
-        let home = crate::home_dir().context("Failed to get home directory (set GROB_HOME)")?;
-        let config_dir = home.join(".grob");
-        fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
-        Ok(config_dir.join("oauth_tokens.json"))
-    }
-
-    /// Creates a token store at the default location (legacy mode).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the default path cannot be resolved or
-    /// the token file cannot be read.
-    pub fn at_default_path() -> Result<Self> {
-        let path = Self::default_path()?;
-        Self::new(path)
-    }
-
     /// Saves a token for a provider.
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,14 @@
 
 use std::path::PathBuf;
 
+/// Process-global lock serializing tests that mutate the `GROB_HOME` env var.
+///
+/// `GROB_HOME` is process-wide, so two tests setting it concurrently clobber
+/// each other. Every test that does `set_var("GROB_HOME", …)` must hold this
+/// for its duration; per-module locks do not exclude across modules.
+#[cfg(test)]
+pub(crate) static GROB_HOME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Returns the Grob home directory (`~/.grob`).
 ///
 /// When the `dirs` feature is disabled, falls back to reading `GROB_HOME`

--- a/src/preset/credentials.rs
+++ b/src/preset/credentials.rs
@@ -364,10 +364,6 @@ pub fn setup_credentials_interactive_filtered(
 mod tests {
     use super::*;
 
-    // Serializes the GROB_HOME-mutating test so it cannot clobber another
-    // test's environment when the suite runs in parallel.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// Regression guard: `load_oauth_provider_list` once read a plaintext
     /// `~/.grob/oauth_tokens.json` that modern installs never write, so
     /// `grob status` and the `setup` wizard reported OAuth providers as
@@ -378,7 +374,9 @@ mod tests {
         use crate::auth::token_store::OAuthToken;
         use secrecy::SecretString;
 
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::GROB_HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         let home =
             std::env::temp_dir().join(format!("grob-oauth-list-test-{}", std::process::id()));

--- a/src/preset/mod.rs
+++ b/src/preset/mod.rs
@@ -648,6 +648,9 @@ mod tests {
 
     #[test]
     fn test_list_presets_contains_builtins() {
+        let _guard = crate::GROB_HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join("grob-test-presets");
         #[allow(unsafe_code)]
         unsafe {

--- a/src/preset/validation.rs
+++ b/src/preset/validation.rs
@@ -69,10 +69,10 @@ pub fn build_registry(config: &AppConfig) -> Result<(Arc<ProviderRegistry>, Toke
     );
 
     // Read OAuth tokens from the encrypted GrobStore — the same backend the
-    // server, `grob doctor` and `grob connect` all use. The legacy
-    // `at_default_path()` reads a plaintext `~/.grob/oauth_tokens.json` that
-    // modern installs never write, so `grob validate` reported "no token found"
-    // for tokens `grob doctor` on the very same store reports as usable.
+    // server, `grob doctor` and `grob connect` all use. This once read a
+    // plaintext `~/.grob/oauth_tokens.json` that modern installs never write, so
+    // `grob validate` reported "no token found" for tokens `grob doctor` on the
+    // very same store reported as usable.
     let token_store = TokenStore::with_store(grob_store.clone())
         .map_err(|e| anyhow::anyhow!("Failed to init token store: {}", e))?;
 
@@ -428,22 +428,20 @@ fn log_broken_mapping(m: &MappingResult) {
 mod tests {
     use super::*;
 
-    // Serializes the `GROB_HOME`-mutating tests below so they cannot clobber
-    // each other's environment when the suite runs in parallel.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// Regression guard for the `grob validate` false negative: it built its
-    /// token store with the legacy `at_default_path()` (a plaintext
-    /// `oauth_tokens.json` modern installs never write), so it reported "no
-    /// token found" for OAuth tokens the encrypted store — and `grob doctor` —
-    /// saw as usable. `build_registry` must read the same GrobStore-backed
+    /// token store from a legacy plaintext `oauth_tokens.json` that modern
+    /// installs never write, so it reported "no token found" for OAuth tokens
+    /// the encrypted store — and `grob doctor` — saw as usable. `build_registry`
+    /// must read the same GrobStore-backed
     /// store as the server.
     #[test]
     fn build_registry_reads_oauth_tokens_from_the_encrypted_store() {
         use crate::auth::token_store::OAuthToken;
         use secrecy::SecretString;
 
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::GROB_HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         let home =
             std::env::temp_dir().join(format!("grob-validate-token-test-{}", std::process::id()));


### PR DESCRIPTION
## What

`TokenStore::at_default_path()` and its `default_path()` helper built a token
store from the plaintext `~/.grob/oauth_tokens.json`. That legacy path was the
**direct cause** of the two false negatives fixed this week:

- #469 — `grob validate` reported "no token found"
- #471 — `grob status` / `setup` reported OAuth providers as "needs auth"

Both read the legacy file that modern installs never write. Once they moved to
the encrypted GrobStore, `at_default_path()` / `default_path()` had **zero
remaining callers** — a loaded footgun aimed at the next person who reached for
the obvious-looking constructor.

Removed both. The legacy JSON mode itself stays via `TokenStore::new(path)`,
which tests still use; only the two convenience wrappers that hardcoded the
legacy location are gone.

## Also: a test-isolation race the regression guards introduced

The #469 and #471 guards each lived behind their **own** module-local
`ENV_LOCK`. A per-module mutex doesn't exclude across modules, so the two
`GROB_HOME`-mutating tests could clobber each other's env and fail when run in
the same test binary (which is how I hit it). This was a latent flake sitting on
`main`.

Replaced the two local locks with one crate-level `GROB_HOME_TEST_LOCK` in
`lib.rs`, adopted by:
- `build_registry_reads_oauth_tokens_from_the_encrypted_store` (#469)
- `load_oauth_provider_list_reads_the_encrypted_store` (#471)
- `test_list_presets_contains_builtins` — a **third** `GROB_HOME` mutator that
  had no lock at all

## Verification

- the previously-flaky trio run together: **3/3 consecutive passes**
- `cargo test --lib` — **1425 passed**
- full local prek gate — clean
- `grep -rn at_default_path src/ tests/ benches/` — no matches

No behaviour change: nothing called the removed functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)