### PR TITLE
docs(design): measure TrustMark cost and pHash robustness contract

### DIFF
--- a/docs/design/001-image-dlp-provenance.md
+++ b/docs/design/001-image-dlp-provenance.md
@@ -74,7 +74,12 @@ Le bon découpage est en trois couches indépendantes qui dégradent gracieuseme
 |---|---|---|---|---|
 | **L1 — Métadonnées signées** (C2PA / manifeste dans XMP/EXIF) | conteneur du fichier | copie, transfert, upload | screenshot, strip metadata, ré-encodage | provenance riche et vérifiable, cas nominal |
 | **L2 — Watermark invisible robuste** (spectre étalé / DCT-DWT, style Trustmark/SynthID) | pixels | recompression, resize, crop partiel, screenshot | crop massif, régénération, forte dégradation | identifiant opaque 64–128 bits, cas hostile |
-| **L3 — Empreinte perceptuelle** (pHash / dHash indexé côté serveur) | aucune modif de l'image | tout, y compris strip complet | transformation sémantique lourde | rattrapage « d'où vient cette image ? » sans rien avoir écrit dedans |
+| **L3 — Empreinte perceptuelle** (pHash / dHash indexé côté serveur) | aucune modif de l'image | recompression, resize, crop ≤ 25 %, screenshot, niveaux de gris, et leur cumul (mesuré) | **miroir, rotation**, transformation sémantique lourde | rattrapage « d'où vient cette image ? » sans rien avoir écrit dedans |
+
+> Les colonnes de L3 sont **mesurées**, pas estimées (voir « Robustesse de L3 mesurée »
+> plus bas). Celles de L1 et L2 restent des attentes issues de la littérature : L1 est
+> évidente (métadonnées présentes ou absentes), L2 devra être mesurée de la même façon
+> avant d'être promise à quiconque.
 
 Le QR devient une variante *L2-visible* : utile seulement quand on **veut** que ce soit
 visible (asset publié, marquage légal, démo), jamais comme mécanisme principal.
@@ -104,31 +109,76 @@ robuste est du traitement du signal → WASM, ou déportée sur l'endpoint serve
 Crate jetable, profil release identique à celui de Grob (`lto = true`,
 `codegen-units = 1`, `strip = true`, `opt-level = 3`), macOS aarch64 :
 
-| Binaire | Taille |
-|---|---|
-| hello world | 296 KB |
-| + `c2pa` (no-default-features, `rust_native_crypto`, `file_io`) | **7,33 MB** |
+| Binaire | Taille | Delta |
+|---|---|---|
+| hello world | 296 KB | référence |
+| + `c2pa` (no-default-features, `rust_native_crypto`, `file_io`) | **7,33 MB** | +7,0 MB |
+| + `trustmark` 0.2.2 | **12,24 MB** | **+11,9 MB** |
 
-Soit **+7,0 MB nets**, pour une image de conteneur Grob qui pèse ~6 MB aujourd'hui.
-Vérifications faites au passage : `cargo tree` ne contient **aucun** `reqwest`, `openssl`,
-`ureq`, `wasi` ni `wstd` avec ces features, mais l'arbre monte quand même à **240 crates
-uniques** (CBOR, COSE, X.509, `rasn-cms`, `iref`…). La compilation prend 26 s en debug.
+Soit +7,0 MB pour C2PA et +11,9 MB pour TrustMark, sur une image de conteneur Grob qui
+pèse ~6 MB aujourd'hui. **TrustMark seul multiplie la taille par plus de trois**, et
+l'arbre (162 crates) contient `ort`/`ort-sys` (ONNX Runtime), `ndarray`, `image` et
+`fast_image_resize`, sans compter les modèles ONNX qui se téléchargent séparément.
 
-**Conclusion qui change le plan** : C2PA ne peut pas être une feature qu'on active
-tranquillement. Activer L1 **plus que double** la taille du binaire. Deux options, à
-trancher dans l'ADR :
+Côté C2PA, `cargo tree` ne contient **aucun** `reqwest`, `openssl`, `ureq`, `wasi` ni
+`wstd` avec ces features, mais l'arbre monte quand même à **240 crates uniques**
+(CBOR, COSE, X.509, `rasn-cms`, `iref`…).
 
