### PR TITLE
docs(design): image/video DLP, content provenance, and agent control plane

### DIFF
--- a/docs/design/001-image-dlp-provenance.md
+++ b/docs/design/001-image-dlp-provenance.md
@@ -60,6 +60,14 @@ Ce qui cloche avec « je colle un QR dans le coin » :
   qui pointe vers un registre, pas la donnée elle-même (mettre le tenant en clair dans
   l'image, c'est créer une nouvelle fuite).
 
+Bonne nouvelle : ce découpage à couches est exactement ce que l'industrie a standardisé
+sous le nom **Durable Content Credentials** (Adobe / CAI). La spec C2PA 2.1 appelle
+watermark et fingerprint des **soft bindings**, et impose qu'ils soient produits par un
+algorithme de la [C2PA Soft Binding Algorithm List](https://github.com/c2pa-org/softbinding-algorithm-list).
+Le principe officiel est littéralement le nôtre : si une plateforme strippe le manifeste
+C2PA, on retrouve la provenance dans une base en ligne via le watermark ou l'empreinte.
+Donc on n'invente rien, on implémente un standard, ce qui règle aussi l'interop.
+
 Le bon découpage est en trois couches indépendantes qui dégradent gracieusement :
 
 | Couche | Support | Survit à | Casse sur | Rôle |
@@ -80,6 +88,46 @@ et ça évite de transformer le watermark en canal d'exfiltration.
 Une lib JS de lecture reste souhaitable : elle lit L1 (parse C2PA/XMP, pur JS), calcule L3
 (pHash en WASM ou Canvas) et appelle Grob pour résoudre le `trace_id`. La détection L2
 robuste est du traitement du signal → WASM, ou déportée sur l'endpoint serveur.
+
+## État de l'art (recherche, 2026-08)
+
+### Ce qui existe déjà en Rust, vérifié sur crates.io
+
+| Besoin | Crate | Verdict |
+|---|---|---|
+| L1 C2PA | `c2pa` 0.90.4, MIT/Apache-2.0, `rust_native_crypto` dispo (évite OpenSSL) | **À utiliser.** C'est l'implémentation de référence CAI. Features à trier finement : couper `default_http` (4 clients HTTP !), `openssl`, `fetch_remote_manifests` (SSRF), garder `rust_native_crypto`. |
+| L2 watermark | `trustmark` 0.2.2 (Adobe, MIT) | **Attention.** Tire `ort` (ONNX Runtime) + `ndarray` + `image` + modèles ONNX externes. Incompatible avec le binaire `FROM scratch` de 6 MB. → **sidecar**, pas dépendance directe. |
+| L3 fingerprint | `img_hash` 3.2.0 (pHash/dHash) | **À utiliser**, léger, pur Rust. |
+
+TrustMark (Adobe/Univ. Surrey, ICCV 2025, `arXiv:2311.18297`) est l'état de l'art ouvert :
+résolution arbitraire, qualité > 43 dB, implémentations Python/Rust/JS via ONNX.
+SynthID-Image (DeepMind, `arXiv:2510.09263`) est le pendant fermé, déployé à l'échelle
+d'internet, non utilisable ici.
+
+**Conséquence sur le design** : écrire notre propre DWT-DCT était une mauvaise idée.
+On garde une implémentation triviale en fallback pur-Rust si vraiment nécessaire, mais
+le chemin principal est TrustMark en sidecar via l'ABI `MediaMarker`. Le trait était donc
+la bonne abstraction : il absorbe le changement sans toucher au pipeline.
+
+À noter aussi `invisimark` (DWT-DCT-SIFT, QR invisible, testé survivant aux pipelines
+Instagram/Facebook) : c'est exactement la variante « QR mais invisible », qui confirme
+que le QR a du sens **encodé dans le domaine fréquentiel**, pas peint dans le coin.
+
+### Sur la prompt injection multimodale
+
+OWASP LLM01:2025 la liste explicitement (« Scenario #7: Multimodal Injection ») et écrit
+noir sur blanc que *les injections n'ont pas besoin d'être lisibles par un humain, du
+moment que le modèle les parse*. Le document conclut que les défenses multimodales
+spécifiques sont un domaine de recherche ouvert. Deux mitigations OWASP s'appliquent
+directement à notre design et sont déjà des primitives Grob :
+
+- « Segregate and identify external content » → marquer les images entrantes comme non
+  fiables, ce que `tool_layer` peut faire.
+- « Require human approval for high-risk actions » → `policies/hit` existe déjà.
+
+Autrement dit : on ne prétend pas détecter toutes les injections image. On fait de
+l'OCR→DLP (bon marché, attrape le cas naïf), on **marque la provenance** et on branche
+le HIT. C'est la posture honnête.
 
 ## Proposed Design
 
@@ -116,7 +164,8 @@ Sous-modules :
     peut brancher Vision ; sinon sidecar HTTP, jamais linké en dur dans le binaire scratch.
   - `phash.rs` — empreinte perceptuelle (L3), et matching contre une deny-list
     d'images connues (documents internes, slides confidentielles).
-- `mark/` — `c2pa.rs` (L1), `invisible.rs` (L2, DWT-DCT), `qr.rs` (L3-visible, opt-in).
+- `mark/` — `c2pa.rs` (L1, crate `c2pa`), `soft_binding.rs` (L2, client sidecar TrustMark
+  conforme à la C2PA Soft Binding Algorithm List), `qr.rs` (L3-visible, opt-in).
 - `registry.rs` — journal `~/.grob/media/YYYY-MM.jsonl` : `trace_id`, phash, verdict,
   tenant, model, ts. Même pattern que `spend/`.
 
@@ -247,6 +296,42 @@ identifié et durable**. Conséquences :
 - Aucune boucle de rappel : rien ne relie « cette image a fuité » à « quel agent l'a produite ».
   C'est précisément le `trace_id` de la partie 1 qui referme cette boucle.
 
+## Ce que dit le marché (recherche, 2026-08)
+
+Le terme « agent control plane » s'est stabilisé en 2025-2026 et converge, chez tous les
+acteurs (Microsoft Agent 365 / Entra Agent ID, Okta, Guild, Nagarro, Lyzr), sur la même
+thèse : **la gouvernance d'agents est un problème de plan d'identité, pas d'admin d'accès.**
+Les briques citées systématiquement :
+
+1. **Une identité dédiée par agent**, pas une clé API partagée ni l'identité de l'humain.
+2. **Credentials scopés** et éphémères.
+3. **Registre** d'agents, avec propriétaire et cycle de vie déclaré.
+4. **Piste d'audit attribuable** par action.
+5. **Révocation / décommissionnement** automatique quand l'agent échoue son évaluation.
+6. Alignement NIST AI RMF / EU AI Act.
+
+Deux points intéressants pour Grob :
+
+- Le problème n°1 identifié est l'**agent sprawl** : personne ne sait combien d'agents
+  tournent ni ce qu'ils touchent. Grob voit déjà *tout le trafic modèle*. Il est
+  structurellement le mieux placé pour tenir le registre, sans instrumenter les agents.
+- Les offres du marché sont des plans de contrôle *SaaS d'entreprise* (Entra, Okta).
+  Grob occupe un créneau différent : un plan de contrôle **local, self-hosted, 6 MB**,
+  qui donne 80 % du résultat sans annuaire d'entreprise. C'est un vrai différenciateur.
+
+Côté standard, MCP 2025-06-18 (`basic/authorization`) donne des fondations réutilisables
+telles quelles, et évite d'inventer un schéma maison :
+
+- OAuth 2.1 + PKCE obligatoire, Dynamic Client Registration (RFC 7591).
+- **Resource Indicators (RFC 8707)** : le token est lié à sa ressource cible.
+- **Protected Resource Metadata (RFC 9728)** + `WWW-Authenticate` sur 401.
+- **Interdiction du token passthrough**, explicitement pour éviter le *confused deputy*.
+
+Ce dernier point est directement une règle de conception pour Grob : un agent enfant ne
+doit **jamais** recevoir le token de son parent. Il reçoit un token dérivé, d'audience
+restreinte. Ça rejoint exactement la contrainte « les capacités décroissent
+monotonement » déjà posée, mais avec un mécanisme normé pour l'appliquer.
+
 ## Direction proposée
 
 **Un namespace `agent` + une identité qui traverse tout le pipeline.**
@@ -304,12 +389,25 @@ Points de conception qui comptent :
 
 ## Open Questions
 
-- L'OCR : sidecar local, ou API vision du provider déjà configuré (attention, on
-  enverrait alors l'image suspecte au provider, ce qui contredit l'objectif) ?
-- C2PA en Rust : implémentation externe acceptable au regard du budget binaire et de
-  `cargo-deny` ?
-- Le watermark L2 : implémentation maison (DWT-DCT ~300 lignes, contrôlée mais à valider
-  empiriquement) ou dépendance ?
-- Les agents deviennent-ils un produit Admin/Enterprise (cf. ADR-0028 open-core boundary)
-  ou restent-ils dans le cœur Apache ?
-- Faut-il un `agent_id` obligatoire à terme, avec un agent implicite par défaut ?
+**Tranchées par la recherche :**
+
+- ~~C2PA en Rust, acceptable ?~~ Oui : `c2pa` 0.90.4, MIT/Apache-2.0, avec
+  `rust_native_crypto` et sans les 4 clients HTTP par défaut. À valider sur `cargo-deny`
+  et sur le poids réel du binaire.
+- ~~Watermark maison ou dépendance ?~~ Ni l'un ni l'autre en direct : TrustMark en
+  **sidecar** (ONNX incompatible avec `FROM scratch`), derrière le trait `MediaMarker`.
+- ~~Faut-il inventer un schéma d'identité d'agent ?~~ Non : OAuth 2.1 + RFC 8707
+  (resource indicators) + RFC 9728, comme MCP 2025-06-18. Et interdiction stricte du
+  token passthrough parent → enfant.
+
+**Encore ouvertes :**
+
+- L'OCR : sidecar local, ou API vision du provider déjà configuré ? (Attention : envoyer
+  l'image suspecte au provider contredit l'objectif.)
+- Le sidecar devient-il un pattern assumé de Grob (media, OCR, ffmpeg) avec un protocole
+  unique, ou trois intégrations ad hoc ? Trancher tôt, ça structure tout le reste.
+- Les agents : produit Admin/Enterprise (cf. ADR-0028 open-core boundary) ou cœur Apache ?
+  Le marché monétise exactement cette couche, donc la question est commerciale.
+- `agent_id` obligatoire à terme, avec un agent implicite par défaut ?
+- Faut-il viser une conformité déclarée NIST AI RMF / EU AI Act, ou juste fournir les
+  primitives et laisser l'utilisateur mapper ?

