### PR TITLE
ci(release-plz): allow manual workflow_dispatch

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,11 +16,16 @@ on:
     types: [closed]
     branches:
       - main
+  # Manual trigger: the push filter above only fires on `src/**`/`Cargo.*`
+  # changes, and a release PR that merges while a prior release is still cutting
+  # its tag can leave a releasable commit stranded with no way to re-run. This
+  # lets an operator open the release PR on demand without pushing to `main`.
+  workflow_dispatch:
 
 jobs:
   release-pr:
     name: Create Release PR
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:


### PR DESCRIPTION
## Why

release-plz only triggered on push to `main` touching `src/**` / `Cargo.*`, with
no manual trigger. When a release PR merges while the previous release is still
cutting its tag, the new release-pr run races the tag creation and concludes
`grob: already up to date` — stranding a releasable commit with **no way to
re-run**.

That just happened: #478's `feat(routing)` merged, its release-plz run raced the
v0.36.83 tag, and there is now a merged `feat` commit on `main` with no release
PR and no way to trigger a fresh evaluation short of pushing to `main` (which the
branch protection forbids).

## Fix

Add `workflow_dispatch` to `on:` and let the `release-pr` job run under it. An
operator (or `gh workflow run release-plz.yml`) can now open the release PR on
demand, without pushing to `main`.

This change touches only `.github/`, so it does not itself trigger the push
filter — the operator dispatches it after merge.

Verified: `actionlint .github/workflows/release-plz.yml` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)