-1. **Feature opt-in assumée** (`media-c2pa`), en documentant noir sur blanc « +7 MB », avec
+**Conclusion qui change le plan** : ni C2PA ni TrustMark ne peuvent être des features
+qu'on active tranquillement. Les activer toutes les deux ferait passer le binaire de
+6 MB à ~25 MB. Deux options, à trancher dans l'ADR :
+
+1. **Feature opt-in assumée** (`media-c2pa`), en documentant noir sur blanc le coût, avec
    une image de conteneur séparée `grob:media`. Le binaire par défaut reste à 6 MB.
-2. **Sidecar de provenance**, comme TrustMark, qui signe et vérifie hors du processus.
-   Le cœur ne connaît que `trace_id` et pHash, tous deux légers.
+2. **Sidecar**, pour C2PA comme pour TrustMark, qui signent et vérifient hors du
+   processus. Le cœur ne connaît que `trace_id` et pHash, tous deux légers.
 
-L'option 2 est plus cohérente : elle rend le noyau indifférent au format de provenance,
-et elle mutualise le protocole sidecar avec l'OCR et TrustMark. L'option 1 reste utile
-pour ceux qui veulent un binaire unique sans orchestration.
+L'option 2 est la seule tenable pour TrustMark, et cohérente pour C2PA : elle rend le
+noyau indifférent au format de provenance et mutualise le protocole sidecar avec l'OCR.
+L'option 1 reste utile pour C2PA seul, si quelqu'un veut un binaire unique sans
+orchestration.
 
 Détail d'API relevé en testant : `c2pa::Reader::from_file` exige la feature `file_io`,
 absente des defaults. À savoir avant de perdre du temps dessus.
+
+### Robustesse de L3 mesurée (le contrat, pas une promesse)
+
+`img_hash` 3.2.0, `HashAlg::Gradient`, hash 64 bits, image synthétique 800×600 de type
+capture d'écran. Distance de Hamming entre l'original et sa version transformée :
+
+| Transformation | Distance /64 |
+|---|---|
+| JPEG q=90 / 70 / 50 | 1 / 1 / 1 |
+| JPEG q=30 | 3 |
+| Resize 75 % / 50 % / 25 % | 1 / 1 / 1 |
+| Crop 5 % / 10 % / 25 % | 1 / 3 / 5 |
+| « Screenshot » (resize + luminosité + JPEG 80) | 1 |
+| Niveaux de gris | 0 |
+| Resize 50 % + luminosité + JPEG 60 (cumulé) | 0 |
+| Crop 20 % + JPEG 60 (cumulé) | 3 |
+| **Miroir horizontal** | **21** |
+| **Rotation 90°** | **52** |
+
+- Pire cas sur les transformations supportées : **5**.
+- Image la plus proche parmi 10 images réellement différentes : **18**.
+- **Marge de séparation : 13.** Un seuil à 10 sépare proprement, avec de la marge des
+  deux côtés. C'est ce seuil qui doit être codé en dur et testé, pas deviné.
+
+Deux enseignements qui vont dans le README du module :
+
+1. L3 est **remarquablement robuste** au cas nominal, y compris aux transformations
+   cumulées, qui sont le cas réel. C'est la couche la moins chère et elle porte
+   beaucoup plus que je ne le supposais.
+2. L3 **ne résiste ni au miroir ni à la rotation** (21 et 52, au-delà du seuil). C'est
+   une limite structurelle du hash par gradient, pas un réglage. Si quelqu'un retourne
+   l'image, seuls L1 et L2 répondent. À écrire dans la doc, sinon on promet une
+   traçabilité qu'on n'a pas.
+
+Méthode : le premier corpus de test que j'avais écrit donnait une séparation nulle, non
+pas à cause de pHash mais parce que mes images « différentes » se ressemblaient toutes
+(distance 1). Un corpus non discriminant produit une conclusion fausse. Le test définitif
+vérifie donc explicitement la séparation avant de conclure quoi que ce soit sur la
+robustesse.
 
 TrustMark (Adobe/Univ. Surrey, ICCV 2025, `arXiv:2311.18297`) est l'état de l'art ouvert :
 résolution arbitraire, qualité > 43 dB, implémentations Python/Rust/JS via ONNX.

