### PR TITLE
fix(policies): enforce decision token expiry and audience

### DIFF
--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -394,6 +394,9 @@ utile, avant même toute notion de contrôle.
 
 **Points de conception**
 
+- **Réutiliser `expires_at` des decision tokens**, qui existe déjà et est désormais
+  réellement vérifié (voir A3). Un second système de TTL parallèle serait une divergence
+  garantie.
 - **Le lease, pas le kill.** Un agent tient un bail à TTL qu'il renouvelle. S'il ne
   renouvelle pas, il expire. C'est le seul modèle qui survit au crash du superviseur :
   un agent orphelin ne peut pas brûler du budget indéfiniment parce que personne n'est
@@ -409,19 +412,43 @@ un parent qui expire fait expirer sa descendance.
 
 ### PR A3 — Budget et capacités hiérarchiques
 
-**Points de conception**
+**Ce qui existe déjà, vérifié dans le code** : `policies/decision_token` implémente
+littéralement un modèle boss/worker avec `issuer`, `audience` (glob), `expires_at`,
+HMAC-SHA256 sur les claims, et une séparation `DecisionToken` / `AgentVisibleToken` qui
+est exactement l'anti-passthrough recherché. Le socle est donc plus avancé que ce plan
+ne le supposait : A3 branche l'existant au lieu de l'inventer.
+
+**Deux failles trouvées et corrigées en amont de cette PR** (elles auraient rendu le
+modèle de sécurité décoratif) :
+
+1. **`expires_at` n'était jamais vérifié.** Un token expiré depuis 2020 routait vers
+   `BackendTarget::Real`, c'est-à-dire le backend *live*. La variante d'erreur `Expired`
+   existait mais n'était construite nulle part. Corrigé : `is_expired()` /
+   `check_not_expired()`, appelés depuis `resolve_backend()`, avec **fail-closed sur une
+   date malformée** (une expiration illisible ne doit pas valoir validité illimitée).
+2. **`audience` n'était vérifiable nulle part.** `route_by_decision_token()` ne reçoit
+   aucune identité d'agent, donc la claim ne pouvait structurellement pas être appliquée.
+   Ajout de `resolve_backend_for(agent_id)` et `route_by_decision_token_for()`, qui
+   valident intégrité + expiration + audience ensemble. Au passage, `worker-*` ne
+   matche plus le préfixe nu `worker-`, et une audience réduite à `*` ne matche plus
+   rien, puisqu'une audience qui matche tout équivaut à pas d'audience.
+
+**Points de conception restants**
 
 - Le budget d'un enfant est **prélevé sur celui du parent**, jamais additionnel. Sinon
   un agent qui se réplique contourne trivialement toute limite.
 - Les capacités (profil pledge) ne peuvent que se restreindre en descendant. Même
   propriété monotone que `Role::has_at_least`, à tester explicitement.
 - **Pas de token passthrough** parent → enfant, conformément à MCP 2025-06-18 et au
-  problème du *confused deputy*. L'enfant reçoit un jeton dérivé d'audience restreinte
-  via `policies/decision_token` qui existe déjà.
+  problème du *confused deputy*. L'enfant reçoit un jeton dérivé d'audience restreinte,
+  et c'est désormais réellement applicable puisque l'audience est enfin vérifiée.
+- Corollaire de la faille n° 1 : l'expiration des decision tokens est le **mécanisme de
+  lease de la PR A2**, déjà présent dans le format. A2 n'a pas à inventer un second
+  système de TTL, elle doit réutiliser celui-là.
 
 **Tests** : un enfant ne peut pas dépasser le budget de son parent, ni élargir ses
 capacités, ni réutiliser le jeton du parent. Ces trois tests sont le cœur du modèle de
-sécurité.
+sécurité. Les huit tests d'expiration et d'audience sont déjà écrits et passent.
 
 ---
 

--- a/src/features/policies/decision_token.rs
+++ b/src/features/policies/decision_token.rs
@@ -75,6 +75,14 @@ pub enum DecisionTokenError {
     /// Token has expired.
     #[error("decision token has expired")]
     Expired,
+    /// Token was minted for a different agent.
+    #[error("decision token audience '{audience}' does not match agent '{agent_id}'")]
+    AudienceMismatch {
+        /// Audience pattern carried by the token.
+        audience: String,
+        /// Agent identifier that presented the token.
+        agent_id: String,
+    },
 }
 
 /// Claims carried inside a decision token.
