### PR TITLE
docs(design): correct c2pa cost with real measurements, reorder media plan

### DIFF
--- a/docs/design/001-image-dlp-provenance.md
+++ b/docs/design/001-image-dlp-provenance.md
@@ -130,7 +130,6 @@ pour ceux qui veulent un binaire unique sans orchestration.
 Détail d'API relevé en testant : `c2pa::Reader::from_file` exige la feature `file_io`,
 absente des defaults. À savoir avant de perdre du temps dessus.
 
-
 TrustMark (Adobe/Univ. Surrey, ICCV 2025, `arXiv:2311.18297`) est l'état de l'art ouvert :
 résolution arbitraire, qualité > 43 dB, implémentations Python/Rust/JS via ONNX.
 SynthID-Image (DeepMind, `arXiv:2510.09263`) est le pendant fermé, déployé à l'échelle
@@ -299,9 +298,9 @@ Chaque slice = une ADR courte + un `README.md` de module, conforme au flow du re
 
 ---
 
-# Partie 2 — Control plane d'agents
+## Partie 2 — Control plane d'agents
 
-## État actuel
+### État actuel
 
 Grob a déjà l'ossature d'un control plane, mais **orienté proxy**, pas **orienté agent** :
 
@@ -319,7 +318,7 @@ Grob a déjà l'ossature d'un control plane, mais **orienté proxy**, pas **orie
 Autrement dit : les *primitives* (identité, capacités, budget, audit, HIT, isolation
 réseau) existent déjà. Ce qui manque est la **notion d'agent comme entité de première classe**.
 
-## Le gap
+### Le gap
 
 Aujourd'hui une requête a un tenant, une policy, un budget. Elle n'a pas d'**agent
 identifié et durable**. Conséquences :
@@ -332,7 +331,7 @@ identifié et durable**. Conséquences :
 - Aucune boucle de rappel : rien ne relie « cette image a fuité » à « quel agent l'a produite ».
   C'est précisément le `trace_id` de la partie 1 qui referme cette boucle.
 
-## Ce que dit le marché (recherche, 2026-08)
+### Ce que dit le marché (recherche, 2026-08)
 
 Le terme « agent control plane » s'est stabilisé en 2025-2026 et converge, chez tous les
 acteurs (Microsoft Agent 365 / Entra Agent ID, Okta, Guild, Nagarro, Lyzr), sur la même
@@ -368,7 +367,7 @@ doit **jamais** recevoir le token de son parent. Il reçoit un token dérivé, d
 restreinte. Ça rejoint exactement la contrainte « les capacités décroissent
 monotonement » déjà posée, mais avec un mécanisme normé pour l'appliquer.
 
-## Direction proposée
+### Direction proposée
 
 **Un namespace `agent` + une identité qui traverse tout le pipeline.**
 
@@ -405,7 +404,7 @@ Points de conception qui comptent :
 - **HIT branché sur l'agent.** `policies/hit` existe déjà ; le point d'attache naturel
   est l'agent, pas la requête isolée.
 
-## Ce que ça débloque
+### Ce que ça débloque
 
 - Kill switch réel : un agent qui déraille est coupé, descendance comprise.
 - Attribution du coût par agent, pas par clé API.
@@ -413,7 +412,7 @@ Points de conception qui comptent :
 - Sandbox alignée : `orca.yaml` isole déjà au niveau réseau ; `AgentId` donne le pendant
   logique côté proxy.
 
-## Risques
+### Risques
 
 - **Scope creep vers l'orchestrateur.** Grob doit rester un *control plane*, pas un
   runtime d'agents. Il n'exécute pas, il autorise, borne, observe et coupe.
@@ -423,7 +422,7 @@ Points de conception qui comptent :
 - **État persistant.** Le control plane actuel est stateless ; les agents introduisent
   du cycle de vie. À contenir dans `GrobStore`, sans base de données.
 
-## Open Questions
+### Open Questions
 
 **Tranchées par la recherche et la mesure :**
 

--- a/docs/design/001-image-dlp-provenance.md
+++ b/docs/design/001-image-dlp-provenance.md
@@ -95,9 +95,41 @@ robuste est du traitement du signal → WASM, ou déportée sur l'endpoint serve
 
 | Besoin | Crate | Verdict |
 |---|---|---|
