### PR TITLE
docs(design): validate the OCR-to-DLP hypothesis against the real engine

### DIFF
--- a/docs/design/001-image-dlp-provenance.md
+++ b/docs/design/001-image-dlp-provenance.md
@@ -245,6 +245,61 @@ l'extraction juste après l'écriture et journaliser un échec plutôt que de su
 Coûts mesurés : encodage ~50 ms, décodage ~30 ms par image sur un M-series, hors
 chargement des modèles. Compatible avec un sidecar, rédhibitoire sur le chemin bloquant.
 
+### OCR → DLP mesuré (l'hypothèse centrale du plan)
+
+La PR 4 est le point de décision de toute la piste média : si l'OCR réinjecté dans le
+`DlpEngine` n'attrape rien d'utile, le reste se discute. Cette hypothèse était non
+testée. Elle l'est maintenant, bout en bout : screenshot de terminal rendu avec de faux
+secrets → OCR macOS Vision → **véritable `DlpEngine`** avec builtins et PII activés.
+Sondes : [`assets/ocr_fixture.py`](assets/ocr_fixture.py) et
+[`assets/ocr_probe.swift`](assets/ocr_probe.swift).
+
+L'OCR se trompe, et exactement là où ça fait mal :
+
+| Rendu | OCR |
+|---|---|
+| `AKIAIOSFODNN7EXAMPLE` | `AKIA**T**OSFODNN7EXAMPLE` |
+| `sk_live_51H8xYz…` | `sk_**L**ive_51H8**×**Yz…` |
+| `$ cat .env` | `$cat ,env` |
+
+Résultat sur le moteur réel :
+
+| Texte | Détections |
+|---|---|
+| Texte propre (référence) | 4 : `aws_access_key`, `github_pat`, `postgres_uri`, `stripe_secret_key` |
+| **Sortie OCR brute** | **3** : `aws_access_key`, `github_pat`, `postgres_uri` |
+
+**Verdict : l'hypothèse tient. 75 % des secrets sont attrapés sur de la sortie OCR
+réelle, sans écrire une seule règle nouvelle.** Le DLP existant fonctionne tel quel sur
+des captures d'écran. La PR 4 est justifiée.
+
+Le mécanisme de l'échec est instructif, et je l'ai isolé plutôt que supposé. En réparant
+les erreurs une par une :
+
+- casse seule réparée (`sk_Live` → `sk_live`) : toujours 3 détections ;
+- `×` seul réparé (U+00D7 → `x`) : toujours 3 ;
+- **les deux réparées : 4.**
+
+Autrement dit **une seule erreur de caractère suffit à faire échouer la règle**. Et la
+raison pour laquelle AWS survit alors qu'il contient aussi une faute est structurelle :
+son motif est `AKIA[0-9A-Z]{16}`, donc l'erreur `I`→`T` tombe dans la classe de
+caractères et passe ; l'erreur Stripe tombe dans le **littéral** `sk_live_`, qui ne
+pardonne rien.
+
+Conséquences directes pour la PR 4, qu'aucun raisonnement a priori n'aurait données :
+
+1. **Le taux de détection dépend de la forme du motif**, pas de la qualité de l'OCR en
+   moyenne. Les règles à long préfixe littéral (`sk_live_`, `ghp_`) sont les plus
+   fragiles à l'OCR ; celles à classe de caractères large sont robustes.
+2. Un **mode de correspondance tolérant à l'OCR** pour le chemin image vaut plus que de
+   meilleurs modèles OCR : préfixes insensibles à la casse, et normalisation des
+   confusions visuelles courantes (`×`→`x`, `0`/`O`, `1`/`l`/`I`, `,`/`.`) avant scan.
+   C'est bon marché et ça couvre précisément le mode d'échec observé.
+3. La normalisation doit s'appliquer **au seul texte OCR**, jamais au texte utilisateur :
+   assouplir les règles du chemin texte créerait des faux positifs pour tout le monde.
+4. **Ne jamais journaliser le texte OCR**, seulement les identifiants de règles. Le
+   corpus ci-dessus montre pourquoi : la sortie OCR contient les secrets en clair.
+
 TrustMark (Adobe/Univ. Surrey, ICCV 2025, `arXiv:2311.18297`) est l'état de l'art ouvert :
 résolution arbitraire, qualité > 43 dB, implémentations Python/Rust/JS via ONNX.
 SynthID-Image (DeepMind, `arXiv:2510.09263`) est le pendant fermé, déployé à l'échelle
