### PR TITLE
ci(docs): exclude flaky istio.io from lychee link check

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,3 +4,6 @@
 ^https?://.*\.internal(/.*)?$
 # public.cyber.mil rate-limits/times out from GitHub runners (flaky, not broken).
 ^https?://(public\.)?cyber\.mil(/.*)?$
+# istio.io refuses connections from GitHub runners intermittently (flaky, not
+# broken — returns 200 from a normal client). Cited in ADR-0022.
+^https?://(www\.)?istio\.io(/.*)?$


### PR DESCRIPTION
## What

The lychee (broken-link) gate failed on the v0.36.84 release PR (#482):

```
### Errors in docs/decisions/0022-declarative-endpoints-policies-schema.md
* [ERROR] https://istio.io/latest/docs/reference/config/security/authorization-policy/
  Connection failed. Check network connectivity and firewall settings
```

The link is **not broken** — it returns `200` from a normal client (verified:
0.6s, HTTP 200). istio.io intermittently refuses connections from GitHub runner
IPs; the same URL timed out earlier this release cycle too.

## Fix

Added the host to `.lycheeignore`, matching the existing precedent for
`public.cyber.mil` (excluded for the identical "flaky from runners, not broken"
reason). The link stays in the doc; only the runner-side flakiness stops blocking
merges.

It was non-blocking for v0.36.84 (lychee isn't a Required check, so the release
went through), but it turns the docs-lint workflow red on every run that
re-checks that URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)