-| L1 C2PA | `c2pa` 0.90.4, MIT/Apache-2.0, `rust_native_crypto` dispo (évite OpenSSL) | **À utiliser.** C'est l'implémentation de référence CAI. Features à trier finement : couper `default_http` (4 clients HTTP !), `openssl`, `fetch_remote_manifests` (SSRF), garder `rust_native_crypto`. |
-| L2 watermark | `trustmark` 0.2.2 (Adobe, MIT) | **Attention.** Tire `ort` (ONNX Runtime) + `ndarray` + `image` + modèles ONNX externes. Incompatible avec le binaire `FROM scratch` de 6 MB. → **sidecar**, pas dépendance directe. |
-| L3 fingerprint | `img_hash` 3.2.0 (pHash/dHash) | **À utiliser**, léger, pur Rust. |
+| L1 C2PA | `c2pa` 0.90.4, MIT/Apache-2.0 | **Mesuré, et c'est un problème** : voir ci-dessous. `--no-default-features --features rust_native_crypto,file_io` élimine bien OpenSSL et les 4 clients HTTP, mais **coûte +7,0 MB** de binaire strippé+LTO. |
+| L2 watermark | `trustmark` 0.2.2 (Adobe, MIT) | **Sidecar.** Tire `ort` (ONNX Runtime) + `ndarray` + `image` + des modèles ONNX téléchargés séparément. Incompatible avec `FROM scratch`. |
+| L3 fingerprint | `img_hash` 3.2.0 (pHash/dHash) | **À utiliser**, 51 deps transitives, pur Rust. |
+
+### Mesures réelles (pas des estimations)
+
+Crate jetable, profil release identique à celui de Grob (`lto = true`,
+`codegen-units = 1`, `strip = true`, `opt-level = 3`), macOS aarch64 :
+
+| Binaire | Taille |
+|---|---|
+| hello world | 296 KB |
+| + `c2pa` (no-default-features, `rust_native_crypto`, `file_io`) | **7,33 MB** |
+
+Soit **+7,0 MB nets**, pour une image de conteneur Grob qui pèse ~6 MB aujourd'hui.
+Vérifications faites au passage : `cargo tree` ne contient **aucun** `reqwest`, `openssl`,
+`ureq`, `wasi` ni `wstd` avec ces features, mais l'arbre monte quand même à **240 crates
+uniques** (CBOR, COSE, X.509, `rasn-cms`, `iref`…). La compilation prend 26 s en debug.
+
+**Conclusion qui change le plan** : C2PA ne peut pas être une feature qu'on active
+tranquillement. Activer L1 **plus que double** la taille du binaire. Deux options, à
+trancher dans l'ADR :
+
+1. **Feature opt-in assumée** (`media-c2pa`), en documentant noir sur blanc « +7 MB », avec
+   une image de conteneur séparée `grob:media`. Le binaire par défaut reste à 6 MB.
+2. **Sidecar de provenance**, comme TrustMark, qui signe et vérifie hors du processus.
+   Le cœur ne connaît que `trace_id` et pHash, tous deux légers.
+
+L'option 2 est plus cohérente : elle rend le noyau indifférent au format de provenance,
+et elle mutualise le protocole sidecar avec l'OCR et TrustMark. L'option 1 reste utile
+pour ceux qui veulent un binaire unique sans orchestration.
+
+Détail d'API relevé en testant : `c2pa::Reader::from_file` exige la feature `file_io`,
+absente des defaults. À savoir avant de perdre du temps dessus.
+
 
 TrustMark (Adobe/Univ. Surrey, ICCV 2025, `arXiv:2311.18297`) est l'état de l'art ouvert :
 résolution arbitraire, qualité > 43 dB, implémentations Python/Rust/JS via ONNX.
@@ -164,8 +196,9 @@ Sous-modules :
     peut brancher Vision ; sinon sidecar HTTP, jamais linké en dur dans le binaire scratch.
   - `phash.rs` — empreinte perceptuelle (L3), et matching contre une deny-list
     d'images connues (documents internes, slides confidentielles).