--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -85,9 +85,25 @@ docs/decisions/0030-media-pipeline.md
 
 - Une decompression bomb (petit fichier, dimensions énormes) est rejetée sans allocation.
 - Chaque format non listé est refusé, y compris avec une extension mensongère.
-- pHash stable sous ré-encodage JPEG q=70 et resize 50 %, distinct entre deux images
-  différentes. Ces seuils sont le contrat de L3, donc ils sont testés, pas supposés.
+- **pHash : la matrice de robustesse est déjà mesurée** (voir le design doc). Elle se
+  transpose directement en test, avec les valeurs constatées comme bornes :
+
+  | Cas | Distance mesurée | Assertion |
+  |---|---|---|
+  | JPEG q ≥ 30 | ≤ 3 | `dist <= 5` |
+  | Resize 25–75 % | 1 | `dist <= 5` |
+  | Crop ≤ 25 % | ≤ 5 | `dist <= 5` |
+  | Cumul resize + luminosité + JPEG 60 | 0 | `dist <= 5` |
+  | Images différentes (10 échantillons) | ≥ 18 | `dist > 10` |
+  | Miroir / rotation | 21 / 52 | **non supporté**, test qui documente la limite |
+
+  Le seuil de correspondance est **10**, choisi au milieu de la marge mesurée (5 → 18).
+  Il est codé en constante nommée, pas dispersé en littéral.
 - Le journal est append-only et relisible après troncature partielle (crash simulé).
+
+**Banc d'essai** : [`assets/phash_robustness_probe.rs`](assets/phash_robustness_probe.rs) (versionné dans le repo) est le programme exact qui a produit ces
+chiffres, pour qu'une mise à jour d'`img_hash` ou un changement d'algorithme se voie
+immédiatement au lieu de dériver en silence.
 
 **Acceptation** : `cargo build` sans `--features media` produit un binaire d'octets
 identiques à `main`. Avec la feature, on peut empreinter une image et la retrouver dans
@@ -274,13 +290,23 @@ src/commands/media.rs               grob media verify|trace
 
 ### PR 8 — Watermark L2 (sidecar TrustMark)
 
-**Fichiers** : `src/features/media/mark/soft_binding.rs`, plus le sidecar de la PR 4.
+**Fichiers** : `src/features/media/mark/soft_binding.rs`, plus le sidecar de la PR 2.
 
-**Tests de robustesse** (ce sont eux le livrable réel, pas le code) :
-matrice recompression JPEG q ∈ {90, 70, 50}, resize ∈ {75 %, 50 %, 25 %}, crop
-∈ {10 %, 25 %}, capture d'écran. Chaque cellule donne un taux d'extraction mesuré,
-publié dans le README du module. Sans ces chiffres, la couche L2 est une promesse
-invérifiable.
+**Le sidecar n'est pas discutable ici** : mesuré, `trustmark` 0.2.2 ajoute **+11,9 MB**
+au binaire (296 KB → 12,24 MB), soit plus de trois fois la taille de l'image Grob
+actuelle, sans compter les modèles ONNX téléchargés séparément. `ort`/`ort-sys`,
+`ndarray` et `fast_image_resize` n'ont rien à faire dans un binaire `FROM scratch`.
+
+**Tests de robustesse** (ce sont eux le livrable réel, pas le code) : même protocole que
+celui déjà appliqué à pHash, dont les résultats sont dans le design doc. Matrice
+recompression JPEG q ∈ {90, 70, 50, 30}, resize ∈ {75 %, 50 %, 25 %}, crop
+∈ {5 %, 10 %, 25 %}, cumuls, capture d'écran. Chaque cellule donne un taux d'extraction
+mesuré, publié dans le README du module, **et comparé à L3** : si L2 ne fait pas mieux
+que pHash sur une ligne, cette ligne ne justifie pas son coût opérationnel.
+
+Rappel de la mesure L3, qui place la barre : pHash encaisse déjà le cumul
+resize 50 % + luminosité + JPEG 60 à distance 0. L2 doit apporter ce que L3 ne sait pas
+faire (miroir, rotation, crop massif), sinon il n'apporte rien.
 
 ---
 

