### PR TITLE
docs: switch merge policy to squash-only for reliable release-plz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,12 @@ feature/* ──► main ──► release-plz PR ──► tag v* ──► rel
 
 - **Never commit or push directly to `main`**. All changes go through feature branches + PRs.
 - **`main` is protected** by a GitHub ruleset (no deletion, no force push, PR required).
-- **Always enable auto-merge** after creating a PR: `gh pr merge <num> --auto --merge`. Do not wait for CI to merge manually.
+- **Always enable auto-merge** after creating a PR: `gh pr merge <num> --auto --squash`. Do not wait for CI to merge manually.
+- **Squash-merge only** (merge commits are disabled on the repo). Every PR lands as ONE commit on `main`'s linear history, with the **PR title** as its message — so the PR title MUST be a conventional commit (`feat(scope): …`). This is not cosmetic: release-plz computes the next version by walking `main`, and a merge-commit puts the feature commit on a second parent where a release cut between two merges can hide it from the version calc (this stranded #478's `feat(routing)` — it never produced a release). A linear history removes that failure mode entirely.
 - **Check file overlap before parallel PRs**: if two PRs modify the same files, base the second on the first branch (`git checkout -b feat/B feat/A`), not on `main`. This prevents merge conflicts when the first PR lands.
-- **Conventional commits required**: `feat:`, `fix:`, `refactor:`, `perf:` with scopes trigger release-plz version bumps. Use `chore:`, `docs:`, `test:`, `style:` for non-release changes.
+- **Conventional commits required** (in the PR title, since that becomes the squash commit): `feat:`, `fix:`, `refactor:`, `perf:` with scopes trigger release-plz version bumps. Use `chore:`, `docs:`, `test:`, `style:`, `ci:` for non-release changes.
 - **release-plz `release_commits` filter**: only `feat|fix|refactor|perf` commits (any scope or no scope) trigger a version bump. The prefix is the gate, not the scope.
+- **release-plz can be run manually**: `gh workflow run release-plz.yml --ref main` (added `workflow_dispatch` in #479) opens the release PR on demand when a push-triggered run was missed.
 
 ### CI Pipeline Stages (`.github/workflows/ci.yml`)
 


### PR DESCRIPTION
## The CI/CD bug this fixes

`feat(routing)` (#478) merged cleanly but **never produced a release**. release-plz
kept reporting `grob: no commit matches the release_commits regex` and there was
no way to cut v0.36.84.

### Root cause

Every PR was merged with a **merge commit** (`gh pr merge --merge`), so the
feature commit sits on the merge's **second parent**:

```
572f539 Merge #478      parents: 95db3f6 (release v0.36.83)  de4b690 (feat routing)
```

When release-plz cut v0.36.83 **between** the routing branch's creation and its
merge, `de4b690` ended up *beside* the release commit rather than after it. Its
version walk over `v0.36.83..HEAD` doesn't traverse into that second parent —
`git log --first-parent v0.36.83..main` is **empty** — so the `feat` commit is
invisible to the bump calc. It works for most PRs only because they're released
immediately after merging, before the next merge buries them.

## Fix

**Squash-merge only.** Repo settings now:
- `allow_merge_commit = false`
- `squash_merge_commit_title = PR_TITLE`

Every PR becomes one conventional commit on a **linear** `main`, which release-plz
reads reliably — the second-parent hiding place no longer exists. Applied to the
repo already; this PR aligns CLAUDE.md (`--auto --merge` → `--auto --squash`,
plus a note on why the PR title must be a conventional commit) and documents the
manual `gh workflow run release-plz.yml` trigger added in #479.

## For the currently-stranded routing fix

It's on `main` and ships with the next release cut for any releasable commit
(now reliably, thanks to squash). Meanwhile it has a trivial workaround — name
the config entry `gpt-5-5` instead of `gpt-5.5`.

## Note

This PR is the first squash-only merge — its single commit validates the new
policy end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)