-- `mark/` — `c2pa.rs` (L1, crate `c2pa`), `soft_binding.rs` (L2, client sidecar TrustMark
-  conforme à la C2PA Soft Binding Algorithm List), `qr.rs` (L3-visible, opt-in).
+- `mark/` — `c2pa.rs` (L1, client sidecar de provenance par défaut, crate `c2pa` en
+  option `media-c2pa` à +7 MB), `soft_binding.rs` (L2, sidecar TrustMark conforme à la
+  C2PA Soft Binding Algorithm List), `qr.rs` (L3-visible, opt-in).
 - `registry.rs` — journal `~/.grob/media/YYYY-MM.jsonl` : `trace_id`, phash, verdict,
   tenant, model, ts. Même pattern que `spend/`.
 
@@ -248,16 +281,19 @@ pas par fichier, sinon un simple découpage efface la provenance.
 
 ## Plan de livraison
 
-1. **Slice 1 — squelette.** `src/features/media/`, feature flag, `MediaRef` depuis
-   `ImageSource`, decode + bornes, `phash.rs`, registry JSONL, events tap. Aucun blocage,
-   observation seule.
-2. **Slice 2 — verdicts.** heuristics + stego, wiring dispatch en mode `async`,
-   politique par policy (`src/features/policies/`), mode `blocking`.
-3. **Slice 3 — provenance.** C2PA (L1) + registry `trace_id`, RPC `media/*`,
-   endpoint HTTP, CLI.
-4. **Slice 4 — watermark.** L2 invisible + QR opt-in, lib JS, tests de robustesse
+Le découpage détaillé en PRs vit dans [`002-media-agents-delivery-plan.md`](002-media-agents-delivery-plan.md).
+En résumé :
+
+1. **Squelette.** `src/features/media/`, feature flag, `MediaRef` depuis `ImageSource`,
+   decode + bornes, `phash.rs`, registry JSONL, events tap. Observation seule.
+2. **Sidecar.** Protocole unique et versionné, partagé par OCR, C2PA et TrustMark.
+   Remonté tôt car la mesure de taille de binaire rend le hors-processus obligatoire.
+3. **Verdicts.** heuristics + stego + OCR→DLP en mode `async`, puis `blocking` et
+   politique par policy (`src/features/policies/`).
+4. **Provenance.** L1 + registry `trace_id`, RPC `media/*`, endpoint HTTP, CLI.
+5. **Watermark.** L2 + QR opt-in, lib JS, tests de robustesse
    (recompression/resize/crop/screenshot) en harness.
-5. **Slice 5 — vidéo.** L1 conteneur + keyframes L3 via sidecar.
+6. **Vidéo.** L1 conteneur + keyframes L3 via sidecar.
 
 Chaque slice = une ADR courte + un `README.md` de module, conforme au flow du repo.
 
@@ -389,25 +425,29 @@ Points de conception qui comptent :
 
 ## Open Questions
 
-**Tranchées par la recherche :**
+**Tranchées par la recherche et la mesure :**
 
-- ~~C2PA en Rust, acceptable ?~~ Oui : `c2pa` 0.90.4, MIT/Apache-2.0, avec
-  `rust_native_crypto` et sans les 4 clients HTTP par défaut. À valider sur `cargo-deny`
-  et sur le poids réel du binaire.
+- ~~C2PA en Rust, acceptable ?~~ Le crate existe et compile sans OpenSSL, mais il coûte
+  **+7,0 MB mesurés** (binaire 296 KB → 7,33 MB, profil release de Grob). Donc : sidecar
+  par défaut, feature in-process `media-c2pa` en option documentée.
 - ~~Watermark maison ou dépendance ?~~ Ni l'un ni l'autre en direct : TrustMark en
   **sidecar** (ONNX incompatible avec `FROM scratch`), derrière le trait `MediaMarker`.
+- ~~Le sidecar : un protocole ou trois intégrations ?~~ **Un seul**, versionné, posé en
+  PR 2. La mesure C2PA a tranché la question : trois couches sur quatre sont hors
+  processus, donc c'est une fondation, pas un détail.
 - ~~Faut-il inventer un schéma d'identité d'agent ?~~ Non : OAuth 2.1 + RFC 8707
   (resource indicators) + RFC 9728, comme MCP 2025-06-18. Et interdiction stricte du
   token passthrough parent → enfant.
 
 **Encore ouvertes :**
 
