### PR TITLE
chore: release v0.36.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.84](https://github.com/azerozero/grob/compare/v0.36.83...v0.36.84) - 2026-07-27
+
+### Fixed
+
+- *(cli)* make grob stop recognise its daemon on macOS ([#481](https://github.com/azerozero/grob/pull/481))
+
+### Other
+
+- switch merge policy to squash-only for reliable release-plz ([#480](https://github.com/azerozero/grob/pull/480))
+- *(release-plz)* allow manual workflow_dispatch
+
 ## [0.36.83](https://github.com/azerozero/grob/compare/v0.36.82...v0.36.83) - 2026-07-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.83"
+version = "0.36.84"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.83"
+version = "0.36.84"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.83 -> 0.36.84

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.84](https://github.com/azerozero/grob/compare/v0.36.83...v0.36.84) - 2026-07-27

### Fixed

- *(cli)* make grob stop recognise its daemon on macOS ([#481](https://github.com/azerozero/grob/pull/481))

### Other

- switch merge policy to squash-only for reliable release-plz ([#480](https://github.com/azerozero/grob/pull/480))
- *(release-plz)* allow manual workflow_dispatch
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).