--- a/docs/design/assets/phash_robustness_probe.rs
+++ b/docs/design/assets/phash_robustness_probe.rs
@@ -1,0 +1,121 @@
+//! Reproducible probe behind the L3 (perceptual fingerprint) robustness figures in
+//! `docs/design/001-image-dlp-provenance.md`. Kept as an asset, not compiled by the
+//! workspace, so the numbers in the design doc can be re-derived rather than trusted.
+//!
+//! ```text
+//! cargo new /tmp/probe-ph && cd /tmp/probe-ph
+//! cargo add img_hash image@0.23
+//! cp <this file> src/main.rs
+//! cargo run --release
+//! ```
+//!
+//! Note on method: an earlier corpus made every "different" image land at distance 1,
+//! which produced a false "no separation" verdict. The probe therefore asserts the
+//! separation between same-image and different-image distances before any robustness
+//! claim is drawn from it.
+
+use image::{DynamicImage, GenericImageView, ImageOutputFormat, RgbImage};
+use img_hash::{HashAlg, HasherConfig};
+use std::io::Cursor;
+
+/// Deterministic pseudo-photo: smooth gradients + shapes, closer to a real
+/// screenshot than random noise (random noise is unfairly easy for pHash).
+fn synth(seed: u32, w: u32, h: u32) -> DynamicImage {
+    let mut img = RgbImage::new(w, h);
+    for y in 0..h {
+        for x in 0..w {
+            let fx = x as f32 / w as f32;
+            let fy = y as f32 / h as f32;
+            let s = seed as f32 * 2.9;
+            let f = 2.0 + (seed % 5) as f32 * 3.0;
+            let r = ((fx * f + s).sin() * 90.0 + 128.0) as u8;
+            let g = ((fy * (f * 0.6) + s * 1.7).cos() * 80.0 + 120.0) as u8;
+            let b = (((fx * 1.7 - fy * 2.3) * f + s).sin() * 70.0 + 130.0) as u8;
+            let n = (seed % 7) + 2;
+            let boxed = ((x / (11 + seed * 5)) + (y / (7 + seed * 3))) % n == 0;
+            img.put_pixel(
+                x,
+                y,
+                image::Rgb(if boxed { [240, 240, 240] } else { [r, g, b] }),
+            );
+        }
+    }
+    DynamicImage::ImageRgb8(img)
+}
+
+fn jpeg(img: &DynamicImage, q: u8) -> DynamicImage {
+    let mut buf = Cursor::new(Vec::new());
+    img.write_to(&mut buf, ImageOutputFormat::Jpeg(q)).unwrap();
+    image::load_from_memory(&buf.into_inner()).unwrap()
+}
+
+fn main() {
+    let hasher = HasherConfig::new().hash_alg(HashAlg::Gradient).to_hasher();
+    let base = synth(1, 800, 600);
+    let h0 = hasher.hash_image(&base);
+
+    println!("transform                       hamming(/64)");
+    println!("----------------------------------------------");
+
+    let mut rows: Vec<(String, u32)> = Vec::new();
+    for q in [90u8, 70, 50, 30] {
+        rows.push((format!("jpeg q={q}"), h0.dist(&hasher.hash_image(&jpeg(&base, q)))));
+    }
+    for pct in [75u32, 50, 25] {
+        let (w, h) = base.dimensions();
+        let r = base.resize_exact(w * pct / 100, h * pct / 100, image::imageops::FilterType::Lanczos3);
+        rows.push((format!("resize {pct}%"), h0.dist(&hasher.hash_image(&r))));
+    }
+    for pct in [5u32, 10, 25] {
+        let (w, h) = base.dimensions();
+        let (dx, dy) = (w * pct / 200, h * pct / 200);
+        let c = base.crop_imm(dx, dy, w - dx * 2, h - dy * 2);
+        rows.push((format!("crop {pct}%"), h0.dist(&hasher.hash_image(&c))));
+    }
+    // "screenshot": resize + jpeg + slight brightness shift
+    let shot = jpeg(&base.resize_exact(1024, 768, image::imageops::FilterType::Triangle).brighten(8), 80);
+    rows.push(("screenshot-ish".into(), h0.dist(&hasher.hash_image(&shot))));
+    rows.push(("grayscale".into(), h0.dist(&hasher.hash_image(&base.grayscale()))));
+    // Chained/adversarial: what actually happens in the wild.
+    let chain = jpeg(
+        &base
+            .resize_exact(400, 300, image::imageops::FilterType::Lanczos3)
+            .brighten(12),
+        60,
+    );
+    rows.push(("resize50+bright+jpeg60".into(), h0.dist(&hasher.hash_image(&chain))));
+    let (w, h) = base.dimensions();
+    let hard = jpeg(&base.crop_imm(w / 10, h / 10, w * 8 / 10, h * 8 / 10), 60);
+    rows.push(("crop20%+jpeg60".into(), h0.dist(&hasher.hash_image(&hard))));
+    let flip = base.fliph();
+    rows.push(("hflip (expected FAIL)".into(), h0.dist(&hasher.hash_image(&flip))));
+    let rot = base.rotate90();
+    rows.push(("rot90 (expected FAIL)".into(), h0.dist(&hasher.hash_image(&rot))));
+
+    for (name, d) in &rows {
+        println!("{name:<30}  {d:>2}");
+    }
+
+    // Discrimination: distance between genuinely different images.
+    let others: Vec<u32> = (2..12)
+        .map(|s| h0.dist(&hasher.hash_image(&synth(s, 800, 600))))
+        .collect();
+    let min_other = *others.iter().min().unwrap();
+    let max_same = rows
+        .iter()
+        .filter(|(n, _)| !n.contains("FAIL"))
+        .map(|(_, d)| *d)
+        .max()
+        .unwrap();
+
+    println!("\nworst same-image distance : {max_same}");
+    println!("closest different image   : {min_other}");
+    println!(
+        "separation                : {}",
+        if min_other > max_same {
+            format!("OK, gap of {}", min_other - max_same)
+        } else {
+            "NONE - overlapping, L3 unusable as specified".into()
+        }
+    );
+}