-- L'OCR : sidecar local, ou API vision du provider déjà configuré ? (Attention : envoyer
-  l'image suspecte au provider contredit l'objectif.)
-- Le sidecar devient-il un pattern assumé de Grob (media, OCR, ffmpeg) avec un protocole
-  unique, ou trois intégrations ad hoc ? Trancher tôt, ça structure tout le reste.
+- L'OCR : moteur du sidecar (Vision sur macOS, autre chose ailleurs) ? Le protocole rend
+  la question locale, mais il faut un défaut recommandé. Ne **pas** utiliser l'API vision
+  du provider : envoyer l'image suspecte au provider contredit l'objectif.
 - Les agents : produit Admin/Enterprise (cf. ADR-0028 open-core boundary) ou cœur Apache ?
   Le marché monétise exactement cette couche, donc la question est commerciale.
 - `agent_id` obligatoire à terme, avec un agent implicite par défaut ?
 - Faut-il viser une conformité déclarée NIST AI RMF / EU AI Act, ou juste fournir les
   primitives et laisser l'utilisateur mapper ?
+- Distribue-t-on des sidecars officiels (images conteneur), ou seulement un protocole
+  et une implémentation de référence ?

--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -24,19 +24,27 @@
 | # | PR | Feature flag | Bloque le trafic ? | ADR |
 |---|---|---|---|---|
 | 1 | Squelette `media` : décodage borné + pHash + journal | `media` | non | ADR-0030 |
-| 2 | Détecteurs bon marché (heuristiques, stégano) + wiring async | `media` | non | — |
-| 3 | Mode `blocking` + intégration policies | `media` | oui | — |
-| 4 | OCR → DLP via sidecar | `media-ocr` | via #3 | ADR-0031 (sidecar) |
-| 5 | Provenance L1 (C2PA) + registre `trace_id` | `media-c2pa` | non | ADR-0032 |
-| 6 | Surfaces : RPC `media/*`, HTTP verify, CLI | `media` | non | — |
-| 7 | Watermark L2 via sidecar TrustMark | `media` | non | — |
-| 8 | Lib JS `grob-media-verify` | — | non | — |
-| 9 | Vidéo : L1 conteneur + keyframes L3 | `media-video` | non | — |
+| 2 | **Protocole sidecar** (fondation partagée) | `media` | non | ADR-0031 |
+| 3 | Détecteurs bon marché (heuristiques, stégano) + wiring async | `media` | non | — |
+| 4 | OCR → DLP via sidecar | `media` | non | — |
+| 5 | Mode `blocking` + intégration policies | `media` | oui | — |
+| 6 | Provenance L1 (C2PA) + registre `trace_id` | sidecar, ou `media-c2pa` | non | ADR-0032 |
+| 7 | Surfaces : RPC `media/*`, HTTP verify, CLI | `media` | non | — |
+| 8 | Watermark L2 via sidecar TrustMark | `media` | non | — |
+| 9 | Lib JS `grob-media-verify` | — | non | — |
+| 10 | Vidéo : L1 conteneur + keyframes L3 | `media` | non | — |
 | A1 | `AgentId` + contexte propagé + attribution du spend | `agents` | non | ADR-0033 |
 | A2 | Registre d'agents + leases | `agents` | oui (expiration) | — |
 | A3 | Budget et capacités hiérarchiques | `agents` | oui | — |
 | A4 | Surfaces `agent/*` + trajectoire auditée | `agents` | non | — |
 | A5 | Jonction media ↔ agent (`trace_id` → agent) | les deux | non | — |
+
+> **Révision après mesure.** Le sidecar est passé de la PR 4 à la PR 2, et C2PA de la
+> PR 5 à la PR 6, derrière le sidecar. Raison : `c2pa` compilé en dur coûte **+7,0 MB**
+> sur un binaire qui en fait 6 (mesure dans le design doc). Trois des couches lourdes
+> (OCR, C2PA, TrustMark) sont donc hors processus, ce qui fait du protocole sidecar la
+> fondation et non un détail d'implémentation. Le noyau ne manipule que `trace_id` et
+> pHash, tous deux légers.
 
 Les deux pistes sont indépendantes jusqu'à A5. Elles peuvent avancer en parallèle.
 