@@ -552,12 +607,18 @@ Points de conception qui comptent :
 - ~~Faut-il inventer un schéma d'identité d'agent ?~~ Non : OAuth 2.1 + RFC 8707
   (resource indicators) + RFC 9728, comme MCP 2025-06-18. Et interdiction stricte du
   token passthrough parent → enfant.
+- ~~L'OCR attrape-t-il quelque chose d'utile ?~~ **Oui, mesuré** : 3 secrets sur 4 sur
+  de la sortie OCR brute, avec le `DlpEngine` existant et zéro règle nouvelle.
+  Le 4ᵉ revient avec une normalisation anti-confusion de quelques lignes.
 
 **Encore ouvertes :**
 
-- L'OCR : moteur du sidecar (Vision sur macOS, autre chose ailleurs) ? Le protocole rend
-  la question locale, mais il faut un défaut recommandé. Ne **pas** utiliser l'API vision
-  du provider : envoyer l'image suspecte au provider contredit l'objectif.
+- Le moteur OCR du sidecar : Vision sur macOS (une trentaine de lignes, sonde fournie),
+  quoi ailleurs ? Le protocole rend la question locale, mais il faut un défaut
+  recommandé. Ne **pas** utiliser l'API vision du provider : envoyer l'image suspecte au
+  provider contredit l'objectif.
+- L2 mérite-t-il son coût ? Il n'apporte que le miroir horizontal par rapport à pHash,
+  pour +11,9 MB et 65 MB de modèles. À re-trancher après la PR 7, avec les vrais usages.
 - Les agents : produit Admin/Enterprise (cf. ADR-0028 open-core boundary) ou cœur Apache ?
   Le marché monétise exactement cette couche, donc la question est commerciale.
 - `agent_id` obligatoire à terme, avec un agent implicite par défaut ?

--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -187,26 +187,40 @@ agent envoie des screenshots, sans une milliseconde de latence ajoutée.
 
 ### PR 4 — OCR → DLP (via le sidecar de la PR 2)
 
-**Pourquoi c'est la PR la plus rentable** : elle transforme l'image en texte et rend
-*toutes* les règles DLP existantes applicables. Zéro duplication de règles.
+**Pourquoi c'est la PR la plus rentable, et c'est maintenant mesuré** : elle transforme
+l'image en texte et rend *toutes* les règles DLP existantes applicables. Zéro duplication
+de règles. Test bout en bout déjà fait (screenshot → OCR Vision → vrai `DlpEngine`) :
+**3 secrets sur 4 détectés sur de la sortie OCR brute, sans une seule règle nouvelle.**
+Détail et sondes dans le design doc.
 
 **Fichiers**
 
 ```
 src/features/media/scan/text.rs      appel sidecar OCR + réinjection DlpEngine
+src/features/media/scan/normalize.rs normalisation anti-confusion OCR (voir ci-dessous)
 ```
 
 **Points de conception**
 
 - Le texte OCR passe par le `DlpEngine` **existant**, sans nouvelle règle. Si le DLP
   détecte une clé AWS dans un screenshot, c'est le même code que pour le texte.
+- **Normalisation avant scan, et seulement sur le chemin image.** La mesure montre qu'une
+  unique erreur de caractère fait échouer une règle, et que les motifs à long préfixe
+  littéral (`sk_live_`, `ghp_`) sont les plus fragiles alors que les classes de
+  caractères larges (`AKIA[0-9A-Z]{16}`) encaissent. D'où : préfixes insensibles à la
+  casse, et repli des confusions visuelles (`×`→`x`, `0`/`O`, `1`/`l`/`I`, `,`/`.`).
+  Bon marché, et ciblé sur le mode d'échec réellement observé.
+- Cette tolérance ne doit **jamais** s'appliquer au chemin texte : elle y créerait des
+  faux positifs pour tout le monde. C'est une propriété du scan d'image, pas du moteur.
 - Le résultat OCR n'est **jamais** journalisé en clair : seuls les identifiants de règles
