### PR TITLE
feat(routing): match model config names spelling-agnostically

### DIFF
--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -419,9 +419,13 @@ impl ProviderRegistry {
 
         for model in models {
             if let Some(first_mapping) = model.mappings.first() {
-                registry
-                    .model_to_provider
-                    .insert(model.name.clone(), first_mapping.provider.clone());
+                // Canonical key so `provider_for_model` matches spelling-agnostically
+                // (`gpt-5.5` config vs a `gpt-5-5` query), mirroring `find_model`.
+                registry.model_to_provider.insert(
+                    crate::routing::classify::model_name::canonicalize_model_name(&model.name)
+                        .into_owned(),
+                    first_mapping.provider.clone(),
+                );
             }
         }
 
@@ -440,8 +444,10 @@ impl ProviderRegistry {
     /// Returns [`ProviderError::ModelNotSupported`] if no registered
     /// provider handles the given model name.
     pub fn provider_for_model(&self, model: &str) -> Result<Arc<dyn LlmProvider>, ProviderError> {
-        // First, check if we have a direct model → provider mapping
-        if let Some(provider_name) = self.model_to_provider.get(model) {
+        // First, check if we have a direct model → provider mapping. The index is
+        // keyed by canonical name, so canonicalize the query to match it.
+        let canonical = crate::routing::classify::model_name::canonicalize_model_name(model);
+        if let Some(provider_name) = self.model_to_provider.get(canonical.as_ref()) {
             if let Some(provider) = self.providers.get(provider_name) {
                 return Ok(provider.clone());
             }
@@ -605,6 +611,67 @@ mod tests {
         let registry = ProviderRegistry::new();
         let result = registry.provider_for_model("gpt-4");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn provider_for_model_is_spelling_agnostic() {
+        use crate::providers::{AuthType, ProviderConfig};
+
+        // A `[[models]]` entry spelled with a dot, as an operator would write it.
+        let providers = vec![ProviderConfig {
+            name: "openai".to_string(),
+            provider_type: "openai".to_string(),
+            auth_type: AuthType::ApiKey,
+            api_key: Some(SecretString::new("test-key".to_string())),
+            base_url: None,
+            models: vec![],
+            enabled: Some(true),
+            oauth_provider: None,
+            project_id: None,
+            location: None,
+            headers: None,
+            budget_usd: None,
+            region: None,
+            pass_through: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            pool: None,
+            reasoning_effort: None,
+            service_tier: None,
+            codex: Default::default(),
+            circuit_breaker: None,
+            health_check: None,
+            max_retries: None,
+        }];
+        let models = vec![crate::cli::ModelConfig {
+            name: "gpt-5.5".to_string(),
+            mappings: vec![crate::cli::ModelMapping {
+                priority: 1,
+                provider: "openai".to_string(),
+                actual_model: "gpt-5.5".to_string(),
+                inject_continuation_prompt: false,
+            }],
+            budget_usd: None,
+            context_window_tokens: None,
+            strategy: Default::default(),
+            fan_out: None,
+            deprecated: None,
+        }];
+
+        let registry = ProviderRegistry::from_configs_with_models(
+            &providers,
+            &crate::storage::secrets::EnvBackend,
+            None,
+            &models,
+            &TimeoutConfig::default(),
+        )
+        .unwrap();
+
+        // The dashed form the router canonicalizes to must resolve to the same
+        // provider as the dotted config name.
+        assert!(registry.provider_for_model("gpt-5-5").is_ok());
+        assert!(registry.provider_for_model("gpt-5.5").is_ok());
     }
 
     #[test]

--- a/src/routing/classify/mod.rs
+++ b/src/routing/classify/mod.rs
@@ -346,8 +346,14 @@ impl Router {
         // name "default-model" to the upstream provider.
         if let Some(ref mapper) = self.auto_mapper {
             if mapper.is_match(&request.model) {
-                let has_explicit_virtual =
-                    self.config.models.iter().any(|m| m.name == request.model);
+                // `request.model` was canonicalized above; compare the config
+                // names in canonical form too, so a dotted `[[models]]` entry
+                // still counts as an explicit match and is not auto-mapped away.
+                let has_explicit_virtual = self
+                    .config
+                    .models
+                    .iter()
+                    .any(|m| model_name::canonicalize_model_name(&m.name) == request.model);
                 if has_explicit_virtual {
                     info!(
                         "Auto-map skipped for '{}' — explicit [[models]] entry takes precedence",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -102,11 +102,17 @@ impl ReloadableState {
         router: Router,
         provider_registry: Arc<ProviderRegistry>,
     ) -> Self {
+        // Key by the canonical model name so a dotted config entry (`gpt-5.5`)
+        // matches a request whose name the router already canonicalized to the
+        // dashed form (`gpt-5-5`) — routing stays agnostic to the spelling, the
+        // same way it is for text. Canonicalization borrows unchanged for names
+        // outside a known family, so existing configs are untouched.
+        use crate::routing::classify::model_name::canonicalize_model_name;
         let model_index = config
             .models
             .iter()
             .enumerate()
-            .map(|(i, m)| (m.name.to_lowercase(), i))
+            .map(|(i, m)| (canonicalize_model_name(&m.name).to_lowercase(), i))
             .collect();
         #[cfg(feature = "policies")]
         let policy_matcher = init::init_policies(&config);
@@ -120,10 +126,15 @@ impl ReloadableState {
         }
     }
 
-    /// O(1) model config lookup by name (case-insensitive)
+    /// O(1) model config lookup by name (case-insensitive, spelling-agnostic).
+    ///
+    /// The query is canonicalized to match the index keys, so `gpt-5.5` and
+    /// `gpt-5-5` resolve to the same `[[models]]` entry.
     pub fn find_model(&self, name: &str) -> Option<&crate::cli::ModelConfig> {
+        let key =
+            crate::routing::classify::model_name::canonicalize_model_name(name).to_lowercase();
         self.model_index
-            .get(&name.to_lowercase())
+            .get(&key)
             .map(|&idx| &self.config.models[idx])
     }
 }


### PR DESCRIPTION
## The friction

The router canonicalizes an inbound model name — dots→dashes for known families,
so `gpt-5.5` becomes `gpt-5-5` — *before* routing. But the `[[models]]` lookup
then compared config names **verbatim**. A config entry spelled `gpt-5.5` never
matched the request the router had just rewritten to `gpt-5-5`, and the turn died
with:

```
Model 'gpt-5-5' is not configured. Add a [[models]] entry ... or set pass_through = true
```

…even though the operator *had* configured it. Routing was spelling-agnostic for
the request but not for the config — the mismatch reported with
`K4DI_VISION_MODEL=gpt-5.5`.

## Fix — make the config side agnostic too, like text

Canonicalize the config side of every model-name comparison, so both ends are
compared in canonical form:

| Site | Before | After |
|---|---|---|
| `AppState::model_index` key + `find_model` query | `to_lowercase()` | `canonicalize(...).to_lowercase()` |
| `ProviderRegistry::model_to_provider` key + `provider_for_model` query | verbatim | canonical |
| Router auto-map guard (`m.name == request.model`) | verbatim | canonical |

`canonicalize_model_name` borrows unchanged for names outside a known family
(`glm-4.6`, `mistral-3.1`, …), so configs already using canonical IDs are
untouched — this only *adds* matches, never removes them.

## Verified live (Codex OAuth, config entry named `gpt-5.5` with a dot)

```
before (0.36.79):  "Model 'gpt-5-5' is not configured"
after:             routes, returns "OK"  (model reported as gpt-5-5)
```

Unit test: `provider_for_model` resolves **both** `gpt-5.5` and `gpt-5-5` for a
dotted `[[models]]` entry. Full local prek gate — clean.

## Note

This closes the last of the three points from the vision report:
- vision on the Responses/Codex path — fixed in #476
- `gpt-5.5` not routable — **this PR**
- dev config routing to a code model — a config choice, not a grob limit

Independent files from #476; no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)