@@ -87,7 +95,45 @@ le journal.
 
 ---
 
-### PR 2 — Détecteurs bon marché + branchement asynchrone
+### PR 2 — Protocole sidecar (la fondation)
+
+**Pourquoi si tôt** : la mesure de taille de binaire (+7 MB pour C2PA seul) rend le
+hors-processus obligatoire pour trois couches sur quatre. Ce n'est donc plus un détail
+d'intégration mais l'ossature de toute la piste média. Le poser une fois, proprement,
+évite trois intégrations divergentes.
+
+**Fichiers**
+
+```
+src/features/media/sidecar/mod.rs      trait MediaSidecar, découverte, santé
+src/features/media/sidecar/proto.rs    contrat requête/réponse versionné
+src/features/media/sidecar/client.rs   HTTP sur unix socket, timeouts, circuit breaker
+docs/decisions/0031-media-sidecar.md
+```
+
+**Points de conception**
+
+- **Un seul protocole** pour OCR, C2PA et TrustMark. C'était une question ouverte du
+  design doc ; elle est tranchée ici.
+- Unix socket par défaut, jamais de port TCP exposé : le sidecar reçoit des images
+  potentiellement sensibles, il ne doit pas être joignable depuis le réseau.
+- **Absence de sidecar = capacité désactivée proprement**, jamais une erreur de
+  démarrage. Grob doit démarrer et servir même si tout l'appareillage média est absent.
+- Réutiliser le circuit breaker existant (`src/routing/`) plutôt que d'en écrire un
+  deuxième : un sidecar en vrac se comporte exactement comme un provider en vrac.
+- Le protocole est versionné dès le premier jour, sinon on ne pourra jamais le faire
+  évoluer sans casser les déploiements.
+
+**Tests** : sidecar absent → dégradation silencieuse et démarrage normal ; sidecar lent
+→ timeout respecté ; sidecar qui plante en boucle → circuit ouvert, plus d'appels ;
+version de protocole incompatible → refus explicite et lisible.
+
+**Acceptation** : un sidecar factice qui renvoie une réponse fixe est appelé par Grob,
+et son absence ne change rien au comportement du proxy.
+
+---
+
+### PR 3 — Détecteurs bon marché + branchement asynchrone
 
 **Fichiers**
 
@@ -118,7 +164,32 @@ agent envoie des screenshots, sans une milliseconde de latence ajoutée.
 
 ---
 
-### PR 3 — Mode bloquant + policies
+### PR 4 — OCR → DLP (via le sidecar de la PR 2)
+
+**Pourquoi c'est la PR la plus rentable** : elle transforme l'image en texte et rend
+*toutes* les règles DLP existantes applicables. Zéro duplication de règles.
+
+**Fichiers**
+
+```
+src/features/media/scan/text.rs      appel sidecar OCR + réinjection DlpEngine
+```
+
+**Points de conception**
+
+- Le texte OCR passe par le `DlpEngine` **existant**, sans nouvelle règle. Si le DLP
+  détecte une clé AWS dans un screenshot, c'est le même code que pour le texte.
+- Le résultat OCR n'est **jamais** journalisé en clair : seuls les identifiants de règles
+  déclenchées le sont. Sinon le journal devient lui-même la fuite.
+- Sur macOS, un sidecar s'appuyant sur Vision est trivial à écrire ; ailleurs, n'importe
+  quel moteur respectant le protocole convient. Le cœur s'en moque, c'est l'intérêt.
+
+**Tests** : screenshot contenant une fausse clé AWS → règle DLP déclenchée ; le texte
+OCR n'apparaît nulle part dans le journal.
+
+---
+
+### PR 5 — Mode bloquant + policies
 
 **Fichiers**
 
@@ -142,66 +213,43 @@ respecte `on_timeout` dans les deux sens.
 
 ---
 