--- a/docs/design/001-image-dlp-provenance.md
+++ b/docs/design/001-image-dlp-provenance.md
@@ -1,0 +1,315 @@
+# Design Doc: DLP images/vidéos, provenance (watermark + C2PA), et control plane d'agents
+
+**Author**: ludwig
+**Status**: Draft
+**Date**: 2026-08-04
+**Reviewers**: TBD
+
+## Context
+
+Le DLP de Grob (`src/features/dlp/`) est 100 % texte : Aho-Corasick + DFA sur les chunks SSE,
+scan des URLs et images Markdown (`url_exfil.rs`), canaries (`canary.rs`).
+Or le pipeline transporte déjà des images : `KnownContentBlock::Image { source: ImageSource }`
+(base64 ou URL) côté requête, et `KnownToolResultBlock::Image` côté résultats d'outils
+(screenshots d'agents navigateur, captures de terminal, PDF rendus).
+
+Deux angles morts :
+
+1. **Exfiltration par pixel.** Un screenshot d'IDE contient des clés API, un `.env`, du code
+   client, des visages, un écran de prod. Aujourd'hui il traverse Grob sans être regardé.
+   Symétriquement, une image *entrante* peut porter une prompt injection écrite en texte
+   dans l'image, invisible pour le scanner texte mais lue par le modèle vision.
+2. **Provenance.** Quand une image sort d'un agent (générée, ou capturée puis rediffusée),
+   rien ne dit d'où elle vient : quel tenant, quelle session, quel modèle, quelle policy.
+   Impossible de tracer une fuite a posteriori.
+
+Question posée : « une lib JS qui lit une sorte de QR code dans l'image/vidéo pour retrouver
+les infos stockées dedans, c'est une bonne idée ? »
+
+## Goals
+
+- Scanner le contenu image (in et out) avec la même sémantique que le DLP texte :
+  `Allow | Redact | Warn | Block`, mêmes rapports, mêmes events tap/watch.
+- Marquer toute image/vidéo qui transite par Grob avec une provenance vérifiable,
+  et pouvoir la relire côté client (lib JS) comme côté serveur (RPC).
+- Ne pas casser le budget latence du chemin chaud : le scan image doit être hors du
+  chemin bloquant par défaut (opt-in synchrone).
+- Rester dans les invariants Grob : feature flag, trait-driven, config TOML, zéro I/O
+  supplémentaire obligatoire.
+
+## Non-Goals
+
+- Faire de la reconnaissance de visages/objets généraliste. Hors périmètre : c'est un
+  produit de vision, pas un proxy.
+- Transcoder/ré-encoder de la vidéo dans le proxy. Grob n'est pas un pipeline média.
+- Prétendre à un DRM inviolable. Un watermark robuste est **dissuasif et traçant**,
+  pas cryptographiquement inarrachable.
+- Embarquer un moteur OCR lourd (Tesseract, ONNX) dans le binaire 6 MB par défaut.
+
+## Réponse directe : le QR code dans l'image, bonne idée ?
+
+**Comme brique unique : non. Comme couche visible optionnelle : oui.**
+
+Ce qui cloche avec « je colle un QR dans le coin » :
+
+- **Visible** → on le recadre en deux secondes, le premier crop tue la traçabilité.
+- **Fragile** → recompression JPEG agressive, resize, screenshot d'écran, capture de
+  capture : le QR se dégrade vite hors de ses tolérances.
+- **Coût pixel** → il mange de la surface utile, inacceptable sur un screenshot d'UI.
+- **Capacité mal placée** → un QR stocke des octets ; on veut un *identifiant opaque*
+  qui pointe vers un registre, pas la donnée elle-même (mettre le tenant en clair dans
+  l'image, c'est créer une nouvelle fuite).
+
+Le bon découpage est en trois couches indépendantes qui dégradent gracieusement :
+
+| Couche | Support | Survit à | Casse sur | Rôle |
+|---|---|---|---|---|
+| **L1 — Métadonnées signées** (C2PA / manifeste dans XMP/EXIF) | conteneur du fichier | copie, transfert, upload | screenshot, strip metadata, ré-encodage | provenance riche et vérifiable, cas nominal |
+| **L2 — Watermark invisible robuste** (spectre étalé / DCT-DWT, style Trustmark/SynthID) | pixels | recompression, resize, crop partiel, screenshot | crop massif, régénération, forte dégradation | identifiant opaque 64–128 bits, cas hostile |
+| **L3 — Empreinte perceptuelle** (pHash / dHash indexé côté serveur) | aucune modif de l'image | tout, y compris strip complet | transformation sémantique lourde | rattrapage « d'où vient cette image ? » sans rien avoir écrit dedans |
+
+Le QR devient une variante *L2-visible* : utile seulement quand on **veut** que ce soit
+visible (asset publié, marquage légal, démo), jamais comme mécanisme principal.
+
+Ce qui est écrit dans L1/L2 : **jamais** de données métier. Uniquement
+`trace_id` (128 bits aléatoires) + version de schéma. Le mapping
+`trace_id → {tenant, session, model, policy, timestamp}` vit dans le `GrobStore`
+(journal JSONL append-only, comme le spend). Cohérent avec le modèle de données existant
+et ça évite de transformer le watermark en canal d'exfiltration.
+
+Une lib JS de lecture reste souhaitable : elle lit L1 (parse C2PA/XMP, pur JS), calcule L3
+(pHash en WASM ou Canvas) et appelle Grob pour résoudre le `trace_id`. La détection L2
+robuste est du traitement du signal → WASM, ou déportée sur l'endpoint serveur.
+
+## Proposed Design
+
+### A. `src/features/media/` (feature flag `media`, off par défaut)
+
+Nouveau module frère de `dlp/`, avec le même style trait-driven :
+
+```rust
+pub trait MediaScanner {                       // → src/traits.rs
+    fn scan(&self, m: &MediaRef) -> MediaVerdict;
+}
+pub trait MediaMarker {
+    fn embed(&self, m: &mut MediaBuf, trace: TraceId) -> Result<(), MediaError>;
+    fn extract(&self, m: &MediaRef) -> Option<TraceId>;
+}
+```
+
+`MediaRef` s'obtient depuis `ImageSource` sans copie quand c'est du base64 inline ;
+les images par URL ne sont **pas** téléchargées par défaut (`fetch_remote = false`,
+sinon on offre un SSRF au client).
+
+Sous-modules :
+
+- `decode.rs` — sniff du format (magic bytes), bornes dures (`max_bytes`, `max_pixels`)
+  contre les décompression bombs, refus par défaut de tout format non listé.
+- `scan/` — les détecteurs, du moins cher au plus cher :
+  - `heuristics.rs` — taille, ratio, format, entropie, présence de métadonnées EXIF/GPS
+    (une image avec GPS qui part chez un provider, c'est déjà un signal).
+  - `stego.rs` — détection de payload caché grossier (LSB, tail-append après le marqueur
+    de fin), pas cher et directement anti-exfiltration.
+  - `text.rs` — OCR **optionnel**, derrière la feature `media-ocr`, qui réinjecte le texte
+    extrait dans le `DlpEngine` existant. C'est le point clé : zéro duplication de règles,
+    l'image devient juste une nouvelle source de texte pour le DFA déjà là. Sur macOS on
+    peut brancher Vision ; sinon sidecar HTTP, jamais linké en dur dans le binaire scratch.
+  - `phash.rs` — empreinte perceptuelle (L3), et matching contre une deny-list
+    d'images connues (documents internes, slides confidentielles).
+- `mark/` — `c2pa.rs` (L1), `invisible.rs` (L2, DWT-DCT), `qr.rs` (L3-visible, opt-in).
+- `registry.rs` — journal `~/.grob/media/YYYY-MM.jsonl` : `trace_id`, phash, verdict,
+  tenant, model, ts. Même pattern que `spend/`.
+
+### B. Point d'insertion dans le pipeline
+
+Dans `src/server/dispatch/mod.rs`, à côté des appels DLP existants
+(`sanitize_request_reported` / `sanitize_provider_response_reported`) :
+
+```
+request  → [DLP texte] → [Media scan in]  → tool_layer → cache → provider
+response → [DLP texte] → [Media scan out] → [Media mark] → client
+```
+
+Trois modes de scan, configurables :
+
+- `off` (défaut),
+- `async` — l'image part, le scan tourne en tâche détachée, alimente registry + tap/watch.
+  Coût zéro sur la latence, détection post-hoc. C'est le défaut recommandé.
+- `blocking` — verdict avant émission, avec `timeout_ms` et fail-open/fail-closed explicite.
+
+Le marquage sortant est lui toujours synchrone mais bon marché : L1 est une écriture de
+métadonnées ; L2 n'est appliqué que si `watermark = true` et que le média est décodable.
+
+### C. Surfaces d'exposition
+
+- **RPC** — nouveau namespace `media` dans `src/control/engine.rs` +
+  `src/server/rpc/media_ns.rs` : `media/verify` (image → trace_id + provenance),
+  `media/trace` (trace_id → contexte), `media/policy`. RBAC : `verify` = Observer,
+  `trace` = Operator (il révèle tenant/session).
+- **MCP** — bridge automatique via `control_bridge.rs`, un agent peut demander
+  « d'où vient cette image ? ».
+- **HTTP** — `POST /v1/media/verify` (multipart), le seul endpoint dont la lib JS a besoin.
+- **CLI** — `grob media verify <file>`, `grob media trace <id>`.
+- **Tap/watch** — nouveaux events `media.scanned`, `media.blocked`, `media.marked`.
+
+### D. La lib JS (`grob-media-verify`, package séparé)
+
+```js
+const r = await grobMedia.verify(fileOrBlob, { endpoint: "https://grob/v1/media/verify" });
+// { level: "c2pa" | "watermark" | "phash" | "none",
+//   traceId, verified: bool, provenance?: {...} }
+```
+
+Fait en local ce qui est local (parse C2PA, pHash), délègue le reste. Pas de secret
+côté client. Le résultat inclut *quelle couche* a répondu, ce qui rend la confiance
+lisible plutôt que binaire.
+
+### E. Vidéo
+
+Même architecture, mais on ne décode pas de vidéo dans le proxy. Découpage :
+L1 sur le conteneur (MP4 `uuid` box / Matroska tags), L3 sur des keyframes échantillonnées
+via un sidecar ffmpeg optionnel, L2 hors périmètre v1. Le tag doit être **par segment**,
+pas par fichier, sinon un simple découpage efface la provenance.
+
+## Alternatives Considered
+
+- **QR visible seul.** Simple, lisible partout, zéro dépendance signal. Rejeté comme
+  mécanisme principal : un crop suffit à l'annuler, et il pollue l'image. Conservé en L3-visible.
+- **EXIF/XMP seuls (sans C2PA).** Trivial à écrire. Rejeté : strip par n'importe quel
+  upload, non signé donc falsifiable. C2PA coûte plus cher mais apporte la signature.
+- **Watermark cryptographique fort / vrai DRM.** Chiffrement + client de confiance.
+  Rejeté : suppose de contrôler le lecteur, ce que Grob ne fait pas. On vise la traçabilité,
+  pas le contrôle d'usage.
+- **Déléguer tout le scan image à un service tiers.** Rejeté par défaut : envoyer les
+  screenshots à scanner à un tiers, c'est exactement la fuite qu'on veut empêcher.
+  Le sidecar reste local et optionnel.
+- **Tout mettre dans le DLP existant.** Rejeté : le DLP est un chemin chaud streaming,
+  strictement CPU-texte. Y greffer du décodage image dégraderait le p99 pour tout le monde.
+
+## Risks and Mitigations
+
+| Risque | Mitigation |
+|---|---|
+| Décompression bomb / DoS via image | bornes dures pré-décodage, timeout, mode `async` par défaut |
+| SSRF via `ImageSource::Url` | pas de fetch distant par défaut, allow-list si activé |
+| Faux positifs OCR→DLP bloquants | mode `async` par défaut, `blocking` explicite et opt-in |
+| Le watermark devient un canal d'exfil | seul un `trace_id` opaque est embarqué, jamais de donnée métier |
+| Poids binaire (6 MB, `FROM scratch`) | feature `media` off par défaut, OCR en sidecar, jamais linké |
+| Fausse confiance en la provenance | la réponse dit toujours *quelle couche* a matché et si elle est signée |
+
+## Plan de livraison
+
+1. **Slice 1 — squelette.** `src/features/media/`, feature flag, `MediaRef` depuis
+   `ImageSource`, decode + bornes, `phash.rs`, registry JSONL, events tap. Aucun blocage,
+   observation seule.
+2. **Slice 2 — verdicts.** heuristics + stego, wiring dispatch en mode `async`,
+   politique par policy (`src/features/policies/`), mode `blocking`.
+3. **Slice 3 — provenance.** C2PA (L1) + registry `trace_id`, RPC `media/*`,
+   endpoint HTTP, CLI.
+4. **Slice 4 — watermark.** L2 invisible + QR opt-in, lib JS, tests de robustesse
+   (recompression/resize/crop/screenshot) en harness.
+5. **Slice 5 — vidéo.** L1 conteneur + keyframes L3 via sidecar.
+
+Chaque slice = une ADR courte + un `README.md` de module, conforme au flow du repo.
+
+---
+
+# Partie 2 — Control plane d'agents
+
+## État actuel
+
+Grob a déjà l'ossature d'un control plane, mais **orienté proxy**, pas **orienté agent** :
+
+- `src/control/engine.rs` — catalogue d'actions `(role, action)` + RBAC 4 niveaux,
+  partagé CLI/RPC/MCP. Bonne fondation, stateless.
+- `src/server/rpc/` — 9 namespaces (`server`, `model`, `provider`, `budget`, `keys`,
+  `config`, `tools`, `hit`, `pledge`).
+- `src/features/pledge/` — retrait structurel d'outils avant dispatch. C'est déjà du
+  contrôle d'agent : la capacité n'existe pas, donc l'agent ne peut pas la tenter.
+- `src/features/policies/` — decision tokens, multisig, quorum, HIT (human-in-the-loop).
+- `src/features/tool_layer/` — aliasing, capability gating, injection d'outils.
+- `src/features/tap`, `watch` — événementiel et TUI temps réel.
+- `orca.yaml` — sandbox podman par workspace, egress limité à grob + GitHub.
+
+Autrement dit : les *primitives* (identité, capacités, budget, audit, HIT, isolation
+réseau) existent déjà. Ce qui manque est la **notion d'agent comme entité de première classe**.
+
+## Le gap
+
+Aujourd'hui une requête a un tenant, une policy, un budget. Elle n'a pas d'**agent
+identifié et durable**. Conséquences :
+
+- Pas de budget par agent, seulement global/provider/model.
+- Pas d'arbre de filiation : un subagent (`GROB-SUBAGENT-MODEL`) n'est pas rattaché à son
+  parent, donc pas de budget hérité ni de kill récursif.
+- Pas de cycle de vie : impossible de suspendre, reprendre, tuer un agent en cours.
+- L'audit est par requête, pas par trajectoire d'agent.
+- Aucune boucle de rappel : rien ne relie « cette image a fuité » à « quel agent l'a produite ».
+  C'est précisément le `trace_id` de la partie 1 qui referme cette boucle.
+
+## Direction proposée
+
+**Un namespace `agent` + une identité qui traverse tout le pipeline.**
+
+```rust
+pub struct AgentId(Ulid);
+pub struct AgentContext {
+    id: AgentId,
+    parent: Option<AgentId>,   // filiation subagent
+    tenant: TenantId,
+    pledge_profile: String,    // capacités, réutilise l'existant
+    budget: BudgetScope,       // hérité du parent, borné
+    lease: Lease,              // TTL + renouvellement, mort par défaut
+}
+```
+
+Points de conception qui comptent :
+
+- **L'identité est portée, pas devinée.** En-tête `x-grob-agent-id` (ou tag système,
+  comme `GROB-SUBAGENT-MODEL` aujourd'hui), propagée aux subagents. Sinon on retombe
+  sur de l'heuristique fragile.
+- **Le lease plutôt que le kill.** Un agent qui ne renouvelle pas son bail s'éteint tout
+  seul. Un agent orphelin ne peut pas brûler du budget indéfiniment. C'est le seul modèle
+  qui survit à un crash du superviseur.
+- **Budget hiérarchique.** Le budget d'un enfant est prélevé sur celui du parent. Un
+  subagent ne peut jamais dépasser son parent. Réutilise le journal spend, en ajoutant
+  la dimension `agent_id`.
+- **Capacités par filiation.** Un enfant hérite du profil pledge du parent et ne peut
+  que le restreindre, jamais l'élargir. Monotone, comme `Role::has_at_least`.
+- **Actions de contrôle** : `agent/spawn`, `agent/list`, `agent/inspect`, `agent/pause`,
+  `agent/resume`, `agent/kill` (récursif sur les descendants), `agent/budget`,
+  `agent/trace`. Exposées d'un coup en CLI + RPC + MCP via `ControlEngine`.
+- **Trajectoire auditée.** Un agent produit une trace ordonnée d'événements
+  (requêtes, outils, verdicts DLP, médias marqués). Journal JSONL, même pattern que le reste.
+- **HIT branché sur l'agent.** `policies/hit` existe déjà ; le point d'attache naturel
+  est l'agent, pas la requête isolée.
+
+## Ce que ça débloque
+
+- Kill switch réel : un agent qui déraille est coupé, descendance comprise.
+- Attribution du coût par agent, pas par clé API.
+- Post-mortem : d'une image marquée → `trace_id` → agent → trajectoire complète.
+- Sandbox alignée : `orca.yaml` isole déjà au niveau réseau ; `AgentId` donne le pendant
+  logique côté proxy.
+
+## Risques
+
+- **Scope creep vers l'orchestrateur.** Grob doit rester un *control plane*, pas un
+  runtime d'agents. Il n'exécute pas, il autorise, borne, observe et coupe.
+  Frontière à écrire noir sur blanc dans l'ADR.
+- **Identité usurpable.** `x-grob-agent-id` en clair est déclaratif. Il faut le lier à
+  la clé API / decision token (`policies/decision_token` existe déjà).
+- **État persistant.** Le control plane actuel est stateless ; les agents introduisent
+  du cycle de vie. À contenir dans `GrobStore`, sans base de données.
+
+## Open Questions
+
+- L'OCR : sidecar local, ou API vision du provider déjà configuré (attention, on
+  enverrait alors l'image suspecte au provider, ce qui contredit l'objectif) ?
+- C2PA en Rust : implémentation externe acceptable au regard du budget binaire et de
+  `cargo-deny` ?
+- Le watermark L2 : implémentation maison (DWT-DCT ~300 lignes, contrôlée mais à valider
+  empiriquement) ou dépendance ?
+- Les agents deviennent-ils un produit Admin/Enterprise (cf. ADR-0028 open-core boundary)
+  ou restent-ils dans le cœur Apache ?
+- Faut-il un `agent_id` obligatoire à terme, avec un agent implicite par défaut ?

--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -1,0 +1,363 @@
+# Plan d'exécution : media DLP/provenance + control plane d'agents
+
+> Compagnon opérationnel de [`001-image-dlp-provenance.md`](001-image-dlp-provenance.md).
+> Ce document ne rejustifie rien : il découpe le travail en PRs livrables, chacune
+> mergeable seule, avec fichiers, tests et critères d'acceptation.
+
+## Principes de découpage
+
+- **Une PR = une valeur observable.** Pas de PR « infrastructure seule » qui n'apporte
+  rien de vérifiable.
+- **Off par défaut jusqu'au bout.** `media` et `agents` restent hors du `default` de
+  `Cargo.toml` tant que la surface n'est pas stabilisée. Zéro impact sur le binaire
+  existant, zéro régression possible sur le chemin chaud.
+- **Observer avant de bloquer.** Toute capacité arrive d'abord en mode lecture seule
+  (journal + events), puis en mode verdict. On ne coupe jamais du trafic sur du code
+  qui n'a pas d'abord tourné à vide en production.
+- **Charte de slice à chaque nouveau module** (`README.md` + entrée dans
+  `docs/slices/MANIFEST.md`), conformément à la convention du repo.
+- Conventional commits, branche `feat/*`, auto-merge activé, une ADR quand une décision
+  est structurante.
+
+## Vue d'ensemble
+
+| # | PR | Feature flag | Bloque le trafic ? | ADR |
+|---|---|---|---|---|
+| 1 | Squelette `media` : décodage borné + pHash + journal | `media` | non | ADR-0030 |
+| 2 | Détecteurs bon marché (heuristiques, stégano) + wiring async | `media` | non | — |
+| 3 | Mode `blocking` + intégration policies | `media` | oui | — |
+| 4 | OCR → DLP via sidecar | `media-ocr` | via #3 | ADR-0031 (sidecar) |
+| 5 | Provenance L1 (C2PA) + registre `trace_id` | `media-c2pa` | non | ADR-0032 |
+| 6 | Surfaces : RPC `media/*`, HTTP verify, CLI | `media` | non | — |
+| 7 | Watermark L2 via sidecar TrustMark | `media` | non | — |
+| 8 | Lib JS `grob-media-verify` | — | non | — |
+| 9 | Vidéo : L1 conteneur + keyframes L3 | `media-video` | non | — |
+| A1 | `AgentId` + contexte propagé + attribution du spend | `agents` | non | ADR-0033 |
+| A2 | Registre d'agents + leases | `agents` | oui (expiration) | — |
+| A3 | Budget et capacités hiérarchiques | `agents` | oui | — |
+| A4 | Surfaces `agent/*` + trajectoire auditée | `agents` | non | — |
+| A5 | Jonction media ↔ agent (`trace_id` → agent) | les deux | non | — |
+
+Les deux pistes sont indépendantes jusqu'à A5. Elles peuvent avancer en parallèle.
+
+---
+
+## Piste média
+
+### PR 1 — Squelette `media` : décoder sans se faire tuer, empreinter, journaliser
+
+**Pourquoi en premier** : le décodage borné est la seule partie où une erreur est fatale
+(DoS). On la pose seule, on la teste à fond, et tout le reste s'appuie dessus.
+
+**Fichiers**
+
+```
+src/features/media/mod.rs          MediaRef, MediaBuf, MediaError, MediaConfig
+src/features/media/decode.rs       sniff magic bytes, bornes pré-décodage
+src/features/media/phash.rs        empreinte perceptuelle (img_hash)
+src/features/media/registry.rs     journal ~/.grob/media/YYYY-MM.jsonl
+src/features/media/README.md       charte de slice
+src/traits.rs                      + MediaScanner, MediaMarker
+Cargo.toml                         feature `media` (hors default), img_hash optionnel
+docs/slices/MANIFEST.md            + ligne media
+docs/decisions/0030-media-pipeline.md
+```
+
+**Points de conception à ne pas rater**
+
+- `MediaRef::from_image_source(&ImageSource)` emprunte sans copier pour le base64 inline.
+  Pour `type = "url"`, retourne `MediaRef::Remote` **sans fetch** : la décision de
+  télécharger n'appartient pas à cette couche.
+- Les bornes (`max_bytes`, `max_pixels`, `allowed_formats`) sont vérifiées **avant**
+  toute allocation de buffer de pixels. C'est tout l'intérêt : refuser un PNG de
+  10 px annonçant 50 000 × 50 000 sans jamais l'ouvrir.
+- Allow-list de formats, jamais de deny-list.
+
+**Tests** — `tests/unit/media_test.rs`
+
+- Une decompression bomb (petit fichier, dimensions énormes) est rejetée sans allocation.
+- Chaque format non listé est refusé, y compris avec une extension mensongère.
+- pHash stable sous ré-encodage JPEG q=70 et resize 50 %, distinct entre deux images
+  différentes. Ces seuils sont le contrat de L3, donc ils sont testés, pas supposés.
+- Le journal est append-only et relisible après troncature partielle (crash simulé).
+
+**Acceptation** : `cargo build` sans `--features media` produit un binaire d'octets
+identiques à `main`. Avec la feature, on peut empreinter une image et la retrouver dans
+le journal.
+
+---
+
+### PR 2 — Détecteurs bon marché + branchement asynchrone
+
+**Fichiers**
+
+```
+src/features/media/scan/mod.rs          MediaVerdict, orchestration
+src/features/media/scan/heuristics.rs   taille, ratio, entropie, EXIF/GPS
+src/features/media/scan/stego.rs        LSB, données après marqueur de fin
+src/server/dispatch/mod.rs              hook async, aucun await bloquant
+src/features/watch/events.rs            media.scanned
+src/features/tap/mod.rs                 idem
+```
+
+**Points de conception**
+
+- Le hook `async` détache une tâche et **ne renvoie rien au pipeline**. Aucun `.await`
+  ajouté sur le chemin de la requête. C'est vérifiable au type : la fonction retourne `()`.
+- Une image porteuse de GPS qui part vers un provider est un signal en soi, même sans
+  secret détecté. C'est le détecteur le moins cher et l'un des plus parlants.
+- La détection de stégano vise le cas grossier (LSB uniforme, appended payload). On ne
+  prétend pas battre un stéganographe motivé, et le README doit le dire.
+
+**Tests** — corpus d'images fixtures : propre, LSB modifié, payload appendu, EXIF GPS.
+Test de non-régression latence : p99 inchangé avec `mode = "async"` sur 1000 requêtes
+portant une image.
+
+**Acceptation** : `grob watch` montre les events `media.scanned` en direct pendant qu'un
+agent envoie des screenshots, sans une milliseconde de latence ajoutée.
+
+---
+
+### PR 3 — Mode bloquant + policies
+
+**Fichiers**
+
+```
+src/features/media/config.rs        mode = off|async|blocking, timeout_ms, on_timeout
+src/features/policies/resolved.rs   + override media par policy
+src/server/dispatch/mod.rs          chemin bloquant
+```
+
+**Points de conception**
+
+- `on_timeout = "allow" | "deny"` doit être **explicite dans la config**, sans défaut
+  implicite. C'est le genre de choix qu'on ne devine pas à la place de l'opérateur.
+- Le verdict réutilise la sémantique DLP (`Allow | Redact | Warn | Block`) pour que les
+  opérateurs n'aient pas deux modèles mentaux.
+- `Redact` sur une image signifie la remplacer par un placeholder, pas la flouter.
+  Le proxy n'édite pas de pixels.
+
+**Tests** : une image piégée est bloquée en `blocking`, passe en `async`, et le timeout
+respecte `on_timeout` dans les deux sens.
+
+---
+
+### PR 4 — OCR → DLP (sidecar, feature `media-ocr`)
+
+**Pourquoi c'est la PR la plus rentable** : elle transforme l'image en texte et rend
+*toutes* les règles DLP existantes applicables. Zéro duplication de règles.
+
+**Fichiers**
+
+```
+src/features/media/scan/text.rs      client sidecar + réinjection DlpEngine
+src/features/media/sidecar.rs        protocole sidecar générique (aussi utilisé PR 7 et 9)
+docs/decisions/0031-media-sidecar.md
+```
+
+**Points de conception**
+
+- Le sidecar est **un seul protocole** pour OCR, watermark et ffmpeg. C'est la question
+  ouverte du design doc, et la réponse est : un seul, tranché ici, sinon on aura trois
+  intégrations divergentes dans six mois.
+- Contrat : HTTP local, unix socket de préférence, timeout court, absence de sidecar =
+  capacité désactivée proprement (pas une erreur de démarrage).
+- Le texte OCR passe par le `DlpEngine` **existant**, sans nouvelle règle. Si le DLP
+  détecte une clé AWS dans un screenshot, c'est le même code que pour le texte.
+- Le résultat OCR n'est **jamais** journalisé en clair : seuls les identifiants de règles
+  déclenchées le sont. Sinon le journal devient la fuite.
+
+**Tests** : screenshot contenant une fausse clé AWS → règle DLP déclenchée ; sidecar
+absent → dégradation propre ; sidecar lent → timeout respecté.
+
+---
+
+### PR 5 — Provenance L1 (C2PA) + registre
+
+**Fichiers**
+
+```
+src/features/media/mark/mod.rs      MediaMarker
+src/features/media/mark/c2pa.rs     crate c2pa
+src/features/media/trace.rs         TraceId (128 bits CSPRNG)
+src/features/media/registry.rs      trace_id → contexte
+Cargo.toml                          feature media-c2pa
+docs/decisions/0032-content-provenance.md
+```
+
+**Points de conception**
+
+- Features du crate `c2pa` : `default-features = false`, `rust_native_crypto`, **sans**
+  `default_http` (il tire quatre clients HTTP), **sans** `fetch_remote_manifests` (SSRF).
+  À vérifier avec `cargo tree` et `cargo-deny` dans la PR même.
+- Le manifeste contient `trace_id` et rien d'autre d'identifiant. Pas de tenant, pas de
+  nom de modèle, pas de session. La tentation sera forte, il faut la refuser : tout ce
+  qu'on écrit dans l'image devient public.
+- Impact sur la taille du binaire mesuré et écrit dans la description de la PR.
+
+**Tests** : round-trip signer → lire ; manifeste strippé → `trace_id` toujours résolvable
+via pHash ; aucune donnée métier présente dans le fichier de sortie (test explicite qui
+cherche le nom du tenant dans les octets).
+
+---
+
+### PR 6 — Surfaces d'exposition
+
+**Fichiers**
+
+```
+src/control/engine.rs               + Action::Media, MediaAction
+src/server/rpc/media_ns.rs          media/verify, media/trace, media/policy
+src/server/endpoints.rs             POST /v1/media/verify
+src/commands/media.rs               grob media verify|trace
+```
+
+**Points de conception**
+
+- RBAC : `verify` en Observer (répond « cette image vient de chez vous »), `trace` en
+  Operator (révèle tenant et session). La distinction est le cœur du modèle de fuite.
+- Le bridge MCP est automatique via `control_bridge.rs`, donc un agent peut demander
+  « d'où vient cette image ? » sans code supplémentaire. C'est le bénéfice du
+  `ControlEngine` existant.
+- La réponse expose **quelle couche** a matché (`c2pa` signé, `watermark`, `phash`,
+  `none`) et non un booléen. La confiance doit être lisible.
+
+---
+
+### PR 7 — Watermark L2 (sidecar TrustMark)
+
+**Fichiers** : `src/features/media/mark/soft_binding.rs`, plus le sidecar de la PR 4.
+
+**Tests de robustesse** (ce sont eux le livrable réel, pas le code) :
+matrice recompression JPEG q ∈ {90, 70, 50}, resize ∈ {75 %, 50 %, 25 %}, crop
+∈ {10 %, 25 %}, capture d'écran. Chaque cellule donne un taux d'extraction mesuré,
+publié dans le README du module. Sans ces chiffres, la couche L2 est une promesse
+invérifiable.
+
+---
+
+### PR 8 — Lib JS `grob-media-verify`
+
+Package séparé. Fait localement ce qui est local (parse C2PA, pHash en WASM), délègue L2
+au serveur. Aucun secret côté client. Retourne toujours la couche qui a répondu.
+
+---
+
+### PR 9 — Vidéo
+
+L1 sur le conteneur (boîte `uuid` MP4, tags Matroska), L3 sur keyframes échantillonnées
+via sidecar ffmpeg. **Marquage par segment**, jamais par fichier : un simple découpage
+ne doit pas effacer la provenance. L2 vidéo hors périmètre.
+
+---
+
+## Piste agents
+
+### PR A1 — `AgentId` et propagation
+
+**Fichiers**
+
+```
+src/features/agents/mod.rs        AgentId (ULID), AgentContext
+src/features/agents/extract.rs    en-tête x-grob-agent-id + tag système
+src/features/agents/README.md
+src/features/token_pricing/       + dimension agent_id dans le journal spend
+docs/decisions/0033-agent-identity.md
+```
+
+**Points de conception**
+
+- L'identité est **portée, jamais devinée**. En-tête `x-grob-agent-id`, ou tag système
+  sur le modèle de `GROB-SUBAGENT-MODEL` qui existe déjà. Toute heuristique
+  d'auto-détection serait fragile et créerait de fausses attributions.
+- La filiation est déclarée par l'appelant (`x-grob-parent-agent-id`), et **vérifiée**
+  contre le registre en A2.
+- Le spend gagne une dimension `agent_id`. Le format du journal doit rester
+  rétrocompatible en lecture (champ optionnel), sinon on casse les journaux existants.
+
+**Acceptation** : `grob status` sait dire combien coûte chaque agent. C'est immédiatement
+utile, avant même toute notion de contrôle.
+
+---
+
+### PR A2 — Registre et leases
+
+**Fichiers** : `src/features/agents/registry.rs`, `lease.rs`, journal
+`~/.grob/agents/*.jsonl`.
+
+**Points de conception**
+
+- **Le lease, pas le kill.** Un agent tient un bail à TTL qu'il renouvelle. S'il ne
+  renouvelle pas, il expire. C'est le seul modèle qui survit au crash du superviseur :
+  un agent orphelin ne peut pas brûler du budget indéfiniment parce que personne n'est
+  là pour le tuer.
+- Le TTL par défaut doit être court (quelques minutes) avec renouvellement transparent.
+  Un défaut long annule le bénéfice.
+- L'expiration se manifeste en HTTP 403 avec un message explicite, pas un échec obscur.
+
+**Tests** : un agent dont le bail expire est refusé ; le renouvellement le maintient ;
+un parent qui expire fait expirer sa descendance.
+
+---
+
+### PR A3 — Budget et capacités hiérarchiques
+
+**Points de conception**
+
+- Le budget d'un enfant est **prélevé sur celui du parent**, jamais additionnel. Sinon
+  un agent qui se réplique contourne trivialement toute limite.
+- Les capacités (profil pledge) ne peuvent que se restreindre en descendant. Même
+  propriété monotone que `Role::has_at_least`, à tester explicitement.
+- **Pas de token passthrough** parent → enfant, conformément à MCP 2025-06-18 et au
+  problème du *confused deputy*. L'enfant reçoit un jeton dérivé d'audience restreinte
+  via `policies/decision_token` qui existe déjà.
+
+**Tests** : un enfant ne peut pas dépasser le budget de son parent, ni élargir ses
+capacités, ni réutiliser le jeton du parent. Ces trois tests sont le cœur du modèle de
+sécurité.
+
+---
+
+### PR A4 — Surfaces et trajectoire
+
+`agent/spawn|list|inspect|pause|resume|kill|budget|trace` via `ControlEngine`, donc
+disponibles d'un coup en CLI, RPC et MCP. `kill` est **récursif** sur la descendance,
+sinon il ne sert à rien.
+
+Trajectoire auditée : journal ordonné par agent (requêtes, outils, verdicts DLP, médias
+marqués). C'est ce qui rend le post-mortem possible.
+
+---
+
+### PR A5 — Jonction media ↔ agent
+
+`trace_id` d'un média → agent producteur → trajectoire complète. C'est la boucle qui
+donne son sens aux deux pistes : d'une image trouvée dans la nature, on remonte à
+l'agent, à sa session, à sa policy et à son propriétaire.
+
+---
+
+## Ce qu'on ne fait pas
+
+Écrit ici pour éviter la dérive, puisque c'est la section qui coûte le plus cher quand
+elle manque :
+
+- Grob **n'exécute pas** d'agents. Il autorise, borne, observe et coupe. Il n'ordonnance
+  rien, il ne relance rien, il n'a pas de boucle d'agent.
+- Pas de reconnaissance d'objets ou de visages.
+- Pas de transcodage vidéo dans le proxy.
+- Pas de prétention à un DRM inviolable : traçabilité dissuasive, pas contrôle d'usage.
+- Pas de base de données. Journaux JSONL et fichiers atomiques, comme le reste.
+
+## Ordre recommandé
+
+1. **PR 1 → 2 → 4** d'abord. C'est le chemin le plus court vers une valeur réelle :
+   les screenshots d'agents sont scannés par les règles DLP existantes.
+2. **A1** en parallèle, indépendante et immédiatement utile (coût par agent).
+3. **PR 5 → 6** ensuite : la provenance devient interrogeable.
+4. **A2 → A3** quand le besoin de contrôle se fait sentir, pas avant.
+5. **PR 7 → 8 → 9**, **A4 → A5** en fonction des retours.
+
+Le point de décision important est après la PR 4 : si l'OCR→DLP n'attrape rien d'utile
+en conditions réelles, tout le reste de la piste média devient discutable et il vaut
+mieux le savoir à ce moment-là.


### PR DESCRIPTION
Two design docs, no code changes.

- `001-image-dlp-provenance.md` — three-layer provenance (C2PA manifest / invisible watermark / perceptual fingerprint), image DLP via OCR reinjected into the existing `DlpEngine`, and the agent control plane gap analysis. Grounded in researched prior art: Durable Content Credentials, C2PA soft bindings, TrustMark (ICCV 2025), OWASP LLM01 multimodal injection, MCP 2025-06-18 authorization.
- `002-media-agents-delivery-plan.md` — the executable plan: 14 PRs, each mergeable alone, with files, tests and acceptance criteria.

Key conclusions:
- A visible QR code is the wrong primary mechanism (one crop kills it). The layered soft-binding approach is already an industry standard.
- Never embed business data in the image, only an opaque `trace_id` resolved against a local journal.
- TrustMark pulls ONNX Runtime, so it must be a sidecar, not a dependency of the 6 MB `FROM scratch` binary.
- No parent-to-child token passthrough for agents (confused deputy), per MCP spec.
