### PR TITLE
chore: release v0.36.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.87](https://github.com/azerozero/grob/compare/v0.36.86...v0.36.87) - 2026-08-04
+
+### Added
+
+- *(media)* cheap detectors for metadata leaks and appended payloads ([#504](https://github.com/azerozero/grob/pull/504))
+- *(media)* bounded decode, perceptual hashing, and observation journal ([#501](https://github.com/azerozero/grob/pull/501))
+
+### Other
+
+- *(design)* track delivery status in the media and agents plan ([#502](https://github.com/azerozero/grob/pull/502))
+
 ## [0.36.86](https://github.com/azerozero/grob/compare/v0.36.85...v0.36.86) - 2026-08-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.86"
+version = "0.36.87"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.86"
+version = "0.36.87"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.86 -> 0.36.87

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.87](https://github.com/azerozero/grob/compare/v0.36.86...v0.36.87) - 2026-08-04

### Added

- *(media)* cheap detectors for metadata leaks and appended payloads ([#504](https://github.com/azerozero/grob/pull/504))
- *(media)* bounded decode, perceptual hashing, and observation journal ([#501](https://github.com/azerozero/grob/pull/501))

### Other

- *(design)* track delivery status in the media and agents plan ([#502](https://github.com/azerozero/grob/pull/502))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).