### PR TITLE
docs(design): measure L2 watermark robustness, correct layer table

### DIFF
--- a/docs/design/001-image-dlp-provenance.md
+++ b/docs/design/001-image-dlp-provenance.md
@@ -44,7 +44,7 @@ les infos stockées dedans, c'est une bonne idée ? »
 - Transcoder/ré-encoder de la vidéo dans le proxy. Grob n'est pas un pipeline média.
 - Prétendre à un DRM inviolable. Un watermark robuste est **dissuasif et traçant**,
   pas cryptographiquement inarrachable.
-- Embarquer un moteur OCR lourd (Tesseract, ONNX) dans le binaire 6 MB par défaut.
+- Embarquer un moteur OCR lourd (Tesseract, ONNX) dans le binaire par défaut.
 
 ## Réponse directe : le QR code dans l'image, bonne idée ?
 
@@ -73,22 +73,24 @@ Le bon découpage est en trois couches indépendantes qui dégradent gracieuseme
 | Couche | Support | Survit à | Casse sur | Rôle |
 |---|---|---|---|---|
 | **L1 — Métadonnées signées** (C2PA / manifeste dans XMP/EXIF) | conteneur du fichier | copie, transfert, upload | screenshot, strip metadata, ré-encodage | provenance riche et vérifiable, cas nominal |