-### PR 4 — OCR → DLP (sidecar, feature `media-ocr`)
-
-**Pourquoi c'est la PR la plus rentable** : elle transforme l'image en texte et rend
-*toutes* les règles DLP existantes applicables. Zéro duplication de règles.
+### PR 6 — Provenance L1 (C2PA) + registre
 
 **Fichiers**
 
 ```
-src/features/media/scan/text.rs      client sidecar + réinjection DlpEngine
-src/features/media/sidecar.rs        protocole sidecar générique (aussi utilisé PR 7 et 9)
-docs/decisions/0031-media-sidecar.md
-```
-
-**Points de conception**
-
-- Le sidecar est **un seul protocole** pour OCR, watermark et ffmpeg. C'est la question
-  ouverte du design doc, et la réponse est : un seul, tranché ici, sinon on aura trois
-  intégrations divergentes dans six mois.
-- Contrat : HTTP local, unix socket de préférence, timeout court, absence de sidecar =
-  capacité désactivée proprement (pas une erreur de démarrage).
-- Le texte OCR passe par le `DlpEngine` **existant**, sans nouvelle règle. Si le DLP
-  détecte une clé AWS dans un screenshot, c'est le même code que pour le texte.
-- Le résultat OCR n'est **jamais** journalisé en clair : seuls les identifiants de règles
-  déclenchées le sont. Sinon le journal devient la fuite.
-
-**Tests** : screenshot contenant une fausse clé AWS → règle DLP déclenchée ; sidecar
-absent → dégradation propre ; sidecar lent → timeout respecté.
-
----
-
-### PR 5 — Provenance L1 (C2PA) + registre
-
-**Fichiers**
-
-```
-src/features/media/mark/mod.rs      MediaMarker
-src/features/media/mark/c2pa.rs     crate c2pa
-src/features/media/trace.rs         TraceId (128 bits CSPRNG)
-src/features/media/registry.rs      trace_id → contexte
-Cargo.toml                          feature media-c2pa
+src/features/media/mark/mod.rs       MediaMarker
+src/features/media/mark/c2pa.rs      client sidecar de provenance (défaut)
+src/features/media/trace.rs          TraceId (128 bits CSPRNG)
+src/features/media/registry.rs       trace_id → contexte
+Cargo.toml                           feature media-c2pa (in-process, opt-in, +7 MB)
 docs/decisions/0032-content-provenance.md
 ```
 
 **Points de conception**
 
-- Features du crate `c2pa` : `default-features = false`, `rust_native_crypto`, **sans**
-  `default_http` (il tire quatre clients HTTP), **sans** `fetch_remote_manifests` (SSRF).
-  À vérifier avec `cargo tree` et `cargo-deny` dans la PR même.
-- Le manifeste contient `trace_id` et rien d'autre d'identifiant. Pas de tenant, pas de
-  nom de modèle, pas de session. La tentation sera forte, il faut la refuser : tout ce
+- **Chemin par défaut : sidecar.** Mesure faite : `c2pa` compilé en dur ajoute
+  **+7,0 MB** à un binaire qui en fait 6, même en `--no-default-features` avec
+  `rust_native_crypto` (240 crates transitives : CBOR, COSE, X.509). Doubler la taille
+  de l'image pour signer des métadonnées n'est pas un arbitrage défendable par défaut.
+- La feature `media-c2pa` reste disponible pour un binaire unique sans orchestration,
+  avec le coût **écrit dans la doc**, pas découvert par l'utilisateur.
+- À savoir avant de commencer : `c2pa::Reader::from_file` exige la feature `file_io`,
+  absente des defaults. Les features utiles vérifiées sont
+  `--no-default-features --features rust_native_crypto,file_io` : cet ensemble élimine
+  bien `reqwest`, `openssl`, `ureq`, `wasi` et `wstd` de l'arbre (vérifié à `cargo tree`).
+- Le manifeste contient `trace_id` et **rien d'autre** d'identifiant. Pas de tenant, pas
+  de nom de modèle, pas de session. La tentation sera forte, il faut la refuser : tout ce
   qu'on écrit dans l'image devient public.
-- Impact sur la taille du binaire mesuré et écrit dans la description de la PR.
 
 **Tests** : round-trip signer → lire ; manifeste strippé → `trace_id` toujours résolvable