### PR DESCRIPTION
Follow-up to #496. I had measured `c2pa` but left two other load-bearing claims untested: TrustMark's cost, and pHash robustness, which is the actual *contract* of the L3 layer. Both are now measured.

## TrustMark is heavier than C2PA

Same throwaway-crate method, Grob's exact release profile:

| Binary | Size | Delta |
|---|---|---|
| hello world | 296 KB | baseline |
| + `c2pa` | 7.33 MB | +7.0 MB |
| + `trustmark` 0.2.2 | **12.24 MB** | **+11.9 MB** |

TrustMark alone more than triples the current 6 MB image, and that excludes the ONNX models downloaded separately (`ort`/`ort-sys`, `ndarray`, `fast_image_resize` in the tree). The sidecar is no longer a preference for L2, it is the only option.

## pHash robustness measured, and it changes what L3 promises

`img_hash` 3.2.0, `HashAlg::Gradient`, 64-bit hash, Hamming distance:

| Transform | Distance /64 |
|---|---|
| JPEG q=90/70/50/30 | 1 / 1 / 1 / 3 |
| Resize 75/50/25 % | 1 / 1 / 1 |
| Crop 5/10/25 % | 1 / 3 / 5 |
| Screenshot-ish, grayscale | 1 / 0 |
| Chained resize+brighten+JPEG60 | 0 |
| **Horizontal mirror** | **21** |
| **90° rotation** | **52** |

Worst supported case 5, closest genuinely different image 18, so a threshold of 10 separates cleanly with margin on both sides. Two conclusions:

- L3 is **much stronger than I assumed**, surviving chained transforms at distance 0. It is the cheapest layer and it carries more weight than the design doc gave it credit for.
- L3 **does not survive mirror or rotation**. That is structural to gradient hashing, not a tuning knob. The layer table said L3 "survives everything", which was wrong and is now corrected.

The measured matrix is written into the plan as PR 1 acceptance criteria with concrete assertions and a named threshold constant.

## Method note

My first test corpus reported *no separation at all*. The cause was not pHash: my "different" images were all landing at distance 1 because they were too similar. A non-discriminating corpus produces a confident wrong answer. The probe now asserts separation before drawing any robustness conclusion, and it is committed at `docs/design/assets/phash_robustness_probe.rs` so the figures can be re-derived instead of trusted.