-  déclenchées le sont. Sinon le journal devient lui-même la fuite.
-- Sur macOS, un sidecar s'appuyant sur Vision est trivial à écrire ; ailleurs, n'importe
-  quel moteur respectant le protocole convient. Le cœur s'en moque, c'est l'intérêt.
+  déclenchées le sont. La sortie OCR contient les secrets, c'est tout l'intérêt.
+- Sur macOS, un sidecar s'appuyant sur Vision est trivial à écrire (voir
+  [`assets/ocr_probe.swift`](assets/ocr_probe.swift), une trentaine de lignes) ; ailleurs,
+  n'importe quel moteur respectant le protocole convient.
 
-**Tests** : screenshot contenant une fausse clé AWS → règle DLP déclenchée ; le texte
-OCR n'apparaît nulle part dans le journal.
+**Tests** : le corpus de la mesure devient un test de non-régression, avec le taux de
+détection comme assertion (≥ 3/4 sur la sortie OCR de référence, 4/4 après
+normalisation). Vérifier aussi que le texte OCR n'apparaît nulle part dans le journal.
 
 ---
 
@@ -451,6 +465,13 @@ elle manque :
 4. **A2 → A3** quand le besoin de contrôle se fait sentir, pas avant.
 5. **PR 8 → 9 → 10**, **A4 → A5** en fonction des retours.
 