@@ -199,9 +207,64 @@ impl DecisionToken {
     /// # Errors
     ///
     /// Returns [`DecisionTokenError::IntegrityFailure`] if authentication
-    /// fails before resolving the backend.
+    /// fails before resolving the backend, or [`DecisionTokenError::Expired`]
+    /// if the `expires_at` claim is in the past.
     pub fn resolve_backend(&self) -> Result<BackendTarget, DecisionTokenError> {
         self.verify_integrity()?;
+        self.check_not_expired()?;
+        Ok(match self.claims.mode {
+            DecisionMode::Training => BackendTarget::Paper,
+            DecisionMode::Live => BackendTarget::Real,
+        })
+    }
+
+    /// Returns whether the `expires_at` claim is in the past.
+    ///
+    /// A token with no `expires_at` never expires. An unparseable timestamp is
+    /// treated as expired: a malformed expiry must not silently grant
+    /// unlimited validity.
+    pub fn is_expired(&self) -> bool {
+        let Some(raw) = self.claims.expires_at.as_deref() else {
+            return false;
+        };
+        match chrono::DateTime::parse_from_rfc3339(raw) {
+            Ok(deadline) => chrono::Utc::now() >= deadline.with_timezone(&chrono::Utc),
+            Err(_) => true,
+        }
+    }
+
+    /// Fails when the token has expired.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecisionTokenError::Expired`] if [`Self::is_expired`] holds.
+    pub fn check_not_expired(&self) -> Result<(), DecisionTokenError> {
+        if self.is_expired() {
+            return Err(DecisionTokenError::Expired);
+        }
+        Ok(())
+    }
+
+    /// Full validation for a request presented by `agent_id`.
+    ///
+    /// Checks integrity, expiry, and audience together, so a caller cannot
+    /// accidentally honour a token that was minted for a different agent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecisionTokenError::IntegrityFailure`] on a bad tag,
+    /// [`DecisionTokenError::Expired`] past `expires_at`, or
+    /// [`DecisionTokenError::AudienceMismatch`] when `agent_id` is outside the
+    /// audience pattern.
+    pub fn resolve_backend_for(&self, agent_id: &str) -> Result<BackendTarget, DecisionTokenError> {
+        self.verify_integrity()?;
+        self.check_not_expired()?;
+        if !self.matches_audience(agent_id) {
+            return Err(DecisionTokenError::AudienceMismatch {
+                audience: self.claims.audience.clone(),
+                agent_id: agent_id.to_string(),
+            });
+        }
         Ok(match self.claims.mode {
             DecisionMode::Training => BackendTarget::Paper,
             DecisionMode::Live => BackendTarget::Real,
@@ -218,13 +281,22 @@ impl DecisionToken {
     }
 
     /// Checks whether the given agent ID matches the audience pattern.
+    ///
+    /// The pattern is a trailing-`*` prefix glob (`trader-agent-*`) or an exact
+    /// match. A bare `*` matches nothing: an audience that matches everything
+    /// is indistinguishable from no audience at all, and silently granting it
+    /// would defeat the purpose of the claim.
     pub fn matches_audience(&self, agent_id: &str) -> bool {
-        // Simple glob: "trader-agent-*" matches "trader-agent-42"
-        if self.claims.audience.ends_with('*') {
-            let prefix = &self.claims.audience[..self.claims.audience.len() - 1];
-            agent_id.starts_with(prefix)
-        } else {
-            self.claims.audience == agent_id
+        if agent_id.is_empty() {
+            return false;
+        }
+        match self.claims.audience.strip_suffix('*') {
+            // A wildcard-only audience is refused rather than treated as "all".
+            Some("") => false,
+            // The prefix must be followed by at least one character, so
+            // "worker-*" does not match the bare prefix "worker-".
+            Some(prefix) => agent_id.len() > prefix.len() && agent_id.starts_with(prefix),
+            None => self.claims.audience == agent_id,
         }
     }
 }
@@ -235,6 +307,19 @@ impl DecisionToken {
 /// fails integrity verification.
 pub fn route_by_decision_token(token: &DecisionToken) -> BackendTarget {
     match token.resolve_backend() {
+        Ok(target) => target,
+        Err(_) => BackendTarget::Deny,
+    }
+}
+
+/// Routes a request based on the token's mode, scoped to the presenting agent.
+///
+/// Prefer this over [`route_by_decision_token`] wherever the agent identity is
+/// known: it is the only variant that can enforce the `audience` claim, and an
+/// audience that is never checked is not a security control.
+/// Returns [`BackendTarget::Deny`] on any validation failure.
+pub fn route_by_decision_token_for(token: &DecisionToken, agent_id: &str) -> BackendTarget {
+    match token.resolve_backend_for(agent_id) {
         Ok(target) => target,
         Err(_) => BackendTarget::Deny,
     }
@@ -417,5 +502,99 @@ mod tests {
         assert_eq!(deserialized.claims.mode, token.claims.mode);
         assert_eq!(deserialized.mac, token.mac);
         assert!(deserialized.verify_integrity().is_ok());
+    }
+}
+
+#[cfg(test)]
+mod expiry_and_audience_tests {
+    use super::*;
+
+    fn claims(audience: &str, expires_at: Option<&str>) -> DecisionClaims {
+        DecisionClaims {
+            mode: DecisionMode::Live,
+            issuer: "boss-agent".to_string(),
+            audience: audience.to_string(),
+            expires_at: expires_at.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn expired_token_is_denied() {
+        let token = DecisionToken::new("t".into(), claims("w-*", Some("2020-01-01T00:00:00Z")));
+        // Integrity still holds: the token is authentic, just no longer valid.
+        assert!(token.verify_integrity().is_ok());
+        assert!(token.is_expired());
+        assert_eq!(token.resolve_backend(), Err(DecisionTokenError::Expired));
+        assert_eq!(route_by_decision_token(&token), BackendTarget::Deny);
+    }
+
+    #[test]
+    fn future_expiry_is_accepted() {
+        let later = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        let token = DecisionToken::new("t".into(), claims("w-*", Some(&later)));
+        assert!(!token.is_expired());
+        assert_eq!(route_by_decision_token(&token), BackendTarget::Real);
+    }
+
+    #[test]
+    fn absent_expiry_never_expires() {
+        let token = DecisionToken::new("t".into(), claims("w-*", None));
+        assert!(!token.is_expired());
+    }
+
+    #[test]
+    fn malformed_expiry_is_treated_as_expired() {
+        // Fail closed: a malformed expiry must not grant unlimited validity.
+        let token = DecisionToken::new("t".into(), claims("w-*", Some("not-a-date")));
+        assert!(token.is_expired());
+        assert_eq!(route_by_decision_token(&token), BackendTarget::Deny);
+    }
+
+    #[test]
+    fn audience_prefix_requires_a_suffix() {
+        let token = DecisionToken::new("t".into(), claims("worker-*", None));
+        assert!(token.matches_audience("worker-1"));
+        assert!(token.matches_audience("worker-42"));
+        // The bare prefix is not a member of "worker-*".
+        assert!(!token.matches_audience("worker-"));
+        assert!(!token.matches_audience("workerX"));
+        assert!(!token.matches_audience(""));
+    }
+
+    #[test]
+    fn wildcard_only_audience_matches_nothing() {
+        let token = DecisionToken::new("t".into(), claims("*", None));
+        assert!(!token.matches_audience("anyone"));
+        assert_eq!(
+            route_by_decision_token_for(&token, "anyone"),
+            BackendTarget::Deny
+        );
+    }
+
+    #[test]
+    fn audience_is_enforced_when_routing_for_an_agent() {
+        let token = DecisionToken::new("t".into(), claims("worker-*", None));
+        assert_eq!(
+            route_by_decision_token_for(&token, "worker-7"),
+            BackendTarget::Real
+        );
+        assert_eq!(
+            route_by_decision_token_for(&token, "intruder-7"),
+            BackendTarget::Deny
+        );
+        assert!(matches!(
+            token.resolve_backend_for("intruder-7"),
+            Err(DecisionTokenError::AudienceMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn expiry_is_checked_before_audience_on_the_agent_path() {
+        let token =
+            DecisionToken::new("t".into(), claims("worker-*", Some("2020-01-01T00:00:00Z")));
+        assert_eq!(
+            token.resolve_backend_for("worker-7"),
+            Err(DecisionTokenError::Expired)
+        );
     }
 }


### PR DESCRIPTION
The media track of the plan got five rounds of empirical validation; the agent track had none. Closing that gap turned up two real bugs in `policies/decision_token`, so this PR fixes them rather than just noting them.

## 1. Expiry was never enforced

`DecisionClaims::expires_at` is signed into the HMAC, and `DecisionTokenError::Expired` exists. Nothing ever constructed it. Verified by probe:

```
integrity: Ok(())
resolve_backend on EXPIRED token (expired 2020): Ok(Real)
route_by_decision_token: Real
```

A token expired since 2020 routes to `BackendTarget::Real`, the **live** backend. For a boss/worker model where the whole point is that grob decides training vs live, that is the control failing open.

Fixed with `is_expired()` / `check_not_expired()`, called from `resolve_backend()`. A malformed timestamp is treated as **expired**, not as valid: an unparseable expiry must not grant unlimited validity.

## 2. Audience could not be enforced at all

`route_by_decision_token(token)` takes no agent identity, so the `audience` claim was structurally unenforceable at the routing boundary:

```
routing with audience "nobody-at-all": Real
```

Added `resolve_backend_for(agent_id)` and `route_by_decision_token_for()`, which validate integrity, expiry and audience together, so a caller cannot accidentally honour a token minted for another agent. Two glob sharp edges fixed while there:

- `worker-*` no longer matches the bare prefix `worker-` (it matched before).
- A lone `*` audience now matches **nothing**. An audience matching everything is indistinguishable from no audience, and silently granting it defeats the claim.

`route_by_decision_token` is kept for callers with no agent context, with docs pointing at the scoped variant.

## Impact on the plan

The existing code is further along than my plan assumed: `policies/decision_token` already implements boss/worker with issuer, audience, expiry, HMAC and a `DecisionToken`/`AgentVisibleToken` split that is exactly the anti-passthrough property MCP 2025-06-18 requires. So PR A3 wires up what exists instead of inventing it, and **PR A2 should reuse `expires_at` as its lease mechanism** rather than building a second TTL system.

8 new tests, 1723 total passing, clippy clean. No external callers of the changed functions, so no breakage.