-via pHash ; aucune donnée métier présente dans le fichier de sortie (test explicite qui
-cherche le nom du tenant dans les octets).
+via pHash ; aucune donnée métier dans le fichier de sortie (test explicite qui cherche le
+nom du tenant dans les octets bruts) ; et un test de garde qui échoue si la taille du
+binaire par défaut dépasse un seuil.
 
 ---
 
-### PR 6 — Surfaces d'exposition
+### PR 7 — Surfaces d'exposition
 
 **Fichiers**
 
@@ -224,7 +272,7 @@ src/commands/media.rs               grob media verify|trace
 
 ---
 
-### PR 7 — Watermark L2 (sidecar TrustMark)
+### PR 8 — Watermark L2 (sidecar TrustMark)
 
 **Fichiers** : `src/features/media/mark/soft_binding.rs`, plus le sidecar de la PR 4.
 
@@ -236,14 +284,14 @@ invérifiable.
 
 ---
 
-### PR 8 — Lib JS `grob-media-verify`
+### PR 9 — Lib JS `grob-media-verify`
 
 Package séparé. Fait localement ce qui est local (parse C2PA, pHash en WASM), délègue L2
 au serveur. Aucun secret côté client. Retourne toujours la couche qui a répondu.
 
 ---
 
-### PR 9 — Vidéo
+### PR 10 — Vidéo
 
 L1 sur le conteneur (boîte `uuid` MP4, tags Matroska), L3 sur keyframes échantillonnées
 via sidecar ffmpeg. **Marquage par segment**, jamais par fichier : un simple découpage
@@ -351,12 +399,12 @@ elle manque :
 
 ## Ordre recommandé
 
-1. **PR 1 → 2 → 4** d'abord. C'est le chemin le plus court vers une valeur réelle :
+1. **PR 1 → 2 → 3 → 4** d'abord. C'est le chemin le plus court vers une valeur réelle :
    les screenshots d'agents sont scannés par les règles DLP existantes.
 2. **A1** en parallèle, indépendante et immédiatement utile (coût par agent).
-3. **PR 5 → 6** ensuite : la provenance devient interrogeable.
+3. **PR 5 → 6 → 7** ensuite : blocage, puis provenance interrogeable.
 4. **A2 → A3** quand le besoin de contrôle se fait sentir, pas avant.
-5. **PR 7 → 8 → 9**, **A4 → A5** en fonction des retours.
+5. **PR 8 → 9 → 10**, **A4 → A5** en fonction des retours.
 
 Le point de décision important est après la PR 4 : si l'OCR→DLP n'attrape rien d'utile
 en conditions réelles, tout le reste de la piste média devient discutable et il vaut


### PR DESCRIPTION
Follow-up to #495, which merged before these corrections landed.

I asserted in #495 that the `c2pa` crate was fine to depend on once `default_http` and `openssl` were disabled, with the binary cost left as "to be validated". I validated it. It is not fine.

Measured in a throwaway crate using Grob's exact release profile (`lto = true`, `codegen-units = 1`, `strip = true`, `opt-level = 3`), macOS aarch64:

| Binary | Size |
|---|---|
| hello world | 296 KB |
| + `c2pa` (`--no-default-features --features rust_native_crypto,file_io`) | **7.33 MB** |

**+7.0 MB net, on a container image that is currently ~6 MB.** Compiling C2PA in more than doubles the binary. The feature trimming does work (no `reqwest`, `openssl`, `ureq`, `wasi` or `wstd` in `cargo tree`), but the tree is still 240 unique crates of CBOR, COSE and X.509.

Consequences, applied to both docs:

- C2PA moves behind the sidecar by default. The in-process `media-c2pa` feature stays available with the +7 MB cost written in the docs rather than discovered by the user.
- The sidecar protocol moves from PR 4 to **PR 2**. With OCR, C2PA and TrustMark all out of process, it is the foundation of the media track, not an integration detail.
- Plan renumbered to 10 media PRs, ordering fixed.

Also recorded while testing: `c2pa::Reader::from_file` requires the `file_io` feature, which is not in the defaults. `img_hash` is confirmed cheap at 51 transitive deps.
