### PR TITLE
chore: release v0.36.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.85](https://github.com/azerozero/grob/compare/v0.36.84...v0.36.85) - 2026-07-28
+
+### Fixed
+
+- *(openai)* preserve tool-result images on the Responses (Codex) path ([#488](https://github.com/azerozero/grob/pull/488))
+
+### Other
+
+- *(docs)* exclude flaky istio.io from lychee link check ([#483](https://github.com/azerozero/grob/pull/483))
+
 ## [0.36.84](https://github.com/azerozero/grob/compare/v0.36.83...v0.36.84) - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.84"
+version = "0.36.85"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.84"
+version = "0.36.85"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.84 -> 0.36.85

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.85](https://github.com/azerozero/grob/compare/v0.36.84...v0.36.85) - 2026-07-28

### Fixed

- *(openai)* preserve tool-result images on the Responses (Codex) path ([#488](https://github.com/azerozero/grob/pull/488))

### Other

- *(docs)* exclude flaky istio.io from lychee link check ([#483](https://github.com/azerozero/grob/pull/483))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).