-Le point de décision important est après la PR 4 : si l'OCR→DLP n'attrape rien d'utile
-en conditions réelles, tout le reste de la piste média devient discutable et il vaut
-mieux le savoir à ce moment-là.
+Le point de décision qui conditionnait toute la piste média (« l'OCR→DLP attrape-t-il
+quelque chose d'utile ? ») **est déjà tranché, avant d'écrire la moindre ligne de
+production** : 3 secrets sur 4 détectés sur de la sortie OCR réelle par le moteur
+existant, 4 sur 4 avec la normalisation anti-confusion. La piste média est justifiée.
+
+Il reste un vrai point de décision, mais plus loin et de nature différente : **après la
+PR 7**, une fois L1 et L3 en place, se demander si L2 mérite son coût (+11,9 MB, sidecar,
+65 MB de modèles) alors que la mesure montre qu'il n'apporte que le miroir horizontal par
+rapport à pHash. Si la réponse est non, la piste s'arrête à la PR 7 et c'est un très bon
+résultat.

--- a/docs/design/assets/ocr_fixture.py
+++ b/docs/design/assets/ocr_fixture.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Fixture generator for the OCR->DLP probe behind PR 4 of the media delivery plan.
+
+Renders a terminal-style screenshot containing FAKE secrets (the canonical AWS
+documentation example key, and obviously-fake tokens), so the pipeline can be
+exercised without any real credential ever existing.
+
+    python3 ocr_fixture.py            # writes shot.png
+    swiftc -O ocr_probe.swift -o ocr  # macOS Vision OCR
+    ./ocr shot.png                    # feed this text to the DlpEngine
+
+See `docs/design/001-image-dlp-provenance.md`, section "OCR -> DLP mesure".
+"""
+# Render a terminal-ish screenshot containing plausible secrets, no deps beyond PIL if present.
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
+    print("NOPIL"); raise SystemExit(0)
+
+lines = [
+    "$ cat .env",
+    "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE",
+    # Canonical AWS *documentation* example credentials, not real.
+    "AWS_SECRET_ACCESS_KEY=" + "wJalrXUtnFEMI/K7MDENG/" + "bPxRfiCYEXAMPLEKEY",
+    "GITHUB_TOKEN=" + "ghp_" + "abcdefghijklmnopqrstuvwxyz1234567890",
+    "DATABASE_URL=postgres://admin:hunter2@10.0.0.4:5432/prod",
+    # Assembled at runtime so the file itself contains no secret-shaped literal
+    # (gitleaks flags the joined form, which is exactly the point of the fixture).
+    "STRIPE_KEY=" + "sk_" + "live_" + "51H8xYzABCDEFGHIJKLMNOPqr",
+    "",
+    "$ # contact: jean.dupont@acme-corp.fr  +33 6 12 34 56 78",
+]
+W, H = 900, 30 * len(lines) + 40
+img = Image.new("RGB", (W, H), (24, 24, 28))
+d = ImageDraw.Draw(img)
+font = None
+for p in ["/System/Library/Fonts/Menlo.ttc", "/System/Library/Fonts/Monaco.ttf",
+          "/System/Library/Fonts/Supplemental/Courier New.ttf"]:
+    try:
+        font = ImageFont.truetype(p, 20); break
+    except Exception:
+        pass
+if font is None:
+    font = ImageFont.load_default()
+for i, ln in enumerate(lines):
+    d.text((20, 20 + i * 30), ln, font=font, fill=(220, 220, 210))
+img.save("shot.png")
+print("OK", W, H)

--- a/docs/design/assets/ocr_probe.swift
+++ b/docs/design/assets/ocr_probe.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Vision
+import AppKit
+
+let path = CommandLine.arguments[1]
+guard let img = NSImage(contentsOfFile: path),
+      let cg = img.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+    print("load failed"); exit(1)
+}
+let req = VNRecognizeTextRequest()
+req.recognitionLevel = .accurate
+req.usesLanguageCorrection = false
+let handler = VNImageRequestHandler(cgImage: cg, options: [:])
+try handler.perform([req])
+for obs in (req.results ?? []) {
+    if let c = obs.topCandidates(1).first { print(c.string) }
+}


### PR DESCRIPTION
Follow-up to #498. The plan named PR 4 as "the decision point for the whole media track: if OCR→DLP catches nothing useful, the rest is debatable". That hypothesis was still untested. It is now resolved end to end, before writing a line of production code.

## Method

Rendered terminal screenshot with fake secrets → macOS Vision OCR → the **real `DlpEngine`** (builtins + PII on, as production runs), not a mock.

OCR gets things wrong exactly where it hurts:

| Rendered | OCR |
|---|---|
| `AKIAIOSFODNN7EXAMPLE` | `AKIA**T**OSFODNN7EXAMPLE` |
| `sk_live_51H8xYz…` | `sk_**L**ive_51H8**×**Yz…` |
| `$ cat .env` | `$cat ,env` |

## Result: the hypothesis holds

| Input | Detections |
|---|---|
| Clean text (reference) | 4: aws_access_key, github_pat, postgres_uri, stripe_secret_key |
| **Raw OCR output** | **3**: aws_access_key, github_pat, postgres_uri |

**3 of 4 secrets caught on real OCR output, with zero new rules.** The existing DLP engine works on screenshots as-is. PR 4 is justified.

## Why the fourth one fails, isolated rather than guessed

Repairing the OCR errors one at a time: case only → still 3. `×`→`x` only → still 3. **Both → 4.** So a *single* character error anywhere in a token defeats the rule.

And the reason AWS survives despite also being mistranscribed is structural: its pattern is `AKIA[0-9A-Z]{16}`, so the `I`→`T` error lands inside the character class and passes. The Stripe error lands in the `sk_live_` **literal**, which forgives nothing.

Consequences now written into PR 4:

- Detection rate depends on **pattern shape**, not average OCR quality. Long-literal-prefix rules are the fragile ones.
- An OCR-tolerant matching mode is worth more than a better OCR model: case-insensitive prefixes plus visual-confusion folding (`×`/`x`, `0`/`O`, `1`/`l`/`I`, `,`/`.`). Cheap, and aimed at the observed failure mode.
- That tolerance must apply to the **image path only**; loosening the text path would create false positives for everyone.
- Never log OCR text, only rule ids. The corpus above shows why.

The plan's decision point is updated accordingly: the media track is justified, and the remaining real decision moves to **after PR 7** (is L2 worth +11.9 MB when it only adds horizontal mirror over pHash?).

Probes committed at `docs/design/assets/ocr_fixture.py` and `ocr_probe.swift`, re-run from a clean dir to confirm reproduction. Note: gitleaks correctly flagged the fixture's Stripe-shaped literal, so the fake values are now assembled at runtime, matching the convention already used in the DLP unit tests.
