### PR TITLE
fix: harden critical architecture boundaries

### DIFF
--- a/src/providers/anthropic_compatible.rs
+++ b/src/providers/anthropic_compatible.rs
@@ -90,7 +90,7 @@ fn log_rate_limits(headers: &HashMap<String, String>, provider: &str) {
 
 use super::anthropic_sanitize::{
     restore_original_tool_ids, sanitize_tool_use_ids, strip_all_thinking_signatures,
-    strip_non_anthropic_thinking, OriginalToolIdMap,
+    strip_non_anthropic_thinking, OriginalToolIdMap, RestoreToolIdStream,
 };
 
 /// Merges server-default beta features with client-provided ones, deduplicating.
@@ -421,14 +421,6 @@ impl LlmProvider for AnthropicCompatibleProvider {
         let mut request = request;
         let (url, auth_value, is_anthropic, id_map) =
             self.prepare_anthropic_request(&mut request).await?;
-        // NOTE: Streaming responses pass through unchanged; tool ID
-        // restoration on streamed `content_block_start` events would require
-        // SSE event rewriting and is intentionally out of scope for the
-        // initial Bug #2 fix. The non-streaming path covers the common case
-        // (single response per call). Future work: see TODO at restore call
-        // site below.
-        // TODO: implement SSE-time ID rewrite using `id_map` for streaming.
-        let _ = id_map;
 
         // Try request, fallback: strip all signed thinking blocks on signature error
         let response = match self
@@ -459,8 +451,12 @@ impl LlmProvider for AnthropicCompatibleProvider {
         // Wrap stream with logging to capture cache statistics
         use crate::providers::streaming::LoggingSseStream;
         let byte_stream = response.bytes_stream().map_err(ProviderError::HttpError);
-        let logging_stream =
-            LoggingSseStream::new(byte_stream, self.base.name.clone(), request.model.clone());
+        let restored_stream = RestoreToolIdStream::new(byte_stream, id_map);
+        let logging_stream = LoggingSseStream::new(
+            restored_stream,
+            self.base.name.clone(),
+            request.model.clone(),
+        );
 
         // Return stream with headers for forwarding
         Ok(StreamResponse {

--- a/src/providers/anthropic_sanitize.rs
+++ b/src/providers/anthropic_sanitize.rs
@@ -2,7 +2,13 @@
 
 use super::constants::MIN_ANTHROPIC_SIGNATURE_LENGTH;
 use crate::models::{CanonicalRequest, ContentBlock, KnownContentBlock, MessageContent};
+use bytes::Bytes;
+use futures::Stream;
+use pin_project::pin_project;
 use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 /// Bidirectional map between sanitized (canonical) tool IDs and the originals
 /// supplied by the client.
@@ -267,6 +273,114 @@ pub(super) fn restore_original_tool_ids(
     }
 }
 
+/// Restores sanitized tool IDs in streamed Anthropic `content_block_start` events.
+#[pin_project]
+pub(super) struct RestoreToolIdStream<S> {
+    #[pin]
+    inner: S,
+    id_map: OriginalToolIdMap,
+    buffer: Vec<u8>,
+    queue: VecDeque<Bytes>,
+}
+
+impl<S> RestoreToolIdStream<S> {
+    pub(super) fn new(inner: S, id_map: OriginalToolIdMap) -> Self {
+        Self {
+            inner,
+            id_map,
+            buffer: Vec::new(),
+            queue: VecDeque::new(),
+        }
+    }
+}
+
+impl<S, E> Stream for RestoreToolIdStream<S>
+where
+    S: Stream<Item = Result<Bytes, E>>,
+{
+    type Item = Result<Bytes, E>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        if this.id_map.is_empty() {
+            return this.inner.poll_next(cx);
+        }
+        if let Some(bytes) = this.queue.pop_front() {
+            return Poll::Ready(Some(Ok(bytes)));
+        }
+
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(bytes))) => {
+                this.buffer.extend_from_slice(&bytes);
+                while let Some(end) = this.buffer.windows(2).position(|window| window == b"\n\n") {
+                    let event = this.buffer.drain(..end + 2).collect::<Vec<_>>();
+                    this.queue
+                        .push_back(restore_tool_id_in_sse_event(&event, this.id_map));
+                }
+
+                if let Some(bytes) = this.queue.pop_front() {
+                    Poll::Ready(Some(Ok(bytes)))
+                } else {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(error))),
+            Poll::Ready(None) if !this.buffer.is_empty() => {
+                let tail = std::mem::take(this.buffer);
+                Poll::Ready(Some(Ok(restore_tool_id_in_sse_event(&tail, this.id_map))))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn restore_tool_id_in_sse_event(event: &[u8], id_map: &OriginalToolIdMap) -> Bytes {
+    let Ok(text) = std::str::from_utf8(event) else {
+        return Bytes::copy_from_slice(event);
+    };
+    let Some(data_start) = text.find("data: ").map(|index| index + "data: ".len()) else {
+        return Bytes::copy_from_slice(event);
+    };
+    let data_end = text[data_start..]
+        .find('\n')
+        .map_or(text.len(), |index| data_start + index);
+    let Ok(mut data) = serde_json::from_str::<serde_json::Value>(&text[data_start..data_end])
+    else {
+        return Bytes::copy_from_slice(event);
+    };
+    if data.get("type").and_then(|value| value.as_str()) != Some("content_block_start")
+        || data
+            .pointer("/content_block/type")
+            .and_then(|value| value.as_str())
+            != Some("tool_use")
+    {
+        return Bytes::copy_from_slice(event);
+    }
+
+    let Some(id) = data
+        .pointer("/content_block/id")
+        .and_then(|value| value.as_str())
+    else {
+        return Bytes::copy_from_slice(event);
+    };
+    let Some(original) = id_map.original_for(id) else {
+        return Bytes::copy_from_slice(event);
+    };
+    data["content_block"]["id"] = serde_json::Value::String(original.to_string());
+
+    let Ok(restored_data) = serde_json::to_vec(&data) else {
+        return Bytes::copy_from_slice(event);
+    };
+    let mut restored = Vec::with_capacity(event.len() + original.len());
+    restored.extend_from_slice(&event[..data_start]);
+    restored.extend_from_slice(&restored_data);
+    restored.extend_from_slice(&event[data_end..]);
+    Bytes::from(restored)
+}
+
 /// Sanitize a tool ID to match pattern ^[a-zA-Z0-9_-]+
 fn sanitize_tool_id(id: &str) -> String {
     id.chars()
@@ -285,6 +399,7 @@ mod tests {
     use super::*;
     use crate::models::{Message, ToolResultContent};
     use crate::providers::{ProviderResponse, Usage};
+    use futures::TryStreamExt;
 
     fn user_message_with_blocks(blocks: Vec<ContentBlock>) -> Message {
         Message {
@@ -476,5 +591,59 @@ mod tests {
             }
             other => panic!("expected ToolUse, got {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn streamed_tool_use_id_restores_original_across_chunks() {
+        let original_id = "functions.Bash:0";
+        let mut request = empty_request();
+        request.messages = vec![assistant_message_with_blocks(vec![ContentBlock::tool_use(
+            original_id.to_string(),
+            "Bash".to_string(),
+            serde_json::json!({}),
+        )])];
+        let mut id_map = OriginalToolIdMap::new();
+        sanitize_tool_use_ids(&mut request, &mut id_map);
+
+        let event = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,",
+            "\"content_block\":{\"type\":\"tool_use\",",
+            "\"id\":\"functions_Bash_0\",\"name\":\"Bash\",\"input\":{}}}\n\n"
+        );
+        let inner = futures::stream::iter(vec![
+            Ok::<_, ()>(Bytes::copy_from_slice(&event.as_bytes()[..37])),
+            Ok(Bytes::copy_from_slice(&event.as_bytes()[37..])),
+        ]);
+
+        let chunks: Vec<Bytes> = RestoreToolIdStream::new(inner, id_map)
+            .try_collect()
+            .await
+            .unwrap();
+        let output = String::from_utf8(chunks.concat()).unwrap();
+        let parsed = crate::providers::streaming::parse_sse_events(&output);
+        let data: serde_json::Value = serde_json::from_str(&parsed[0].data).unwrap();
+
+        assert_eq!(
+            data.pointer("/content_block/id").and_then(|id| id.as_str()),
+            Some(original_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn streamed_non_start_event_is_unchanged() {
+        let mut id_map = OriginalToolIdMap::new();
+        id_map.record("functions_Bash_0", "functions.Bash:0");
+        let event = Bytes::from_static(
+            b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}\n\n",
+        );
+        let inner = futures::stream::iter(vec![Ok::<_, ()>(event.clone())]);
+
+        let chunks: Vec<Bytes> = RestoreToolIdStream::new(inner, id_map)
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_eq!(chunks.concat(), event.as_ref());
     }
 }

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -16,6 +16,22 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Why a configured mapping cannot be dispatched right now.
+///
+/// [`ProviderRegistry::provider_for_dispatch`] is the sole composition point for
+/// provider-level availability and endpoint-level health. The underlying state
+/// remains owned by the supplied [`crate::traits::ProviderAvailability`] and by
+/// this registry's endpoint health components respectively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DispatchRejection {
+    /// The mapping references a provider absent from the registry.
+    ProviderNotRegistered,
+    /// The provider-level availability authority rejected the dispatch.
+    ProviderUnavailable,
+    /// Active or passive endpoint health rejected the provider/model pair.
+    EndpointUnavailable,
+}
+
 /// Default base URL for OpenAI-compatible API
 const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 
@@ -437,6 +453,34 @@ impl ProviderRegistry {
         self.providers.get(name).cloned()
     }
 
+    /// Resolves a provider for dispatch through the single availability gate.
+    ///
+    /// Provider-level health is evaluated first because its state machine may
+    /// consume a half-open permit. Endpoint health is then evaluated for the
+    /// concrete `(provider, model)` mapping. Both must allow the request.
+    pub(crate) async fn provider_for_dispatch(
+        &self,
+        provider: &str,
+        model: &str,
+        provider_availability: Option<&dyn crate::traits::ProviderAvailability>,
+    ) -> Result<Arc<dyn LlmProvider>, DispatchRejection> {
+        let provider_impl = self
+            .provider(provider)
+            .ok_or(DispatchRejection::ProviderNotRegistered)?;
+
+        if let Some(availability) = provider_availability {
+            if !availability.can_execute(provider).await {
+                return Err(DispatchRejection::ProviderUnavailable);
+            }
+        }
+
+        if !self.is_endpoint_healthy(provider, model) {
+            return Err(DispatchRejection::EndpointUnavailable);
+        }
+
+        Ok(provider_impl)
+    }
+
     /// Gets a provider for a specific model.
     ///
     /// # Errors
@@ -444,20 +488,32 @@ impl ProviderRegistry {
     /// Returns [`ProviderError::ModelNotSupported`] if no registered
     /// provider handles the given model name.
     pub fn provider_for_model(&self, model: &str) -> Result<Arc<dyn LlmProvider>, ProviderError> {
+        self.provider_and_name_for_model(model)
+            .map(|(_, provider)| provider)
+    }
+
+    /// Gets the configured provider name and implementation for a model.
+    ///
+    /// Dispatch uses the name to apply the same provider and endpoint health
+    /// decision to backward-compatible direct model lookups as mapped lookups.
+    pub(crate) fn provider_and_name_for_model(
+        &self,
+        model: &str,
+    ) -> Result<(String, Arc<dyn LlmProvider>), ProviderError> {
         // First, check if we have a direct model → provider mapping. The index is
         // keyed by canonical name, so canonicalize the query to match it.
         let canonical = crate::routing::classify::model_name::canonicalize_model_name(model);
         if let Some(provider_name) = self.model_to_provider.get(canonical.as_ref()) {
             if let Some(provider) = self.providers.get(provider_name) {
-                return Ok(provider.clone());
+                return Ok((provider_name.clone(), provider.clone()));
             }
         }
 
         // If no direct mapping, search through all providers
         self.providers
-            .values()
-            .find(|p| p.supports_model(model))
-            .cloned()
+            .iter()
+            .find(|(_, provider)| provider.supports_model(model))
+            .map(|(name, provider)| (name.clone(), provider.clone()))
             .ok_or_else(|| ProviderError::ModelNotSupported(model.to_string()))
     }
 
@@ -598,6 +654,38 @@ impl Default for ProviderRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::providers::mocks::MockLlmProvider;
+    use crate::security::CircuitState;
+    use crate::traits::ProviderAvailability;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct FixedAvailability {
+        allowed: bool,
+        checks: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl ProviderAvailability for FixedAvailability {
+        async fn can_execute(&self, _provider: &str) -> bool {
+            self.checks.fetch_add(1, Ordering::Relaxed);
+            self.allowed
+        }
+
+        async fn record_success(&self, _provider: &str, _latency_ms: u64) {}
+
+        async fn record_failure(&self, _provider: &str) {}
+
+        async fn all_states(&self) -> HashMap<String, CircuitState> {
+            HashMap::new()
+        }
+    }
+
+    fn registry_with_mock_provider() -> ProviderRegistry {
+        let mut registry = ProviderRegistry::new();
+        registry
+            .insert_provider_for_test("primary", Arc::new(MockLlmProvider::text("model-a", "ok")));
+        registry
+    }
 
     #[test]
     fn test_empty_registry() {
@@ -611,6 +699,97 @@ mod tests {
         let registry = ProviderRegistry::new();
         let result = registry.provider_for_model("gpt-4");
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn dispatch_gate_does_not_consume_availability_for_missing_provider() {
+        let registry = ProviderRegistry::new();
+        let availability = FixedAvailability {
+            allowed: true,
+            checks: AtomicUsize::new(0),
+        };
+
+        let result = registry
+            .provider_for_dispatch("missing", "model-a", Some(&availability))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(DispatchRejection::ProviderNotRegistered)
+        ));
+        assert_eq!(availability.checks.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn dispatch_gate_rejects_provider_before_endpoint_health() {
+        let mut registry = registry_with_mock_provider();
+        registry.cb_templates.insert(
+            "primary".to_string(),
+            CircuitBreakerConfig {
+                max_fails: 1,
+                fail_duration: Duration::from_secs(60),
+                cooldown: Some(Duration::from_secs(60)),
+            },
+        );
+        let availability = FixedAvailability {
+            allowed: false,
+            checks: AtomicUsize::new(0),
+        };
+
+        let result = registry
+            .provider_for_dispatch("primary", "model-a", Some(&availability))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(DispatchRejection::ProviderUnavailable)
+        ));
+        assert_eq!(availability.checks.load(Ordering::Relaxed), 1);
+        assert!(registry.endpoint_breakers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatch_gate_requires_provider_and_endpoint_health() {
+        let mut registry = registry_with_mock_provider();
+        registry.cb_templates.insert(
+            "primary".to_string(),
+            CircuitBreakerConfig {
+                max_fails: 1,
+                fail_duration: Duration::from_secs(60),
+                cooldown: Some(Duration::from_secs(60)),
+            },
+        );
+        registry.record_endpoint_failure("primary", "model-a");
+        let availability = FixedAvailability {
+            allowed: true,
+            checks: AtomicUsize::new(0),
+        };
+
+        let result = registry
+            .provider_for_dispatch("primary", "model-a", Some(&availability))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(DispatchRejection::EndpointUnavailable)
+        ));
+        assert_eq!(availability.checks.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn dispatch_gate_returns_provider_when_all_signals_allow() {
+        let registry = registry_with_mock_provider();
+        let availability = FixedAvailability {
+            allowed: true,
+            checks: AtomicUsize::new(0),
+        };
+
+        let result = registry
+            .provider_for_dispatch("primary", "model-a", Some(&availability))
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(availability.checks.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/src/security/circuit_breaker.rs
+++ b/src/security/circuit_breaker.rs
@@ -254,7 +254,7 @@ impl crate::traits::ProviderAvailability for CircuitBreakerRegistry {
         self.can_execute(provider).await
     }
 
-    async fn record_success(&self, provider: &str) {
+    async fn record_success(&self, provider: &str, _latency_ms: u64) {
         self.record_success(provider).await;
     }
 

--- a/src/security/provider_scorer.rs
+++ b/src/security/provider_scorer.rs
@@ -261,10 +261,8 @@ impl crate::traits::ProviderAvailability for ProviderScorer {
         self.can_execute(provider).await
     }
 
-    async fn record_success(&self, provider: &str) {
-        // Record with 0 latency when called through the trait (latency unknown).
-        // The dispatch layer should call record_success(provider, latency_ms) directly.
-        self.record_success(provider, 0).await;
+    async fn record_success(&self, provider: &str, latency_ms: u64) {
+        self.record_success(provider, latency_ms).await;
     }
 
     async fn record_failure(&self, provider: &str) {
@@ -313,6 +311,17 @@ mod tests {
         let scores = scorer.scores.read().await;
         let s = scores.get("p1").unwrap();
         assert!((s.success_rate() - 0.6).abs() < 0.01);
+    }
+
+    #[tokio::test]
+    async fn availability_trait_preserves_success_latency() {
+        let scorer = ProviderScorer::new(test_config(), None);
+
+        crate::traits::ProviderAvailability::record_success(&scorer, "p1", 250).await;
+
+        let details = scorer.all_score_details().await;
+        let (_, latency, _) = details.get("p1").expect("provider score recorded");
+        assert_eq!(*latency, 250.0);
     }
 
     #[tokio::test]

--- a/src/server/config_api.rs
+++ b/src/server/config_api.rs
@@ -209,12 +209,9 @@ pub(crate) async fn update_config_json(
 
 /// Reload configuration without restarting the server.
 ///
-/// Rejects only **structurally** invalid candidates: a parse error, an
-/// `AppConfig::validate()` failure (model mapping references an unknown
-/// provider, missing provider auth, bad router regex), or a provider-registry
-/// build failure surface as a 4xx and leave the live `inner` snapshot
-/// untouched. A structurally-valid candidate is always swapped in — the reload
-/// is **not** gated on live provider health, because a provider being
+/// Rejects invalid candidates and changes to startup-only config-derived
+/// subsystems, leaving the live `inner` snapshot untouched. Accepted reloads
+/// are **not** gated on live provider health, because a provider being
 /// momentarily unreachable must not block a config swap. Health is still
 /// observed: `validate_config`'s live probes run in a detached task that only
 /// logs warnings on unhealthy mappings.
@@ -239,11 +236,10 @@ pub(crate) async fn reload_config(State(state): State<Arc<AppState>>) -> Respons
         }
     };
 
-    // 1b. Reject a reload that would change/break the `/metrics` bearer token: it
-    //     is resolved once at startup into non-reloadable state, so applying it
-    //     here is impossible and a silent success would falsely imply /metrics is
-    //     now gated (or opened). Shared guard — every reload path calls it.
-    if let Err(msg) = super::config_guard::ensure_metrics_auth_reloadable(&state, &new_config) {
+    // 1b. Reject changes to config-derived subsystems that are initialized only
+    //     at startup. This guard applies equally to API writes and direct edits of
+    //     the config file followed by this endpoint.
+    if let Err(msg) = super::config_guard::ensure_config_reloadable(&state, &new_config) {
         warn!("config reload rejected: {msg}");
         return (
             StatusCode::BAD_REQUEST,
@@ -359,4 +355,76 @@ pub(crate) fn spawn_health_probe(config: AppConfig, registry: Arc<ProviderRegist
             );
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::extract::State;
+
+    fn config_toml(rate_limit_rps: u32, default_model: &str) -> String {
+        format!(
+            r#"
+[server]
+host = "127.0.0.1"
+port = 18100
+
+[router]
+default = "{default_model}"
+
+[security]
+rate_limit_rps = {rate_limit_rps}
+
+[[providers]]
+name = "mock"
+provider_type = "openai"
+auth_type = "apikey"
+api_key = "sk-test"
+base_url = "http://127.0.0.1:1"
+models = ["alpha", "beta"]
+
+[[models]]
+name = "alpha"
+[[models.mappings]]
+priority = 1
+provider = "mock"
+actual_model = "alpha"
+
+[[models]]
+name = "beta"
+[[models.mappings]]
+priority = 1
+provider = "mock"
+actual_model = "beta"
+"#
+        )
+    }
+
+    #[tokio::test]
+    async fn reload_endpoint_rejects_direct_edit_to_startup_only_section() {
+        use crate::cli::{AppConfig, ConfigSource};
+        use crate::providers::ProviderRegistry;
+
+        let live_config = AppConfig::from_content(&config_toml(10, "alpha"), "reload_live")
+            .expect("live config parses");
+        let file = tempfile::NamedTempFile::new().expect("temp config");
+        std::fs::write(file.path(), config_toml(20, "beta")).expect("edit config directly");
+        let state = crate::server::test_app_state_with_source(
+            live_config,
+            ProviderRegistry::new(),
+            ConfigSource::File(file.path().to_path_buf()),
+        );
+
+        let response = reload_config(State(state.clone())).await;
+        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        assert!(
+            String::from_utf8_lossy(&body).contains("[security]"),
+            "response should identify the startup-only section"
+        );
+        assert_eq!(state.snapshot().config.router.default, "alpha");
+    }
 }

--- a/src/server/config_guard.rs
+++ b/src/server/config_guard.rs
@@ -11,6 +11,31 @@ use std::path::Path;
 use std::sync::Arc;
 use tracing::info;
 
+/// Top-level config keys whose consumers are rebuilt or read from the atomic
+/// [`super::ReloadableState`] snapshot.
+///
+/// Everything else fails closed: adding a new config section cannot silently
+/// become "reloadable" while its runtime subsystem still uses startup state.
+const RELOADABLE_SECTIONS: &[&str] = &[
+    "version",
+    "router",
+    "providers",
+    "models",
+    "tiers",
+    "classifier",
+    "budget",
+    "secrets",
+    "compliance",
+    "user",
+    "pledge",
+    "tool_validation",
+    "policies",
+];
+
+/// Message prefix returned when a reload changes startup-only configuration.
+pub const RESTART_REQUIRED_MSG: &str =
+    "configuration change requires a daemon restart; reload was not applied";
+
 /// Top-level TOML sections that are never writable via any config API.
 ///
 /// Each entry is denied because hot-reloading it cannot be done safely
@@ -140,6 +165,50 @@ pub fn ensure_metrics_auth_reloadable(
     Ok(())
 }
 
+/// Rejects candidates that would make the atomic config snapshot disagree with
+/// subsystems initialized only at process startup.
+///
+/// The comparison is fail-closed at the top-level TOML key boundary. Only keys
+/// in [`RELOADABLE_SECTIONS`] may change. The resolved metrics token check is
+/// retained separately so edits to the contents of an unchanged token file are
+/// also detected.
+///
+/// # Errors
+///
+/// Returns a restart-required message naming the first startup-only section
+/// that changed, or a serialization error.
+pub fn ensure_config_reloadable(
+    state: &Arc<super::AppState>,
+    candidate: &crate::config::AppConfig,
+) -> Result<(), String> {
+    ensure_metrics_auth_reloadable(state, candidate)?;
+
+    let live = toml::Value::try_from(&state.snapshot().config)
+        .map_err(|e| format!("failed to compare live configuration: {e}"))?;
+    let candidate = toml::Value::try_from(candidate)
+        .map_err(|e| format!("failed to compare candidate configuration: {e}"))?;
+    let live = live
+        .as_table()
+        .ok_or_else(|| "live configuration did not serialize as a TOML table".to_string())?;
+    let candidate = candidate
+        .as_table()
+        .ok_or_else(|| "candidate configuration did not serialize as a TOML table".to_string())?;
+
+    let changed = live
+        .keys()
+        .chain(candidate.keys())
+        .filter(|key| !RELOADABLE_SECTIONS.contains(&key.as_str()))
+        .find(|key| live.get(*key) != candidate.get(*key));
+
+    if let Some(section) = changed {
+        return Err(format!(
+            "{RESTART_REQUIRED_MSG}: [{section}] is initialized only at startup"
+        ));
+    }
+
+    Ok(())
+}
+
 /// Validates a key update against the deny-list using [`ConfigSection`].
 ///
 /// Delegates to [`is_section_or_key_denied`] after converting the enum to a
@@ -180,10 +249,9 @@ pub async fn persist_and_reload(
         }
     };
 
-    // Reject a `/metrics` token change BEFORE any persistence, so the on-disk
-    // config and the running token never diverge (the token is resolved once at
-    // startup and cannot be hot-applied).
-    ensure_metrics_auth_reloadable(state, config).map_err(super::RequestError::BadRequest)?;
+    // Reject startup-only changes BEFORE persistence, so disk and runtime never
+    // diverge even when a config mutation path misses its field-level deny-list.
+    ensure_config_reloadable(state, config).map_err(super::RequestError::BadRequest)?;
 
     // 1. Backup
     let backup_path = config_path.with_extension("toml.backup");
@@ -408,6 +476,33 @@ actual_model = "alpha"
             err.contains("restart") || err.contains("could not be read"),
             "message must explain the rejection: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn startup_only_section_change_is_rejected() {
+        use crate::providers::ProviderRegistry;
+
+        let config = guard_config("");
+        let live = crate::server::test_app_state(config.clone(), ProviderRegistry::new());
+        let mut candidate = config;
+        candidate.security.rate_limit_rps += 1;
+
+        let err = ensure_config_reloadable(&live, &candidate)
+            .expect_err("startup-only security state must not split from config");
+        assert!(err.contains("[security]"), "unexpected message: {err}");
+    }
+
+    #[tokio::test]
+    async fn reloadable_section_change_is_allowed() {
+        use crate::providers::ProviderRegistry;
+
+        let config = guard_config("");
+        let live = crate::server::test_app_state(config.clone(), ProviderRegistry::new());
+        let mut candidate = config;
+        candidate.router.default = "beta".to_string();
+
+        ensure_config_reloadable(&live, &candidate)
+            .expect("router is rebuilt as part of the atomic reload state");
     }
 
     // #3: persist_and_reload must reject a token change BEFORE persisting. The

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -117,27 +117,17 @@ impl DispatchContext<'_> {
         }
     }
 
-    /// Records a provider success in the scorer or circuit breaker.
-    ///
-    /// Prefers the adaptive scorer (which wraps the circuit breaker);
-    /// falls back to the bare circuit breaker when no scorer is configured.
+    /// Records a provider success through the configured availability authority.
     pub(crate) async fn record_provider_success(&self, provider: &str, latency_ms: u64) {
-        if let Some(ref scorer) = self.state.security.provider_scorer {
-            scorer.record_success(provider, latency_ms).await;
-        } else if let Some(ref cb) = self.state.security.circuit_breakers {
-            cb.record_success(provider).await;
+        if let Some(ref availability) = self.state.security.provider_availability {
+            availability.record_success(provider, latency_ms).await;
         }
     }
 
-    /// Records a provider failure in the scorer or circuit breaker.
-    ///
-    /// Prefers the adaptive scorer (which wraps the circuit breaker);
-    /// falls back to the bare circuit breaker when no scorer is configured.
+    /// Records a provider failure through the configured availability authority.
     pub(crate) async fn record_provider_failure(&self, provider: &str) {
-        if let Some(ref scorer) = self.state.security.provider_scorer {
-            scorer.record_failure(provider).await;
-        } else if let Some(ref cb) = self.state.security.circuit_breakers {
-            cb.record_failure(provider).await;
+        if let Some(ref availability) = self.state.security.provider_availability {
+            availability.record_failure(provider).await;
         }
     }
 

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -4,6 +4,7 @@
 //! delegate to the single `dispatch()` function, which orchestrates the full pipeline:
 //! DLP scanning → cache lookup → routing → provider loop with fallback → audit → response.
 
+mod preflight;
 mod provider_loop;
 mod resolver;
 mod retry;
@@ -315,57 +316,10 @@ pub(crate) async fn dispatch(
     #[cfg(feature = "mcp")]
     let grob_hint = resolve_grob_hint(ctx, request)?;
 
-    // ── Step 1: DLP input scanning ──
+    // ── Step 1: Security and tool preflight ──
     // `dlp_triggered` feeds the post-route policy context (Step 5.4).
     #[cfg_attr(not(feature = "policies"), allow(unused_variables))]
-    let dlp_triggered = scan_dlp_input(ctx, request)?;
-
-    // Security: DLP sanitizes the canonical request in place. Drop any verbatim
-    // Responses passthrough body so the OpenAI provider rebuilds from the
-    // sanitized request — otherwise the original, un-redacted bytes would be
-    // forwarded upstream, bypassing DLP. The rebuild path stays cache-friendly
-    // (typed content + prompt_cache_key), so the only cost is a one-request cache
-    // miss when DLP actually fires.
-    if dlp_triggered {
-        request.extensions.responses_passthrough_body = None;
-    }
-
-    // ── Step 1.4: Tool-call spike anomaly detection (T-AD1) ──
-    // Runs after DLP so scoped DLP blocks take precedence, and before
-    // routing so a runaway client cannot exhaust provider quotas before
-    // the spike is observed.
-    check_tool_spike(ctx, request)?;
-
-    // ── Step 1.5: MCP tool calibration ──
-    #[cfg(feature = "mcp")]
-    if let Some(ref mcp) = ctx.state.security.mcp {
-        crate::features::mcp::calibration::calibrate_tools(mcp, request);
-    }
-
-    // ── Step 1.55: Inbound tool well-formedness validation ──
-    // Strips (or, in reject mode, 400s on) tools with a missing name or a
-    // malformed `input_schema`. Well-formedness only — client tools are
-    // arbitrary and are NOT checked against grob's internal catalogue. Runs
-    // before pledge so malformed tools never reach the allowlist check.
-    match crate::features::tool_validation::validate_inbound_tools(
-        request,
-        &ctx.inner.config.tool_validation,
-    ) {
-        Ok(stripped) => warn_stripped_tools(&stripped),
-        Err(reason) => return Err(RequestError::BadRequest(reason)),
-    }
-
-    // ── Step 1.6: Pledge tool filtering ──
-    if ctx.inner.config.pledge.enabled {
-        let filter = crate::features::pledge::PledgeFilter::new(&ctx.inner.config.pledge);
-        let token = ctx
-            .headers
-            .get("authorization")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "))
-            .or_else(|| ctx.headers.get("x-api-key").and_then(|v| v.to_str().ok()));
-        filter.apply(request, ctx.tenant_id.as_deref(), token);
-    }
+    let dlp_triggered = preflight::run(ctx, request)?;
 
     // ── Step 2: Cache key ──
     let cache_key = ctx
@@ -709,270 +663,6 @@ async fn check_cache(
     })
 }
 
-/// Returns `true` when DLP input scanning is disabled for this request.
-///
-/// Extracted so the early-return guard in [`scan_dlp_input`] is unit-testable
-/// without constructing a full [`DispatchContext`].
-#[inline]
-fn dlp_input_scan_disabled(scan_input: bool) -> bool {
-    !scan_input
-}
-
-/// Returns `true` when a DLP block should escalate via the compliance webhook.
-///
-/// Extracted so the compliance-escalation guard in [`scan_dlp_input`] is
-/// unit-testable without constructing a full [`DispatchContext`].
-#[inline]
-fn should_escalate_compliance(enabled: bool, risk_classification: bool) -> bool {
-    enabled && risk_classification
-}
-
-/// Returns `true` when DLP produced at least one redact/warn report.
-///
-/// Extracted so the trigger flag in [`scan_dlp_input`] is unit-testable
-/// without constructing a full [`DispatchContext`].
-#[inline]
-fn dlp_reports_triggered<T>(reports: &[T]) -> bool {
-    !reports.is_empty()
-}
-
-/// Builds the audit `dlp_rules_triggered` entries for a set of redact/warn reports.
-///
-/// Each entry is `"<rule_type>: <detail>"` (e.g. `"secret: AWS access key"`),
-/// mirroring the format the block path uses so a caviardage is named in the
-/// per-tenant audit log exactly like a block is.
-///
-/// Extracted so the formatting is unit-testable without a full pipeline.
-#[inline]
-fn redaction_audit_rules(reports: &[crate::features::dlp::DlpActionReport]) -> Vec<String> {
-    reports
-        .iter()
-        .map(|r| format!("{}: {}", r.rule_type, r.detail))
-        .collect()
-}
-
-/// Returns `true` when any DLP report concerns personally identifiable information.
-///
-/// Drives the C2 (Restricted) vs C1 (Internal) split for a caviardage: a
-/// redacted PII field is Restricted, a redacted secret is Internal.
-///
-/// Extracted so the PII guard is unit-testable without a full pipeline.
-#[inline]
-fn reports_have_pii(reports: &[crate::features::dlp::DlpActionReport]) -> bool {
-    reports
-        .iter()
-        .any(|r| matches!(r.rule_type, crate::features::dlp::DlpRuleType::Pii))
-}
-
-/// Logs a warning when tool validation stripped malformed inbound tools.
-///
-/// Extracted so the non-empty guard is unit-testable; the inline `if` was
-/// otherwise only reachable through the full `dispatch` pipeline.
-#[inline]
-fn warn_stripped_tools(stripped: &[String]) {
-    if !stripped.is_empty() {
-        tracing::warn!(
-            tools = ?stripped,
-            "tool validation: stripped malformed inbound tools"
-        );
-    }
-}
-
-/// DLP input scanning with risk assessment and audit logging.
-///
-/// Returns `Ok(true)` when DLP acted on the request (one or more redact/warn
-/// reports), `Ok(false)` when scanning is off or nothing matched. That flag
-/// feeds the post-route policy context so `dlp_triggered`-keyed policies match.
-fn scan_dlp_input(
-    ctx: &DispatchContext<'_>,
-    request: &mut CanonicalRequest,
-) -> Result<bool, RequestError> {
-    let Some(ref dlp_engine) = ctx.dlp else {
-        return Ok(false);
-    };
-    if dlp_input_scan_disabled(dlp_engine.config.scan_input) {
-        return Ok(false);
-    }
-
-    match dlp_engine.sanitize_request_checked(request) {
-        Ok(reports) => {
-            let triggered = dlp_reports_triggered(&reports);
-            ctx.emit_dlp_events(&reports, DlpDirection::Request);
-            if triggered {
-                // A caviardage (redact/warn) is a security-relevant event in
-                // its own right, just like a block. Emit a classified audit
-                // entry here so the per-tenant audit log — and the Loki
-                // dashboards built on it — record the redaction as C1 (secret,
-                // Internal) or C2 (PII, Restricted), instead of leaving the
-                // request indistinguishable from clean (Nc) traffic on the
-                // later Response entry. Blocks already do this in the Err arm.
-                ctx.log_audit_if_enabled(AuditEntry {
-                    action: crate::security::audit_log::AuditEvent::DlpWarn,
-                    backend: "REDACTED",
-                    dlp_rules: redaction_audit_rules(&reports),
-                    duration_ms: ctx.start_time.elapsed().as_millis() as u64,
-                    model_name: Some(&ctx.model),
-                    token_counts: None,
-                    risk_level: Some(crate::security::audit_log::RiskLevel::Medium),
-                    dlp_blocked: false,
-                    dlp_had_injection: false,
-                    dlp_had_pii: reports_have_pii(&reports),
-                    dlp_had_redact_or_warn: true,
-                });
-            }
-            Ok(triggered)
-        }
-        Err(block_err) => {
-            // Emit DLP block event for `grob watch`.
-            let (block_rule_type, block_detail) = match &block_err {
-                crate::features::dlp::DlpBlockError::InjectionBlocked(dets) => {
-                    ("injection", format!("{} injection(s) detected", dets.len()))
-                }
-                crate::features::dlp::DlpBlockError::UrlExfilBlocked(dets) => (
-                    "url_exfil",
-                    format!("{} exfiltration URL(s) detected", dets.len()),
-                ),
-                crate::features::dlp::DlpBlockError::IndirectInjectionBlocked(dets) => (
-                    "indirect_injection",
-                    format!("{} indirect injection(s) detected", dets.len()),
-                ),
-            };
-            ctx.state.event_bus.emit(WatchEvent::DlpAction {
-                request_id: ctx.req_id.to_string(),
-                direction: DlpDirection::Request,
-                action: "block".into(),
-                rule_type: block_rule_type.into(),
-                detail: block_detail,
-                timestamp: chrono::Utc::now(),
-            });
-
-            let had_injection = matches!(
-                &block_err,
-                crate::features::dlp::DlpBlockError::InjectionBlocked(_)
-                    | crate::features::dlp::DlpBlockError::IndirectInjectionBlocked(_)
-            );
-            let risk =
-                crate::security::risk::assess_risk(&crate::security::risk::SecurityOutcome {
-                    dlp_rules_triggered: 1,
-                    was_blocked: true,
-                    had_injection,
-                    had_pii: false,
-                });
-
-            let compliance = &ctx.inner.config.compliance;
-            if should_escalate_compliance(compliance.enabled, compliance.risk_classification) {
-                let threshold = crate::security::audit_log::RiskLevel::from_str_threshold(
-                    &compliance.escalation_threshold,
-                );
-                crate::security::risk::maybe_escalate(&crate::security::risk::EscalationEvent {
-                    risk,
-                    threshold,
-                    webhook_url: &compliance.escalation_webhook,
-                    event_id: ctx.req_id,
-                    tenant_id: ctx.tenant_id.as_deref().unwrap_or("anon"),
-                    model: &ctx.model,
-                });
-            }
-
-            ctx.log_audit_if_enabled(AuditEntry {
-                action: crate::security::audit_log::AuditEvent::DlpBlock,
-                backend: "BLOCKED",
-                dlp_rules: vec![block_err.to_string()],
-                duration_ms: ctx.start_time.elapsed().as_millis() as u64,
-                model_name: Some(&ctx.model),
-                token_counts: None,
-                risk_level: Some(risk),
-                dlp_blocked: true,
-                dlp_had_injection: had_injection,
-                dlp_had_pii: false,
-                dlp_had_redact_or_warn: false,
-            });
-            Err(RequestError::DlpBlocked(format!("{}", block_err)))
-        }
-    }
-}
-
-/// Runs the per-session tool-call spike anomaly detector (T-AD1).
-///
-/// Counts the `tool_use` and `tool_result` content blocks in the
-/// incoming request and feeds them into a 60-second rolling window
-/// keyed by session id (falling back to user id, then tenant id).
-/// Crossing the warn threshold logs and emits a metric; crossing the
-/// block threshold writes an audit entry and returns
-/// [`RequestError::ToolSpikeBlocked`] (HTTP 429).
-///
-/// Returns `Ok(())` when the detector is disabled or the request is
-/// below all thresholds.
-///
-/// # Errors
-///
-/// Returns [`RequestError::ToolSpikeBlocked`] when the rolling-window
-/// tool-call total for the resolved session key reaches the configured
-/// block threshold.
-fn check_tool_spike(
-    ctx: &DispatchContext<'_>,
-    request: &CanonicalRequest,
-) -> Result<(), RequestError> {
-    use crate::security::tool_spike::{count_tool_blocks, resolve_key};
-    use crate::security::SpikeAction;
-
-    let Some(detector) = ctx.state.security.tool_spike_detector.as_ref() else {
-        return Ok(());
-    };
-
-    let count = count_tool_blocks(request);
-    let key = resolve_key(request, ctx.tenant_id.as_deref());
-
-    match detector.observe(&key, count) {
-        SpikeAction::Allow => Ok(()),
-        SpikeAction::Warn => {
-            // NOTE: session keys are unbounded, so they stay in the
-            // structured log (high cardinality) rather than a metric label.
-            metrics::counter!("grob_tool_spike_warn_total").increment(1);
-            tracing::warn!(
-                session = %key,
-                rolling_total = detector.current_total(&key),
-                threshold = detector.config().warn_per_min,
-                "tool_spike: warn threshold crossed"
-            );
-            Ok(())
-        }
-        SpikeAction::Block => {
-            metrics::counter!("grob_tool_spike_blocked_total").increment(1);
-            let total = detector.current_total(&key);
-            let block_threshold = detector.config().block_per_min;
-            tracing::warn!(
-                session = %key,
-                rolling_total = total,
-                threshold = block_threshold,
-                "tool_spike: block threshold crossed, returning 429"
-            );
-
-            ctx.log_audit_if_enabled(AuditEntry {
-                action: crate::security::audit_log::AuditEvent::ToolSpikeBlocked,
-                backend: "BLOCKED",
-                dlp_rules: vec![format!(
-                    "tool_spike: {} tool calls in 60s window (threshold {})",
-                    total, block_threshold
-                )],
-                duration_ms: ctx.start_time.elapsed().as_millis() as u64,
-                model_name: Some(&ctx.model),
-                token_counts: None,
-                risk_level: Some(crate::security::audit_log::RiskLevel::High),
-                dlp_blocked: true,
-                dlp_had_injection: false,
-                dlp_had_pii: false,
-                dlp_had_redact_or_warn: false,
-            });
-
-            Err(RequestError::ToolSpikeBlocked(format!(
-                "tool-call spike anomaly: {} tool calls observed in 60s window for session {} (block threshold {})",
-                total, key, block_threshold
-            )))
-        }
-    }
-}
-
 /// Handle fan-out strategy (dispatch to multiple providers in parallel).
 async fn dispatch_fan_out(
     ctx: &DispatchContext<'_>,
@@ -1125,6 +815,10 @@ async fn record_fan_out_costs(
 
 #[cfg(test)]
 mod tests {
+    use super::preflight::{
+        dlp_input_scan_disabled, dlp_reports_triggered, redaction_audit_rules, reports_have_pii,
+        should_escalate_compliance, warn_stripped_tools,
+    };
     use super::*;
     use tracing_test::traced_test;
 

--- a/src/server/dispatch/preflight.rs
+++ b/src/server/dispatch/preflight.rs
@@ -1,0 +1,256 @@
+//! Request security and tool preflight stages that run before routing.
+
+use super::{AuditEntry, DispatchContext};
+use crate::features::watch::events::{DlpDirection, WatchEvent};
+use crate::models::CanonicalRequest;
+use crate::server::RequestError;
+
+/// Runs the security and tool stages that must complete before routing.
+///
+/// Returns whether DLP acted on the request so post-route policy matching can
+/// include the `dlp_triggered` signal.
+pub(super) fn run(
+    ctx: &DispatchContext<'_>,
+    request: &mut CanonicalRequest,
+) -> Result<bool, RequestError> {
+    let dlp_triggered = scan_dlp_input(ctx, request)?;
+
+    // Never forward a verbatim Responses body after mutating the canonical
+    // request, otherwise the original unredacted bytes could bypass DLP.
+    if dlp_triggered {
+        request.extensions.responses_passthrough_body = None;
+    }
+
+    check_tool_spike(ctx, request)?;
+
+    #[cfg(feature = "mcp")]
+    if let Some(ref mcp) = ctx.state.security.mcp {
+        crate::features::mcp::calibration::calibrate_tools(mcp, request);
+    }
+
+    match crate::features::tool_validation::validate_inbound_tools(
+        request,
+        &ctx.inner.config.tool_validation,
+    ) {
+        Ok(stripped) => warn_stripped_tools(&stripped),
+        Err(reason) => return Err(RequestError::BadRequest(reason)),
+    }
+
+    if ctx.inner.config.pledge.enabled {
+        let filter = crate::features::pledge::PledgeFilter::new(&ctx.inner.config.pledge);
+        let token = ctx
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .or_else(|| ctx.headers.get("x-api-key").and_then(|v| v.to_str().ok()));
+        filter.apply(request, ctx.tenant_id.as_deref(), token);
+    }
+
+    Ok(dlp_triggered)
+}
+
+#[inline]
+pub(super) fn dlp_input_scan_disabled(scan_input: bool) -> bool {
+    !scan_input
+}
+
+#[inline]
+pub(super) fn should_escalate_compliance(enabled: bool, risk_classification: bool) -> bool {
+    enabled && risk_classification
+}
+
+#[inline]
+pub(super) fn dlp_reports_triggered<T>(reports: &[T]) -> bool {
+    !reports.is_empty()
+}
+
+#[inline]
+pub(super) fn redaction_audit_rules(
+    reports: &[crate::features::dlp::DlpActionReport],
+) -> Vec<String> {
+    reports
+        .iter()
+        .map(|r| format!("{}: {}", r.rule_type, r.detail))
+        .collect()
+}
+
+#[inline]
+pub(super) fn reports_have_pii(reports: &[crate::features::dlp::DlpActionReport]) -> bool {
+    reports
+        .iter()
+        .any(|r| matches!(r.rule_type, crate::features::dlp::DlpRuleType::Pii))
+}
+
+#[inline]
+pub(super) fn warn_stripped_tools(stripped: &[String]) {
+    if !stripped.is_empty() {
+        tracing::warn!(
+            tools = ?stripped,
+            "tool validation: stripped malformed inbound tools"
+        );
+    }
+}
+
+fn scan_dlp_input(
+    ctx: &DispatchContext<'_>,
+    request: &mut CanonicalRequest,
+) -> Result<bool, RequestError> {
+    let Some(ref dlp_engine) = ctx.dlp else {
+        return Ok(false);
+    };
+    if dlp_input_scan_disabled(dlp_engine.config.scan_input) {
+        return Ok(false);
+    }
+
+    match dlp_engine.sanitize_request_checked(request) {
+        Ok(reports) => {
+            let triggered = dlp_reports_triggered(&reports);
+            ctx.emit_dlp_events(&reports, DlpDirection::Request);
+            if triggered {
+                ctx.log_audit_if_enabled(AuditEntry {
+                    action: crate::security::audit_log::AuditEvent::DlpWarn,
+                    backend: "REDACTED",
+                    dlp_rules: redaction_audit_rules(&reports),
+                    duration_ms: ctx.start_time.elapsed().as_millis() as u64,
+                    model_name: Some(&ctx.model),
+                    token_counts: None,
+                    risk_level: Some(crate::security::audit_log::RiskLevel::Medium),
+                    dlp_blocked: false,
+                    dlp_had_injection: false,
+                    dlp_had_pii: reports_have_pii(&reports),
+                    dlp_had_redact_or_warn: true,
+                });
+            }
+            Ok(triggered)
+        }
+        Err(block_err) => {
+            let (block_rule_type, block_detail) = match &block_err {
+                crate::features::dlp::DlpBlockError::InjectionBlocked(dets) => {
+                    ("injection", format!("{} injection(s) detected", dets.len()))
+                }
+                crate::features::dlp::DlpBlockError::UrlExfilBlocked(dets) => (
+                    "url_exfil",
+                    format!("{} exfiltration URL(s) detected", dets.len()),
+                ),
+                crate::features::dlp::DlpBlockError::IndirectInjectionBlocked(dets) => (
+                    "indirect_injection",
+                    format!("{} indirect injection(s) detected", dets.len()),
+                ),
+            };
+            ctx.state.event_bus.emit(WatchEvent::DlpAction {
+                request_id: ctx.req_id.to_string(),
+                direction: DlpDirection::Request,
+                action: "block".into(),
+                rule_type: block_rule_type.into(),
+                detail: block_detail,
+                timestamp: chrono::Utc::now(),
+            });
+
+            let had_injection = matches!(
+                &block_err,
+                crate::features::dlp::DlpBlockError::InjectionBlocked(_)
+                    | crate::features::dlp::DlpBlockError::IndirectInjectionBlocked(_)
+            );
+            let risk =
+                crate::security::risk::assess_risk(&crate::security::risk::SecurityOutcome {
+                    dlp_rules_triggered: 1,
+                    was_blocked: true,
+                    had_injection,
+                    had_pii: false,
+                });
+
+            let compliance = &ctx.inner.config.compliance;
+            if should_escalate_compliance(compliance.enabled, compliance.risk_classification) {
+                let threshold = crate::security::audit_log::RiskLevel::from_str_threshold(
+                    &compliance.escalation_threshold,
+                );
+                crate::security::risk::maybe_escalate(&crate::security::risk::EscalationEvent {
+                    risk,
+                    threshold,
+                    webhook_url: &compliance.escalation_webhook,
+                    event_id: ctx.req_id,
+                    tenant_id: ctx.tenant_id.as_deref().unwrap_or("anon"),
+                    model: &ctx.model,
+                });
+            }
+
+            ctx.log_audit_if_enabled(AuditEntry {
+                action: crate::security::audit_log::AuditEvent::DlpBlock,
+                backend: "BLOCKED",
+                dlp_rules: vec![block_err.to_string()],
+                duration_ms: ctx.start_time.elapsed().as_millis() as u64,
+                model_name: Some(&ctx.model),
+                token_counts: None,
+                risk_level: Some(risk),
+                dlp_blocked: true,
+                dlp_had_injection: had_injection,
+                dlp_had_pii: false,
+                dlp_had_redact_or_warn: false,
+            });
+            Err(RequestError::DlpBlocked(block_err.to_string()))
+        }
+    }
+}
+
+fn check_tool_spike(
+    ctx: &DispatchContext<'_>,
+    request: &CanonicalRequest,
+) -> Result<(), RequestError> {
+    use crate::security::tool_spike::{count_tool_blocks, resolve_key};
+    use crate::security::SpikeAction;
+
+    let Some(detector) = ctx.state.security.tool_spike_detector.as_ref() else {
+        return Ok(());
+    };
+
+    let count = count_tool_blocks(request);
+    let key = resolve_key(request, ctx.tenant_id.as_deref());
+
+    match detector.observe(&key, count) {
+        SpikeAction::Allow => Ok(()),
+        SpikeAction::Warn => {
+            metrics::counter!("grob_tool_spike_warn_total").increment(1);
+            tracing::warn!(
+                session = %key,
+                rolling_total = detector.current_total(&key),
+                threshold = detector.config().warn_per_min,
+                "tool_spike: warn threshold crossed"
+            );
+            Ok(())
+        }
+        SpikeAction::Block => {
+            metrics::counter!("grob_tool_spike_blocked_total").increment(1);
+            let total = detector.current_total(&key);
+            let block_threshold = detector.config().block_per_min;
+            tracing::warn!(
+                session = %key,
+                rolling_total = total,
+                threshold = block_threshold,
+                "tool_spike: block threshold crossed, returning 429"
+            );
+
+            ctx.log_audit_if_enabled(AuditEntry {
+                action: crate::security::audit_log::AuditEvent::ToolSpikeBlocked,
+                backend: "BLOCKED",
+                dlp_rules: vec![format!(
+                    "tool_spike: {} tool calls in 60s window (threshold {})",
+                    total, block_threshold
+                )],
+                duration_ms: ctx.start_time.elapsed().as_millis() as u64,
+                model_name: Some(&ctx.model),
+                token_counts: None,
+                risk_level: Some(crate::security::audit_log::RiskLevel::High),
+                dlp_blocked: true,
+                dlp_had_injection: false,
+                dlp_had_pii: false,
+                dlp_had_redact_or_warn: false,
+            });
+
+            Err(RequestError::ToolSpikeBlocked(format!(
+                "tool-call spike anomaly: {} tool calls observed in 60s window for session {} (block threshold {})",
+                total, key, block_threshold
+            )))
+        }
+    }
+}

--- a/src/server/dispatch/resolver.rs
+++ b/src/server/dispatch/resolver.rs
@@ -11,85 +11,60 @@ use std::sync::Arc;
 use super::super::{is_auth_revoked_error, RequestError};
 use super::retry::{capture_upstream_error, is_upstream_rate_limit};
 use super::{DispatchContext, DispatchResult};
+use crate::providers::registry::DispatchRejection;
 use tracing::info;
 
 /// Returns the provider for a mapping, or `None` if it must be skipped.
 ///
-/// Checks, in order:
-///
-/// 1. Provider exists in the registry.
-/// 2. `SecurityConfig::provider_scorer` (wraps `CircuitBreakerRegistry`) —
-///    if a scorer is enabled, it owns availability decisions.
-/// 3. Bare `CircuitBreakerRegistry` — used when no scorer is configured.
-/// 4. Routing-layer passive CB (RE-1a, ADR-0018) — per-endpoint, orthogonal
-///    to the global per-provider CB above.
-///
-/// Each rejection path emits a `grob_circuit_breaker_rejected_total` (or
-/// `grob_routing_endpoint_cb_rejected_total`) counter for observability.
+/// The registry owns composition of provider-level availability and
+/// endpoint-level health. This resolver only translates the decision into
+/// dispatch logs and rejection metrics.
 pub(super) async fn resolve_provider(
     ctx: &DispatchContext<'_>,
     mapping: &crate::cli::ModelMapping,
 ) -> Option<Arc<dyn crate::providers::LlmProvider>> {
-    let provider = ctx
+    let result = ctx
         .inner
         .provider_registry
-        .provider(&mapping.provider)
-        .or_else(|| {
+        .provider_for_dispatch(
+            &mapping.provider,
+            &mapping.actual_model,
+            ctx.state.security.provider_availability.as_deref(),
+        )
+        .await;
+
+    match result {
+        Ok(provider) => Some(provider),
+        Err(DispatchRejection::ProviderNotRegistered) => {
             info!(
                 "Provider {} not found in registry, trying next fallback",
                 mapping.provider
             );
             None
-        })?;
-
-    // Check availability: scorer (which wraps CB) takes priority over bare CB
-    if let Some(ref scorer) = ctx.state.security.provider_scorer {
-        if !scorer.can_execute(&mapping.provider).await {
+        }
+        Err(DispatchRejection::ProviderUnavailable) => {
+            info!("Provider {} unavailable, skipping", mapping.provider);
+            metrics::counter!(
+                "grob_circuit_breaker_rejected_total",
+                "provider" => mapping.provider.clone()
+            )
+            .increment(1);
+            None
+        }
+        Err(DispatchRejection::EndpointUnavailable) => {
             info!(
-                "Provider {} unavailable (scorer/CB), skipping",
-                mapping.provider
+                "Endpoint {}/{} unavailable, skipping",
+                mapping.provider, mapping.actual_model
             );
             metrics::counter!(
-                "grob_circuit_breaker_rejected_total",
-                "provider" => mapping.provider.clone()
+                "grob_routing_endpoint_cb_rejected_total",
+                "provider" => mapping.provider.clone(),
+                "model" => mapping.actual_model.clone(),
             )
             .increment(1);
-            return None;
-        }
-    } else if let Some(ref cb) = ctx.state.security.circuit_breakers {
-        if !cb.can_execute(&mapping.provider).await {
-            info!("Circuit breaker open for {}, skipping", mapping.provider);
-            metrics::counter!(
-                "grob_circuit_breaker_rejected_total",
-                "provider" => mapping.provider.clone()
-            )
-            .increment(1);
-            return None;
+            None
         }
     }
-
-    // Routing-layer passive CB (RE-1a, ADR-0018). Per-endpoint, orthogonal
-    // to the global per-provider security CB above — an endpoint can be
-    // down while the provider still has other endpoints up.
-    if !ctx
-        .inner
-        .provider_registry
-        .is_endpoint_healthy(&mapping.provider, &mapping.actual_model)
-    {
-        info!(
-            "Endpoint {}/{} tripped by passive CB, skipping",
-            mapping.provider, mapping.actual_model
-        );
-        metrics::counter!(
-            "grob_routing_endpoint_cb_rejected_total",
-            "provider" => mapping.provider.clone(),
-            "model" => mapping.actual_model.clone(),
-        )
-        .increment(1);
-        return None;
-    }
-
-    Some(provider)
 }
 
 /// Backward-compat fallback: try direct model -> provider lookup from the registry.
@@ -104,7 +79,14 @@ pub(super) async fn try_direct_provider_lookup(
     model_name: &str,
     context_guard: Option<crate::server::ContextGuardInfo>,
 ) -> Result<Option<DispatchResult>, RequestError> {
-    let Ok(provider) = ctx.inner.provider_registry.provider_for_model(model_name) else {
+    let Ok((provider_name, _)) = ctx
+        .inner
+        .provider_registry
+        .provider_and_name_for_model(model_name)
+    else {
+        return Ok(None);
+    };
+    let Some(provider) = resolve_provider_name(ctx, &provider_name, model_name).await else {
         return Ok(None);
     };
     info!(
@@ -135,4 +117,18 @@ pub(super) async fn try_direct_provider_lookup(
         provider_duration_ms: 0,
         context_guard,
     }))
+}
+
+async fn resolve_provider_name(
+    ctx: &DispatchContext<'_>,
+    provider: &str,
+    model: &str,
+) -> Option<Arc<dyn crate::providers::LlmProvider>> {
+    let mapping = crate::cli::ModelMapping {
+        provider: provider.to_string(),
+        actual_model: model.to_string(),
+        priority: 0,
+        inject_continuation_prompt: false,
+    };
+    resolve_provider(ctx, &mapping).await
 }

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -72,8 +72,8 @@ pub(super) async fn readiness_check(State(state): State<Arc<AppState>>) -> Respo
     }
 
     // Check if all circuit breakers are open (all providers degraded)
-    if let Some(ref cb) = state.security.circuit_breakers {
-        let states = cb.all_states().await;
+    if let Some(ref availability) = state.security.provider_availability {
+        let states = availability.all_states().await;
         if !states.is_empty() {
             let all_open = states
                 .values()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -162,8 +162,11 @@ pub struct SecurityState {
     pub rate_limiter: Option<Arc<RateLimiter>>,
     /// DLP session manager for secret scanning and PII redaction.
     pub dlp_sessions: Option<Arc<DlpSessionManager>>,
-    /// Circuit breakers tracking provider availability.
-    pub circuit_breakers: Option<Arc<dyn traits::ProviderAvailability>>,
+    /// Sole provider-level availability authority used by dispatch.
+    ///
+    /// This is the adaptive scorer when enabled (it forwards outcomes to the
+    /// provider circuit breaker), otherwise the bare provider circuit breaker.
+    pub provider_availability: Option<Arc<dyn traits::ProviderAvailability>>,
     /// Append-only audit log for compliance recording.
     pub audit_log: Option<Arc<AuditLog>>,
     /// LRU response cache for deterministic requests.
@@ -331,7 +334,7 @@ pub(crate) fn test_app_state_with_source(
             jwt_validator: None,
             rate_limiter: None,
             dlp_sessions: None,
-            circuit_breakers: None,
+            provider_availability: None,
             audit_log: None,
             response_cache: None,
             tap_sender: None,
@@ -402,8 +405,10 @@ pub async fn start_server(
     // Coerce concrete types to trait objects for testability
     let tracer: Arc<dyn traits::Tracer> = message_tracer;
     let tracker: Box<dyn traits::SpendTracking> = Box::new(spend_tracker);
-    let availability: Option<Arc<dyn traits::ProviderAvailability>> =
-        circuit_breakers.map(|cb| cb as Arc<dyn traits::ProviderAvailability>);
+    let provider_availability: Option<Arc<dyn traits::ProviderAvailability>> = provider_scorer
+        .clone()
+        .map(|scorer| scorer as Arc<dyn traits::ProviderAvailability>)
+        .or_else(|| circuit_breakers.map(|cb| cb as Arc<dyn traits::ProviderAvailability>));
 
     let log_exporter = crate::features::log_export::init_log_exporter(&config.log_export);
 
@@ -462,7 +467,7 @@ pub async fn start_server(
             jwt_validator,
             rate_limiter,
             dlp_sessions,
-            circuit_breakers: availability,
+            provider_availability,
             audit_log,
             response_cache,
             tap_sender,

--- a/src/server/responses_compat/transform.rs
+++ b/src/server/responses_compat/transform.rs
@@ -17,19 +17,61 @@ fn internal_metadata(
     })
 }
 
-/// Extracts text from [`InputContent`].
-fn extract_input_text(content: &InputContent) -> String {
+/// Converts Responses message content without discarding non-text parts.
+fn convert_input_content(content: &InputContent) -> Result<MessageContent, String> {
     match content {
-        InputContent::Text(s) => s.clone(),
-        InputContent::Parts(parts) => parts
-            .iter()
-            .map(|p| match p {
-                InputContentPart::InputText { text } => text.as_str(),
-                InputContentPart::OutputText { text } => text.as_str(),
-                InputContentPart::Other => "",
+        InputContent::Text(s) => Ok(MessageContent::Text(s.clone())),
+        InputContent::Parts(parts) => {
+            let mut blocks = Vec::with_capacity(parts.len());
+            for part in parts {
+                blocks.push(match part {
+                    InputContentPart::InputText { text }
+                    | InputContentPart::OutputText { text } => {
+                        ContentBlock::text(text.clone(), None)
+                    }
+                    InputContentPart::InputImage { image_url } => {
+                        let source = match image_url.split_once(',') {
+                            Some((header, data)) if header.starts_with("data:") => {
+                                crate::models::ImageSource {
+                                    r#type: "base64".to_string(),
+                                    media_type: header
+                                        .strip_prefix("data:")
+                                        .and_then(|value| value.split(';').next())
+                                        .map(str::to_string),
+                                    data: Some(data.to_string()),
+                                    url: None,
+                                }
+                            }
+                            _ => crate::models::ImageSource {
+                                r#type: "url".to_string(),
+                                media_type: None,
+                                data: None,
+                                url: Some(image_url.clone()),
+                            },
+                        };
+                        ContentBlock::image(source)
+                    }
+                    InputContentPart::Other => {
+                        return Err("unsupported Responses message content part".to_string());
+                    }
+                });
+            }
+            Ok(MessageContent::Blocks(blocks))
+        }
+    }
+}
+
+fn extract_system_text(content: &InputContent) -> Result<String, String> {
+    match convert_input_content(content)? {
+        MessageContent::Text(text) => Ok(text),
+        MessageContent::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| match block {
+                ContentBlock::Known(KnownContentBlock::Text { text, .. }) => Ok(text),
+                _ => Err("Responses system messages cannot contain images".to_string()),
             })
-            .collect::<Vec<_>>()
-            .join("\n"),
+            .collect::<Result<Vec<_>, _>>()
+            .map(|parts| parts.join("\n")),
     }
 }
 
@@ -130,6 +172,13 @@ fn merge_tool_result_into_user(
 /// Returns a `String` description if the input items contain
 /// an unrecognised variant that cannot be mapped to the canonical format.
 pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<CanonicalRequest, String> {
+    if req.previous_response_id.is_some() {
+        return Err(
+            "previous_response_id cannot be converted to canonical history; send full input history"
+                .to_string(),
+        );
+    }
+
     let mut messages: Vec<Message> = Vec::new();
     let mut system_prompt: Option<SystemPrompt> = None;
 
@@ -151,7 +200,7 @@ pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<Canonic
                     InputItem::Message { role, content } => {
                         if role == "system" {
                             // Merge into system prompt
-                            let text = extract_input_text(content);
+                            let text = extract_system_text(content)?;
                             system_prompt = Some(match system_prompt.take() {
                                 Some(SystemPrompt::Text(existing)) => {
                                     SystemPrompt::Text(format!("{}\n{}", existing, text))
@@ -161,7 +210,7 @@ pub fn transform_responses_to_canonical(req: ResponsesRequest) -> Result<Canonic
                         } else {
                             messages.push(Message {
                                 role: role.clone(),
-                                content: MessageContent::Text(extract_input_text(content)),
+                                content: convert_input_content(content)?,
                             });
                         }
                     }
@@ -466,6 +515,42 @@ mod tests {
         assert_eq!(converted[0].name.as_deref(), Some("get_weather"));
         assert_eq!(converted[0].description.as_deref(), Some("Gets weather"));
         assert!(converted[0].input_schema.is_some());
+    }
+
+    #[test]
+    fn previous_response_id_is_rejected_instead_of_losing_history() {
+        let req: ResponsesRequest = serde_json::from_value(serde_json::json!({
+            "model": "gpt-5.3-codex",
+            "input": "continue",
+            "previous_response_id": "resp_previous"
+        }))
+        .unwrap();
+
+        let error = transform_responses_to_canonical(req).unwrap_err();
+        assert!(error.contains("cannot be converted to canonical history"));
+    }
+
+    #[test]
+    fn input_image_becomes_a_canonical_image_block() {
+        let req: ResponsesRequest = serde_json::from_value(serde_json::json!({
+            "model": "gpt-5.3-codex",
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_image", "image_url": "https://example.com/a.png"}]
+            }]
+        }))
+        .unwrap();
+
+        let canonical = transform_responses_to_canonical(req).unwrap();
+        let MessageContent::Blocks(blocks) = &canonical.messages[0].content else {
+            panic!("image content was flattened to text");
+        };
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::Known(KnownContentBlock::Image { source })
+                if source.url.as_deref() == Some("https://example.com/a.png")
+        ));
     }
 
     #[test]

--- a/src/server/responses_compat/types.rs
+++ b/src/server/responses_compat/types.rs
@@ -36,8 +36,8 @@ pub struct ResponsesRequest {
     #[serde(default)]
     pub metadata: Option<HashMap<String, Value>>,
 
-    // ── Ignored gracefully (accepted but not processed) ──
-    /// Reference to a previous response for multi-turn (ignored by grob).
+    // ── Compatibility fields ──
+    /// Reference to a previous response for server-side multi-turn history.
     #[serde(default)]
     pub previous_response_id: Option<String>,
     /// Whether to persist the response server-side (ignored by grob).
@@ -137,8 +137,13 @@ pub enum InputContentPart {
         /// The previously generated assistant text.
         text: String,
     },
-    /// Any other content part type (e.g. `input_image`) not modelled here.
-    /// Tolerated and skipped so multi-turn Codex payloads do not 422.
+    /// Image input, represented by either a URL or a base64 data URI.
+    #[serde(rename = "input_image")]
+    InputImage {
+        /// Image URL or data URI.
+        image_url: String,
+    },
+    /// Any other content part type not modelled here.
     #[serde(other)]
     Other,
 }

--- a/src/server/rpc/config_ns.rs
+++ b/src/server/rpc/config_ns.rs
@@ -5,7 +5,7 @@ use super::types::{rpc_err, Role, StatusResponse, ERR_INTERNAL};
 use crate::config::AppConfig;
 use crate::providers::ProviderRegistry;
 use crate::routing::classify::Router;
-use crate::server::config_guard::is_section_or_key_denied;
+use crate::server::config_guard::{ensure_config_reloadable, is_section_or_key_denied};
 use crate::server::{AppState, ReloadableState};
 use jsonrpsee::types::error::INVALID_PARAMS_CODE;
 use jsonrpsee::types::ErrorObjectOwned;
@@ -58,6 +58,8 @@ pub async fn set(
     // Clone the active config so a validation failure leaves the snapshot intact.
     let mut new_config = state.snapshot().config.clone();
     apply_runtime_update(&mut new_config, key, value)?;
+    ensure_config_reloadable(state, &new_config)
+        .map_err(|message| rpc_err(INVALID_PARAMS_CODE, message))?;
 
     // Rebuild the reloadable state from the mutated config and swap atomically.
     // Mirrors the pattern in `server_ns::reload_config` and
@@ -356,6 +358,25 @@ max_entry_bytes = 8192
         apply_runtime_update(&mut config, "cache.ttl_secs", &serde_json::json!(900))
             .expect("cache.ttl_secs update should succeed");
         assert_eq!(config.cache.ttl_secs, 900);
+    }
+
+    #[tokio::test]
+    async fn set_rejects_startup_only_cache_change() {
+        let state = crate::server::test_app_state(
+            fixture_config(),
+            crate::providers::ProviderRegistry::new(),
+        );
+        let admin = CallerIdentity {
+            role: Role::Admin,
+            ip: "127.0.0.1".into(),
+            tenant_id: String::new(),
+        };
+
+        let err = set(&state, &admin, "cache.ttl_secs", &serde_json::json!(900))
+            .await
+            .expect_err("cache instance is initialized only at startup");
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+        assert!(err.message().contains("[cache]"));
     }
 
     #[test]

--- a/src/server/rpc/server_ns.rs
+++ b/src/server/rpc/server_ns.rs
@@ -39,12 +39,10 @@ pub async fn status(
 
 /// Triggers an atomic configuration reload.
 ///
-/// Rejects only **structurally** invalid candidates (parse error,
-/// `AppConfig::validate()` failure, or provider-registry build failure) as a
-/// JSON-RPC error, leaving the in-flight `inner` snapshot untouched. A
-/// structurally-valid candidate is always swapped in — the reload is **not**
-/// gated on live provider health. The same contract the HTTP
-/// `/api/config/reload` endpoint enforces.
+/// Rejects invalid candidates and changes to startup-only config-derived
+/// subsystems as a JSON-RPC error, leaving the in-flight `inner` snapshot
+/// untouched. Accepted reloads are **not** gated on live provider health. The
+/// same contract the HTTP `/api/config/reload` endpoint enforces.
 pub async fn reload_config(
     state: &Arc<AppState>,
     caller: &CallerIdentity,
@@ -65,10 +63,8 @@ pub async fn reload_config(
         .await
         .map_err(|e| rpc_err(ERR_INTERNAL, format!("Failed to reload config: {e}")))?;
 
-    // Same shared guard as the HTTP reload path: a `/metrics` bearer-token change
-    // cannot be hot-applied (resolved once at startup), so reject it here too
-    // instead of silently keeping the old posture.
-    crate::server::config_guard::ensure_metrics_auth_reloadable(state, &new_config)
+    // Same shared fail-closed guard as the HTTP reload path.
+    crate::server::config_guard::ensure_config_reloadable(state, &new_config)
         .map_err(|msg| rpc_err(ERR_INTERNAL, msg))?;
 
     let new_router = Router::new(new_config.clone());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -273,8 +273,8 @@ pub trait ProviderAvailability: Send + Sync {
     /// Returns true if the provider is available for requests.
     async fn can_execute(&self, provider: &str) -> bool;
 
-    /// Records a successful request to the provider.
-    async fn record_success(&self, provider: &str);
+    /// Records a successful request to the provider, including observed latency.
+    async fn record_success(&self, provider: &str, latency_ms: u64);
 
     /// Records a failed request to the provider.
     async fn record_failure(&self, provider: &str);
@@ -337,7 +337,7 @@ pub mod mocks {
             true
         }
 
-        async fn record_success(&self, _provider: &str) {}
+        async fn record_success(&self, _provider: &str, _latency_ms: u64) {}
 
         async fn record_failure(&self, _provider: &str) {}
 


### PR DESCRIPTION
## Summary
- reject unsafe hot reloads of startup-derived configuration
- preserve Responses images and reject lossy previous-response history conversion
- restore streamed Anthropic tool IDs
- centralize dispatch availability decisions
- extract dispatch security preflight into a cohesive module

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check --all-features
- cargo check --no-default-features
- cargo nextest run --all-features (1727 passed)
- focused regression suites for reload, Responses compatibility, tool-ID streaming, and availability gating