-| **L2 — Watermark invisible robuste** (spectre étalé / DCT-DWT, style Trustmark/SynthID) | pixels | recompression, resize, crop partiel, screenshot | crop massif, régénération, forte dégradation | identifiant opaque 64–128 bits, cas hostile |
+| **L2 — Watermark invisible robuste** (spectre étalé / DCT-DWT, style Trustmark/SynthID) | pixels | recompression (jusqu'à JPEG q=30), resize, crop ≤ 20 %, niveaux de gris, miroir horizontal (mesuré) | **décalage de luminosité, même +2/255**, miroir vertical, rotation, crop ≥ 25 % | identifiant opaque **61 bits**, cas hostile |
 | **L3 — Empreinte perceptuelle** (pHash / dHash indexé côté serveur) | aucune modif de l'image | recompression, resize, crop ≤ 25 %, screenshot, niveaux de gris, et leur cumul (mesuré) | **miroir, rotation**, transformation sémantique lourde | rattrapage « d'où vient cette image ? » sans rien avoir écrit dedans |
 
-> Les colonnes de L3 sont **mesurées**, pas estimées (voir « Robustesse de L3 mesurée »
-> plus bas). Celles de L1 et L2 restent des attentes issues de la littérature : L1 est
-> évidente (métadonnées présentes ou absentes), L2 devra être mesurée de la même façon
-> avant d'être promise à quiconque.
+> Les colonnes de L2 et L3 sont **mesurées**, pas estimées (voir les deux sections
+> « Robustesse … mesurée » plus bas). Celles de L1 restent évidentes par construction
+> (les métadonnées sont présentes ou absentes). Fait notable : L2 et L3 tombent sur des
+> transformations **disjointes**, ce qui valide empiriquement le modèle en couches.
 
 Le QR devient une variante *L2-visible* : utile seulement quand on **veut** que ce soit
 visible (asset publié, marquage légal, démo), jamais comme mécanisme principal.
 
 Ce qui est écrit dans L1/L2 : **jamais** de données métier. Uniquement
-`trace_id` (128 bits aléatoires) + version de schéma. Le mapping
-`trace_id → {tenant, session, model, policy, timestamp}` vit dans le `GrobStore`
-(journal JSONL append-only, comme le spend). Cohérent avec le modèle de données existant
-et ça évite de transformer le watermark en canal d'exfiltration.
+`trace_id` + version de schéma. Contrainte mesurée : la capacité utile de TrustMark Bch5
+est de **61 bits**, donc le `trace_id` fait 61 bits, pas 128. C'est amplement suffisant
+(2⁶¹ ≈ 2,3 × 10¹⁸ valeurs) et c'est une contrainte du type, pas un détail d'encodage.
+Le mapping `trace_id → {tenant, session, model, policy, timestamp}` vit dans le
+`GrobStore` (journal JSONL append-only, comme le spend). Cohérent avec le modèle de
+données existant et ça évite de transformer le watermark en canal d'exfiltration.
 
 Une lib JS de lecture reste souhaitable : elle lit L1 (parse C2PA/XMP, pur JS), calcule L3
 (pHash en WASM ou Canvas) et appelle Grob pour résoudre le `trace_id`. La détection L2
@@ -115,21 +117,35 @@ Crate jetable, profil release identique à celui de Grob (`lto = true`,
 | + `c2pa` (no-default-features, `rust_native_crypto`, `file_io`) | **7,33 MB** | +7,0 MB |
 | + `trustmark` 0.2.2 | **12,24 MB** | **+11,9 MB** |
 
-Soit +7,0 MB pour C2PA et +11,9 MB pour TrustMark, sur une image de conteneur Grob qui
-pèse ~6 MB aujourd'hui. **TrustMark seul multiplie la taille par plus de trois**, et
-l'arbre (162 crates) contient `ort`/`ort-sys` (ONNX Runtime), `ndarray`, `image` et
-`fast_image_resize`, sans compter les modèles ONNX qui se téléchargent séparément.
+Soit +7,0 MB pour C2PA et +11,9 MB pour TrustMark.
+
+**Mise en perspective, en restant honnête sur les bases de comparaison.** Le « 6 MB » que
+le README annonce est l'**image conteneur** (`FROM scratch`, cible
+`x86_64-unknown-linux-musl`, strippée). Le binaire `grob` construit ici, en release sur
+macOS aarch64, pèse **17,3 MB** (mesuré) : ce sont deux chiffres différents et les
+mélanger serait malhonnête. Ce qui est directement comparable, ce sont les **deltas**,
+obtenus avec le même profil et la même plateforme :
+
+- +7,0 MB pour C2PA, soit environ **+40 %** du binaire actuel.
+- +11,9 MB pour TrustMark, soit environ **+69 %**.
+- Les deux ensemble : **+19 MB, plus du double**.
+
+Sur l'image conteneur musl, les valeurs absolues différeront, mais l'ordre de grandeur
+relatif ne s'inversera pas : ONNX Runtime et la pile COSE/X.509 ne deviennent pas
+gratuits en changeant de cible.
 
 Côté C2PA, `cargo tree` ne contient **aucun** `reqwest`, `openssl`, `ureq`, `wasi` ni
 `wstd` avec ces features, mais l'arbre monte quand même à **240 crates uniques**
-(CBOR, COSE, X.509, `rasn-cms`, `iref`…).
+(CBOR, COSE, X.509, `rasn-cms`, `iref`…). TrustMark en apporte 162, dont `ort`/`ort-sys`
+(ONNX Runtime), `ndarray`, `image` et `fast_image_resize`, **plus 65 MB de modèles ONNX**
+téléchargés séparément, qu'aucune mesure de binaire ne capture.
 
 **Conclusion qui change le plan** : ni C2PA ni TrustMark ne peuvent être des features
-qu'on active tranquillement. Les activer toutes les deux ferait passer le binaire de
-6 MB à ~25 MB. Deux options, à trancher dans l'ADR :
+qu'on active tranquillement. Deux options, à trancher dans l'ADR :
 
 1. **Feature opt-in assumée** (`media-c2pa`), en documentant noir sur blanc le coût, avec
-   une image de conteneur séparée `grob:media`. Le binaire par défaut reste à 6 MB.
+   une image de conteneur séparée `grob:media`. Le binaire et l'image par défaut sont
+   inchangés.
 2. **Sidecar**, pour C2PA comme pour TrustMark, qui signent et vérifient hors du
    processus. Le cœur ne connaît que `trace_id` et pHash, tous deux légers.
 
@@ -179,6 +195,55 @@ pas à cause de pHash mais parce que mes images « différentes » se ressemblai
 (distance 1). Un corpus non discriminant produit une conclusion fausse. Le test définitif
 vérifie donc explicitement la séparation avant de conclure quoi que ce soit sur la
 robustesse.
+
+### Robustesse de L2 mesurée (TrustMark, modèles ONNX réels)
+
+Même exigence pour L2 : j'avais écrit que sa mesure attendrait la PR 8. C'était faux, les
+modèles sont publics et le test tient en une heure. Sonde reproductible :
+[`assets/l2_watermark_robustness_probe.rs`](assets/l2_watermark_robustness_probe.rs).
+
+TrustMark `Variant::Q` / `Version::Bch5`, modèles ONNX officiels (~65 MB), porteuse
+`ghost.png` du dépôt amont, payload de 61 bits (capacité imposée, voir plus bas) :
+
+| Transformation | L2 extrait ? | Rappel L3 |
+|---|---|---|
+| Aucune (clean) | ✅ | ✅ |
+| JPEG q=90 / 70 / 60 / 50 / 30 | ✅ | ✅ |
+| Resize 75 % / 50 % / 25 % | ✅ | ✅ |
+| Resize 50 % + JPEG 60 | ✅ | ✅ |
+| Crop 10 % / 15 % / 20 % | ✅ | ✅ |
+| **Crop 25 %** | ❌ | ✅ (distance 5) |
+| Niveaux de gris | ✅ | ✅ |
+| Contraste +10 | ✅ | — |
+| **Miroir horizontal** | ✅ | ❌ (21) |
+| **Miroir vertical** | ❌ | — |
+| **Rotation 90°** | ❌ | ❌ (52) |
+| **Luminosité +2** (quasi invisible) | ❌ | ✅ |
+| Luminosité +5 / +8 / +12, −5 | ❌ | ✅ |
+
+Trois résultats qui comptent, et qu'aucune lecture d'article n'aurait donnés :
+
+1. **L2 casse sur un décalage de luminosité de +2/255**, invisible à l'œil, alors qu'il
+   encaisse JPEG q=30. C'est contre-intuitif et c'est une **fragilité opérationnelle
+   majeure** : n'importe quel outil de capture avec auto-exposition, n'importe quel thème
+   clair/sombre, n'importe quelle normalisation d'image détruit le watermark. Pour des
+   screenshots d'agents, ce cas est loin d'être théorique.
+2. **L2 et L3 échouent sur des transformations disjointes.** L2 survit au miroir
+   horizontal où L3 meurt ; L3 survit à la luminosité et au crop 25 % où L2 meurt. C'est
+   la meilleure justification possible du modèle en couches, et elle est maintenant
+   mesurée au lieu d'être postulée. **Aucune des deux couches ne rend l'autre superflue.**
+3. **La capacité est de 61 bits**, pas 64 ni 128. `Version::Bch5.data_bits()` vaut 61 et
+   toute autre longueur est rejetée (`InvalidDataLength`). Le `trace_id` doit donc tenir
+   dans **61 bits**, ce qui reste largement suffisant (2⁶¹ ≈ 2,3 × 10¹⁸) mais doit être
+   fixé dans le type dès le premier jour, pas découvert en PR 8.
+
+Détail de mise en œuvre relevé au passage : la porteuse compte. Mon image synthétique
+512×512 échoue au round-trip propre là où la même en 256×256 et `ghost.png` réussissent.
+Le watermark n'est donc **pas garanti sur toute image** ; le code devra vérifier
+l'extraction juste après l'écriture et journaliser un échec plutôt que de supposer.
+
+Coûts mesurés : encodage ~50 ms, décodage ~30 ms par image sur un M-series, hors
+chargement des modèles. Compatible avec un sidecar, rédhibitoire sur le chemin bloquant.
 
 TrustMark (Adobe/Univ. Surrey, ICCV 2025, `arXiv:2311.18297`) est l'état de l'art ouvert :
 résolution arbitraire, qualité > 43 dB, implémentations Python/Rust/JS via ONNX.
@@ -325,7 +390,7 @@ pas par fichier, sinon un simple découpage efface la provenance.
 | SSRF via `ImageSource::Url` | pas de fetch distant par défaut, allow-list si activé |
 | Faux positifs OCR→DLP bloquants | mode `async` par défaut, `blocking` explicite et opt-in |
 | Le watermark devient un canal d'exfil | seul un `trace_id` opaque est embarqué, jamais de donnée métier |
-| Poids binaire (6 MB, `FROM scratch`) | feature `media` off par défaut, OCR en sidecar, jamais linké |
+| Poids binaire (image 6 MB `FROM scratch`, binaire 17,3 MB) | feature `media` off par défaut, OCR en sidecar, jamais linké |
 | Fausse confiance en la provenance | la réponse dit toujours *quelle couche* a matché et si elle est signée |
 
 ## Plan de livraison

--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -105,9 +105,14 @@ docs/decisions/0030-media-pipeline.md
 chiffres, pour qu'une mise à jour d'`img_hash` ou un changement d'algorithme se voie
 immédiatement au lieu de dériver en silence.
 
-**Acceptation** : `cargo build` sans `--features media` produit un binaire d'octets
-identiques à `main`. Avec la feature, on peut empreinter une image et la retrouver dans
-le journal.
+**Acceptation** : sans `--features media`, `cargo tree` ne contient aucune des nouvelles
+dépendances et la taille du binaire release ne bouge pas de plus de 1 % par rapport à
+`main` (référence mesurée aujourd'hui : **17,3 MB** en release macOS aarch64 ; l'image
+conteneur musl `FROM scratch` reste sur sa propre référence de ~6 MB). Un critère
+« binaire identique à l'octet près » serait ininspectable en pratique, à cause des
+identifiants de build et des chemins ; la garde utile est l'absence de dépendance et la
+stabilité de la taille. Avec la feature, on peut empreinter une image et la retrouver
+dans le journal.
 
 ---
 
@@ -236,7 +241,7 @@ respecte `on_timeout` dans les deux sens.
 ```
 src/features/media/mark/mod.rs       MediaMarker
 src/features/media/mark/c2pa.rs      client sidecar de provenance (défaut)
-src/features/media/trace.rs          TraceId (128 bits CSPRNG)
+src/features/media/trace.rs          TraceId (61 bits CSPRNG, capacité TrustMark Bch5)
 src/features/media/registry.rs       trace_id → contexte
 Cargo.toml                           feature media-c2pa (in-process, opt-in, +7 MB)
 docs/decisions/0032-content-provenance.md
@@ -297,16 +302,30 @@ au binaire (296 KB → 12,24 MB), soit plus de trois fois la taille de l'image G
 actuelle, sans compter les modèles ONNX téléchargés séparément. `ort`/`ort-sys`,
 `ndarray` et `fast_image_resize` n'ont rien à faire dans un binaire `FROM scratch`.
 
-**Tests de robustesse** (ce sont eux le livrable réel, pas le code) : même protocole que
-celui déjà appliqué à pHash, dont les résultats sont dans le design doc. Matrice
-recompression JPEG q ∈ {90, 70, 50, 30}, resize ∈ {75 %, 50 %, 25 %}, crop
-∈ {5 %, 10 %, 25 %}, cumuls, capture d'écran. Chaque cellule donne un taux d'extraction
-mesuré, publié dans le README du module, **et comparé à L3** : si L2 ne fait pas mieux
-que pHash sur une ligne, cette ligne ne justifie pas son coût opérationnel.
+**Tests de robustesse** : **déjà mesurés**, contrairement à ce que ce plan disait
+initialement. Les modèles ONNX sont publics et la matrice complète est dans le design
+doc, avec la sonde reproductible
+[`assets/l2_watermark_robustness_probe.rs`](assets/l2_watermark_robustness_probe.rs).
+Cette PR se contente donc de **transposer la matrice en tests** et de vérifier qu'elle
+ne régresse pas avec la version des modèles.
 
-Rappel de la mesure L3, qui place la barre : pHash encaisse déjà le cumul
-resize 50 % + luminosité + JPEG 60 à distance 0. L2 doit apporter ce que L3 ne sait pas
-faire (miroir, rotation, crop massif), sinon il n'apporte rien.
+Ce que la mesure impose au code de cette PR :
+
+- **Vérifier l'extraction juste après l'écriture.** Le marquage n'est pas garanti sur
+  toute porteuse : une image synthétique 512×512 échoue au round-trip propre là où la
+  même en 256×256 réussit. Écrire sans relire, c'est promettre une traçabilité absente.
+- **Journaliser l'échec de marquage** comme un événement de premier ordre, pas comme une
+  erreur silencieuse.
+- **Ne pas promettre L2 sur les captures d'écran retouchées** : un décalage de luminosité
+  de +2/255, invisible, suffit à détruire le watermark. La doc utilisateur doit le dire.
+- Budget mesuré : ~50 ms d'encodage, ~30 ms de décodage par image. Confirme le sidecar et
+  exclut le chemin bloquant.
+
+**Ce que L2 apporte réellement par rapport à L3**, mesuré : le miroir horizontal, et
+rien d'autre dans la matrice testée. En sens inverse L3 couvre la luminosité et le crop
+25 % où L2 échoue. Les deux couches sont donc complémentaires mais **L2 est le moins
+rentable des deux** rapporté à son coût (+11,9 MB, sidecar, modèles de 65 MB). Cette PR
+est légitimement la dernière de la piste média.
 
 ---
 

--- a/docs/design/assets/l2_watermark_robustness_probe.rs
+++ b/docs/design/assets/l2_watermark_robustness_probe.rs
@@ -1,0 +1,175 @@
+//! Reproducible probe behind the L2 (invisible watermark) robustness figures in
+//! `docs/design/001-image-dlp-provenance.md`. Kept as an asset, not compiled by the
+//! workspace, so the numbers in the design doc can be re-derived rather than trusted.
+//!
+//! ```text
+//! # models (~65 MB, not vendored)
+//! mkdir -p /tmp/tm-models && cd /tmp/tm-models
+//! for m in encoder_Q.onnx decoder_Q.onnx; do
+//!   curl -sLO "https://cai-watermark.adobe.net/watermarking/trustmark-models/$m"
+//! done
+//! curl -sLO "https://raw.githubusercontent.com/adobe/trustmark/main/images/ghost.png"
+//!
+//! cargo new /tmp/probe-l2 && cd /tmp/probe-l2
+//! cargo add trustmark image@0.25
+//! cp <this file> src/main.rs
+//! cargo run --release
+//! ```
+//!
+//! The payload length is not free: `Version::data_bits()` fixes it (61 bits for Bch5).
+//! Passing any other length fails with `InvalidDataLength`, which is exactly the
+//! capacity budget a `trace_id` has to fit inside.
+
+use image::{DynamicImage, GenericImageView, RgbImage};
+use std::io::Cursor;
+use trustmark::{Trustmark, Variant, Version};
+
+/// Deterministic pseudo-screenshot, same generator as the pHash probe.
+fn synth(seed: u32, w: u32, h: u32) -> DynamicImage {
+    let mut img = RgbImage::new(w, h);
+    for y in 0..h {
+        for x in 0..w {
+            let fx = x as f32 / w as f32;
+            let fy = y as f32 / h as f32;
+            let s = seed as f32 * 2.9;
+            let f = 2.0 + (seed % 5) as f32 * 3.0;
+            let r = ((fx * f + s).sin() * 90.0 + 128.0) as u8;
+            let g = ((fy * (f * 0.6) + s * 1.7).cos() * 80.0 + 120.0) as u8;
+            let b = (((fx * 1.7 - fy * 2.3) * f + s).sin() * 70.0 + 130.0) as u8;
+            let n = (seed % 7) + 2;
+            let boxed = ((x / (11 + seed * 5)) + (y / (7 + seed * 3))) % n == 0;
+            img.put_pixel(
+                x,
+                y,
+                image::Rgb(if boxed { [240, 240, 240] } else { [r, g, b] }),
+            );
+        }
+    }
+    DynamicImage::ImageRgb8(img)
+}
+
+fn jpeg(img: &DynamicImage, q: u8) -> DynamicImage {
+    let mut buf = Cursor::new(Vec::new());
+    img.to_rgb8()
+        .write_with_encoder(image::codecs::jpeg::JpegEncoder::new_with_quality(
+            &mut buf, q,
+        ))
+        .unwrap();
+    image::load_from_memory(&buf.into_inner()).unwrap()
+}
+
+fn main() {
+    let models = std::env::args().nth(1).unwrap_or("/tmp/tm-models".into());
+    let tm = match Trustmark::new(&models, Variant::Q, Version::Bch5) {
+        Ok(t) => t,
+        Err(e) => {
+            println!("cannot load models from {models}: {e:?}");
+            return;
+        }
+    };
+
+    let bits = Version::Bch5.data_bits() as usize;
+    let payload: String = (0..bits)
+        .map(|i| if i % 3 == 0 { '1' } else { '0' })
+        .collect();
+    println!("payload capacity (Bch5): {bits} bits");
+
+    // Sanity first: does a clean roundtrip work at all, on which kind of image?
+    let candidates: Vec<(&str, Option<DynamicImage>)> = vec![
+        (
+            "upstream ghost.png",
+            image::open(format!("{models}/ghost.png")).ok(),
+        ),
+        ("synthetic 512x512", Some(synth(1, 512, 512))),
+        ("synthetic 256x256", Some(synth(1, 256, 256))),
+    ];
+
+    let mut carrier: Option<(String, DynamicImage)> = None;
+    println!("\nclean roundtrip by carrier:");
+    for (label, img) in candidates {
+        let Some(img) = img else {
+            println!("  {label:<20} (missing)");
+            continue;
+        };
+        let t = std::time::Instant::now();
+        match tm.encode(payload.clone(), img.clone(), 0.95) {
+            Ok(marked) => {
+                let ms = t.elapsed().as_millis();
+                let ok = tm.decode(marked.clone()).map(|s| s == payload).unwrap_or(false);
+                println!("  {label:<20} {} ({ms} ms)", if ok { "OK" } else { "FAIL" });
+                if ok && carrier.is_none() {
+                    carrier = Some((label.to_string(), marked));
+                }
+            }
+            Err(e) => println!("  {label:<20} encode error {e:?}"),
+        }
+    }
+
+    let Some((label, marked)) = carrier else {
+        println!("\nno carrier survived a clean roundtrip; robustness matrix is meaningless here");
+        return;
+    };
+    println!("\nrobustness matrix (carrier: {label})");
+
+    let (w, h) = marked.dimensions();
+    let cases: Vec<(String, DynamicImage)> = vec![
+        ("clean".into(), marked.clone()),
+        ("jpeg q=90".into(), jpeg(&marked, 90)),
+        ("jpeg q=70".into(), jpeg(&marked, 70)),
+        ("jpeg q=50".into(), jpeg(&marked, 50)),
+        ("jpeg q=30".into(), jpeg(&marked, 30)),
+        (
+            "resize 75%".into(),
+            marked.resize_exact(w * 3 / 4, h * 3 / 4, image::imageops::FilterType::Lanczos3),
+        ),
+        (
+            "resize 50%".into(),
+            marked.resize_exact(w / 2, h / 2, image::imageops::FilterType::Lanczos3),
+        ),
+        (
+            "resize 25%".into(),
+            marked.resize_exact(w / 4, h / 4, image::imageops::FilterType::Lanczos3),
+        ),
+        (
+            "crop 10%".into(),
+            marked.crop_imm(w / 20, h / 20, w * 9 / 10, h * 9 / 10),
+        ),
+        (
+            "crop 25%".into(),
+            marked.crop_imm(w / 8, h / 8, w * 3 / 4, h * 3 / 4),
+        ),
+        ("grayscale".into(), marked.grayscale()),
+        ("hflip".into(), marked.fliph()),
+        ("rot90".into(), marked.rotate90()),
+        ("brighten +2".into(), marked.brighten(2)),
+        ("brighten +5".into(), marked.brighten(5)),
+        ("brighten +8".into(), marked.brighten(8)),
+        ("brighten +12".into(), marked.brighten(12)),
+        ("darken -5".into(), marked.brighten(-5)),
+        ("contrast +10".into(), marked.adjust_contrast(10.0)),
+        ("jpeg q=60".into(), jpeg(&marked, 60)),
+        (
+            "resize50 + jpeg60".into(),
+            jpeg(&marked.resize_exact(w / 2, h / 2, image::imageops::FilterType::Lanczos3), 60),
+        ),
+        ("vflip".into(), marked.flipv()),
+        ("crop 15%".into(), marked.crop_imm(w*3/40, h*3/40, w*17/20, h*17/20)),
+        ("crop 20%".into(), marked.crop_imm(w/10, h/10, w*8/10, h*8/10)),
+        (
+            "resize50+bright+jpeg60".into(),
+            jpeg(
+                &marked
+                    .resize_exact(w / 2, h / 2, image::imageops::FilterType::Lanczos3)
+                    .brighten(12),
+                60,
+            ),
+        ),
+    ];
+
+    println!("{:<26} extracted", "transform");
+    println!("{}", "-".repeat(40));
+    for (name, img) in cases {
+        let ok = tm.decode(img).map(|s| s == payload).unwrap_or(false);
+        println!("{name:<26} {}", if ok { "YES" } else { "no" });
+    }
+}


### PR DESCRIPTION
Follow-up to #497. I had written that L2 robustness "requires running the TrustMark sidecar, which is the PR 8 deliverable". That was wrong: the ONNX models are public, and the measurement takes under an hour. So I ran it.

## L2 measured (TrustMark Variant::Q / Bch5, real ONNX models, upstream `ghost.png`)

| Transform | L2 | L3 (recall) |
|---|---|---|
| JPEG q=90→30 | YES | YES |
| Resize 75/50/25 % | YES | YES |
| Crop 10/15/20 % | YES | YES |
| **Crop 25 %** | **no** | YES |
| Grayscale, contrast +10 | YES | YES |
| **Horizontal mirror** | **YES** | **no** (21) |
| Vertical mirror, rot90 | no | no (52) |
| **Brighten +2/255** (invisible) | **no** | YES |

Three findings that no amount of paper-reading would have produced:

1. **L2 dies on a +2/255 brightness shift** while surviving JPEG q=30. Any auto-exposure capture tool, any light/dark theme, any normalization destroys the watermark. For agent screenshots this is not a theoretical case.
2. **L2 and L3 fail on *disjoint* transforms.** L2 survives horizontal mirror where L3 dies; L3 survives brightness and 25 % crop where L2 dies. This is the strongest possible justification for the layered model, and it is now measured rather than assumed. Neither layer makes the other redundant.
3. **Capacity is 61 bits, not 128.** `Version::Bch5.data_bits()` is 61 and any other length is rejected with `InvalidDataLength`. `TraceId` is resized accordingly in the plan, a constraint that belongs in the type on day one rather than being discovered in PR 8.

Also: watermarking is **not guaranteed on every carrier**. My synthetic 512×512 fails a clean roundtrip while the same image at 256×256 and `ghost.png` succeed. PR 8 therefore must verify extraction immediately after embedding and log failures, instead of assuming success. Cost: ~50 ms encode, ~30 ms decode, confirming sidecar and ruling out the blocking path.

## Two honesty corrections

- I had been comparing my macOS aarch64 deltas against the README's "6 MB", which is the **musl container image**. The actual release binary here measures **17.3 MB**. Mixing the two was sloppy, so the doc now states both and frames the costs as deltas (+40 % for C2PA, +69 % for TrustMark) rather than a bogus absolute ratio.
- The PR 1 acceptance criterion said "byte-identical binary", which is not actually checkable (build ids, paths). Replaced with what CI can assert: no new deps in `cargo tree`, and release size within 1 %.

Probe committed at `docs/design/assets/l2_watermark_robustness_probe.rs`, re-run from a clean crate to confirm it reproduces.
