### PR TITLE
fix(cli): make grob stop recognise its daemon on macOS

### DIFF
--- a/src/shared/pid.rs
+++ b/src/shared/pid.rs
@@ -135,12 +135,19 @@ pub fn is_process_running(pid: u32) -> bool {
 
 #[cfg(feature = "unix-signals")]
 fn command_invokes_grob(command: &str) -> bool {
-    let first_arg = command
-        .split('\0')
-        .find(|part| !part.trim().is_empty())
-        .or_else(|| command.split_whitespace().next())
-        .unwrap_or_default()
-        .trim();
+    // The command string arrives in two shapes: Linux `/proc/<pid>/cmdline` is
+    // NUL-separated (`grob\0start\0`), while macOS `ps -o command=` is
+    // space-separated (`/opt/homebrew/bin/grob start`). Splitting only on `\0`
+    // left the macOS form intact, so `Path::file_name` on
+    // `"…/grob start"` returned `"grob start"` (≠ `"grob"`) and `grob stop`
+    // refused to stop its own daemon. Pick the separator by which one is present.
+    let first_arg = if command.contains('\0') {
+        command.split('\0').next()
+    } else {
+        command.split_whitespace().next()
+    }
+    .unwrap_or_default()
+    .trim();
     let executable = std::path::Path::new(first_arg)
         .file_name()
         .and_then(|name| name.to_str())
@@ -190,5 +197,18 @@ mod tests {
         assert!(!command_invokes_grob("/tmp/grob-upgrade --config x"));
         assert!(!command_invokes_grob("/usr/bin/python /tmp/grob.py"));
         assert!(!command_invokes_grob("/usr/bin/agrob-helper"));
+    }
+
+    /// macOS `ps -o command=` is space-separated; the executable and its args
+    /// must not be read as one path component. This is the exact string that
+    /// made `grob stop` refuse to stop a live daemon.
+    #[cfg(feature = "unix-signals")]
+    #[test]
+    fn command_identity_accepts_space_separated_macos_form() {
+        assert!(command_invokes_grob("/opt/homebrew/bin/grob start"));
+        assert!(command_invokes_grob("/opt/homebrew/bin/grob start\n"));
+        assert!(command_invokes_grob("grob start -d"));
+        // A non-grob program with a grob-ish argument still must not match.
+        assert!(!command_invokes_grob("/usr/bin/python grob start"));
     }
 }


### PR DESCRIPTION
## The bug

On macOS, `grob stop` refused to stop its own running daemon:

```
❌ Failed to stop service (PID: 41257): refusing to stop PID 41257: not a running Grob process
```

…and `grob start -d` (restart) silently left the old daemon running, so a
restart never actually took effect.

### Cause

`command_invokes_grob` (the PID-identity guard) split the process command line
only on NUL. That matches Linux `/proc/<pid>/cmdline` (`grob\0start\0`) but **not**
macOS `ps -o command=`, which is space-separated:

```
/opt/homebrew/bin/grob start
```

With no NUL, the whole string reached `Path::file_name`, giving `"grob start"`
(≠ `"grob"`). So `is_process_running` returned false for a live daemon, and both
`grob stop` and the restart path in `grob start` refused to act.

Reproduced:
```
executable = "grob start"  → == "grob" ? false
```

## Fix

Pick the separator by which one is present — NUL when the string contains it
(Linux), whitespace otherwise (macOS):

```rust
let first_arg = if command.contains('\0') {
    command.split('\0').next()
} else {
    command.split_whitespace().next()
} …
```

All existing negative cases still hold (`grob-upgrade`, `python …/grob.py`,
`agrob-helper`).

## Verification

- Unit tests: added `command_identity_accepts_space_separated_macos_form`
  (the exact `ps` string); existing test still green.
- End to end on macOS: a daemon started with the fixed binary is now stopped by
  `grob stop` → `✅ Service stopped successfully` (was `refusing to stop`).

## Note (single-daemon model)

The pid file is a single global `~/.grob/grob.pid`. With identity now working,
`grob start` on any port stops whatever that file points at — so a second daemon
on another port replaces the first. That's consistent with the one-daemon
design; a port-scoped pid file would be a separate change if parallel daemons
are ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)