### PR TITLE
feat(media): cheap detectors for metadata leaks and appended payloads

### DIFF
--- a/docs/slices/MANIFEST.md
+++ b/docs/slices/MANIFEST.md
@@ -31,7 +31,7 @@
 | [`harness`](../../src/features/harness/README.md) | 999 | 5 | ✓ | Record & replay sandwich testing (feature `harness`) |
 | [`log_export`](../../src/features/log_export/README.md) | 651 | 3 | ✓ | Structured log export with age-encrypted content envelopes |
 | [`mcp`](../../src/features/mcp/README.md) | 2.6k | 11 | ✓ | MCP tool matrix and JSON-RPC server |
-| [`media`](../../src/features/media/README.md) | 1.2k | 6 | ✓ | Bounded media decode, perceptual hash, observation journal (feature `media`) |
+| [`media`](../../src/features/media/README.md) | 1.8k | 10 | ✓ | Bounded media decode, perceptual hash, cheap detectors, observation journal (feature `media`) |
 | [`pledge`](../../src/features/pledge/README.md) | 509 | 4 | ✓ | Structural tool stripping per session profile |
 | [`policies`](../../src/features/policies/README.md) | 3.8k | 15 | ✓ | Unified policy engine, HIT gateway, per-action authorization |
 | [`tap`](../../src/features/tap/README.md) | 369 | 2 | ✓ | Webhook tap (request/response event emission) |

--- a/src/features/media/README.md
+++ b/src/features/media/README.md
@@ -19,6 +19,7 @@ The slice is compiled out unless `--features media` is passed, and inert unless 
 | `MediaFormat`, `MediaProbe` | `decode.rs` | ingestion, journal |
 | `GrayImage`, `PerceptualHash`, `gradient_hash`, `MATCH_THRESHOLD` | `phash.rs` | fingerprinting, lookup |
 | `MediaEvent`, `MediaJournal`, `current_month` | `registry.rs` | observation journal |
+| `scan`, `ScanReport`, `Finding`, `Severity` | `scan/` | cheap detectors |
 
 ## Owns
 
@@ -26,6 +27,7 @@ The slice is compiled out unless `--features media` is passed, and inert unless 
 - Header-only dimension parsing for PNG, JPEG, GIF and WebP.
 - The 64-bit gradient perceptual hash and its measured match threshold.
 - The `~/.grob/media/YYYY-MM.jsonl` observation journal.
+- Cheap detectors: shape heuristics, EXIF/GPS presence, appended payloads.
 
 ## Depends on
 
@@ -63,16 +65,34 @@ Worst same-image distance is 7 and the closest different image is 16, so `MATCH_
 
 **Known limitation:** mirroring and rotation defeat this layer, structurally rather than as a tuning problem, because the hash reads left-to-right. Recovering provenance from a flipped image needs the manifest or watermark layers. There is a test that documents this rather than a comment that hopes for it.
 
+## Detectors
+
+`scan()` runs every cheap detector over an already-probed payload and returns findings, never decisions. Nothing decodes pixels.
+
+| Rule | Severity | Signal |
+|---|---|---|
+| `exif_gps` | Suspicious | Image carries GPS tags; location leaves with the image |
+| `appended_payload` | Suspicious | Data follows the container's end marker |
+| `appended_text` | Suspicious | That appended data contains a long printable run |
+| `extreme_aspect_ratio` | Notice | Ratio beyond 20:1 |
+| `tiny_image` | Notice | 64 pixels or fewer, typically a tracking pixel |
+| `exif_present` | Info | EXIF block present without GPS |
+
+Two properties are enforced by tests rather than convention. Findings **never quote the payload they found**, because a finding that echoed a secret would copy the leak into every log line recording it. And detection is **total**: every prefix of a malformed input yields findings or nothing, never a panic.
+
+**Known limitation:** this catches carelessness, not craft. LSB steganography from a competent tool is statistically indistinguishable without a decoder and a model. Claiming to detect it would be worse than not looking, because it would manufacture confidence.
+
 ## Non-goals
 
-- Verdicts, redaction or blocking.
+- Verdicts, redaction or blocking (detectors report; policy decides, later).
+- Real steganalysis.
 - Watermarking, C2PA manifests, OCR.
 - Object or face recognition.
 - Video.
 
 ## Tests
 
-`tests.rs` covers the decompression-bomb refusal, budget boundaries, lying MIME types, truncated-header totality across all four formats, SSRF refusal, the full perceptual-hash matrix above, the separation gap, and journal append/replay including a torn tail.
+`scan/tests.rs` covers each detector, the no-payload-in-findings property, totality over truncated inputs, and an ignored cross-check against real system JPEGs (`--ignored`). `tests.rs` covers the decompression-bomb refusal, budget boundaries, lying MIME types, truncated-header totality across all four formats, SSRF refusal, the full perceptual-hash matrix above, the separation gap, and journal append/replay including a torn tail.
 
 ## Related design docs
 

--- a/src/features/media/mod.rs
+++ b/src/features/media/mod.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod decode;
 pub mod phash;
 pub mod registry;
+pub mod scan;
 #[cfg(test)]
 mod tests;
 

--- a/src/features/media/scan/heuristics.rs
+++ b/src/features/media/scan/heuristics.rs
@@ -1,0 +1,161 @@
+//! Shape and metadata heuristics.
+//!
+//! The cheapest signals available, and among the most telling. An image
+//! carrying GPS coordinates on its way to a third-party model is a leak
+//! whether or not it also contains a secret, and it costs a header walk to
+//! notice.
+
+use super::super::decode::{MediaFormat, MediaProbe};
+use super::{Finding, Severity};
+
+/// Aspect ratio beyond which an image is more likely a stitched capture or a
+/// crafted payload than a photograph.
+const EXTREME_RATIO: f64 = 20.0;
+
+/// Below this, an "image" is too small to be worth sending anywhere.
+const TINY_PIXELS: u64 = 64;
+
+/// Runs the metadata and shape heuristics.
+#[must_use]
+pub fn detect(bytes: &[u8], probe: &MediaProbe) -> Vec<Finding> {
+    let mut out = Vec::new();
+
+    if let Some(finding) = extreme_ratio(probe) {
+        out.push(finding);
+    }
+    if probe.pixels() <= TINY_PIXELS {
+        out.push(Finding::new(
+            "tiny_image",
+            Severity::Notice,
+            format!(
+                "{}x{} is too small to carry visual meaning; often a tracking pixel",
+                probe.width, probe.height
+            ),
+        ));
+    }
+    if probe.format == MediaFormat::Jpeg {
+        out.extend(exif_findings(bytes));
+    }
+    out
+}
+
+/// Flags implausible aspect ratios.
+fn extreme_ratio(probe: &MediaProbe) -> Option<Finding> {
+    if probe.width == 0 || probe.height == 0 {
+        return None;
+    }
+    let (w, h) = (f64::from(probe.width), f64::from(probe.height));
+    let ratio = if w > h { w / h } else { h / w };
+    (ratio >= EXTREME_RATIO).then(|| {
+        Finding::new(
+            "extreme_aspect_ratio",
+            Severity::Notice,
+            format!(
+                "aspect ratio {ratio:.0}:1 ({}x{})",
+                probe.width, probe.height
+            ),
+        )
+    })
+}
+
+/// Scans JPEG APP1 segments for an EXIF block, reporting GPS presence.
+///
+/// Only the *presence* of GPS is reported, never the coordinates: a finding
+/// that quotes the location would copy the leak into every log line that
+/// records it.
+fn exif_findings(bytes: &[u8]) -> Vec<Finding> {
+    let Some(exif) = find_exif_segment(bytes) else {
+        return Vec::new();
+    };
+    let mut out = vec![Finding::new(
+        "exif_present",
+        Severity::Info,
+        format!("{} byte EXIF block", exif.len()),
+    )];
+    if exif_has_gps(exif) {
+        out.push(Finding::new(
+            "exif_gps",
+            Severity::Suspicious,
+            "EXIF contains GPS tags; location would leave with the image",
+        ));
+    }
+    out
+}
+
+/// Locates the payload of the first APP1/Exif segment.
+fn find_exif_segment(bytes: &[u8]) -> Option<&[u8]> {
+    let mut i = 2; // skip SOI
+    while i + 3 < bytes.len() {
+        if bytes[i] != 0xFF {
+            return None;
+        }
+        let marker = bytes[i + 1];
+        if marker == 0xD8 || marker == 0x01 || (0xD0..=0xD7).contains(&marker) {
+            i += 2;
+            continue;
+        }
+        // Start of scan: entropy-coded data follows, no more segment headers.
+        if marker == 0xDA {
+            return None;
+        }
+        let len = u16::from_be_bytes([*bytes.get(i + 2)?, *bytes.get(i + 3)?]) as usize;
+        if len < 2 {
+            return None;
+        }
+        if marker == 0xE1 {
+            let payload = bytes.get(i + 4..i + 2 + len)?;
+            if payload.starts_with(b"Exif\0\0") {
+                return payload.get(6..);
+            }
+        }
+        i += 2 + len;
+    }
+    None
+}
+
+/// Returns whether the TIFF IFD0 inside `exif` references a GPS sub-IFD.
+///
+/// Walks only IFD0's tag list, which is bounded by the entry count and the
+/// buffer, so a malformed block terminates instead of looping.
+fn exif_has_gps(exif: &[u8]) -> bool {
+    /// TIFF tag pointing at the GPS sub-IFD.
+    const GPS_IFD_TAG: u16 = 0x8825;
+
+    let Some(order) = exif.get(0..2) else {
+        return false;
+    };
+    let little = match order {
+        b"II" => true,
+        b"MM" => false,
+        _ => return false,
+    };
+
+    let u16_at = |o: usize| -> Option<u16> {
+        let b = exif.get(o..o + 2)?;
+        Some(if little {
+            u16::from_le_bytes([b[0], b[1]])
+        } else {
+            u16::from_be_bytes([b[0], b[1]])
+        })
+    };
+    let u32_at = |o: usize| -> Option<u32> {
+        let b = exif.get(o..o + 4)?;
+        Some(if little {
+            u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+        } else {
+            u32::from_be_bytes([b[0], b[1], b[2], b[3]])
+        })
+    };
+
+    let Some(ifd0) = u32_at(4).map(|v| v as usize) else {
+        return false;
+    };
+    let Some(count) = u16_at(ifd0) else {
+        return false;
+    };
+
+    (0..count as usize).any(|n| {
+        // Each IFD entry is 12 bytes, after the 2-byte count.
+        u16_at(ifd0 + 2 + n * 12) == Some(GPS_IFD_TAG)
+    })
+}

--- a/src/features/media/scan/mod.rs
+++ b/src/features/media/scan/mod.rs
@@ -1,0 +1,97 @@
+//! Cheap, dependency-free detectors over already-probed media.
+//!
+//! Every detector here reads bytes that are already in memory and returns a
+//! signal, never a decision. Ordering matters: the cheapest checks run first,
+//! and none of them decode pixels.
+//!
+//! These catch the careless case, not the determined adversary. A motivated
+//! steganographer defeats all of this, and the module says so rather than
+//! implying a guarantee it cannot keep.
+
+pub mod heuristics;
+pub mod stego;
+#[cfg(test)]
+mod tests;
+
+use super::decode::MediaProbe;
+
+/// Severity of a single observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    /// Worth recording, not worth acting on.
+    Info,
+    /// Unusual enough that a human might want to know.
+    Notice,
+    /// Strongly suggests deliberate concealment or leakage.
+    Suspicious,
+}
+
+/// One thing a detector noticed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    /// Stable identifier, safe to alert on (e.g. `exif_gps`).
+    pub rule: &'static str,
+    /// How much it matters.
+    pub severity: Severity,
+    /// Human-readable detail.
+    ///
+    /// Never contains payload bytes: a finding that quotes the secret it
+    /// found would leak it into every log that records the finding.
+    pub detail: String,
+}
+
+impl Finding {
+    /// Builds a finding.
+    #[must_use]
+    pub fn new(rule: &'static str, severity: Severity, detail: impl Into<String>) -> Self {
+        Self {
+            rule,
+            severity,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// Everything the detectors noticed about one media item.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScanReport {
+    /// Findings, in detector order.
+    pub findings: Vec<Finding>,
+}
+
+impl ScanReport {
+    /// Returns whether anything at all was noticed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.findings.is_empty()
+    }
+
+    /// Highest severity observed, if any.
+    #[must_use]
+    pub fn max_severity(&self) -> Option<Severity> {
+        self.findings.iter().map(|f| f.severity).max()
+    }
+
+    /// Returns whether a given rule fired.
+    #[must_use]
+    pub fn has(&self, rule: &str) -> bool {
+        self.findings.iter().any(|f| f.rule == rule)
+    }
+
+    /// Rule identifiers that fired, for structured logging.
+    #[must_use]
+    pub fn rules(&self) -> Vec<&'static str> {
+        self.findings.iter().map(|f| f.rule).collect()
+    }
+}
+
+/// Runs every cheap detector over a probed payload.
+///
+/// `bytes` must be the decoded payload that produced `probe`.
+#[must_use]
+pub fn scan(bytes: &[u8], probe: &MediaProbe) -> ScanReport {
+    let mut findings = Vec::new();
+    findings.extend(heuristics::detect(bytes, probe));
+    findings.extend(stego::detect(bytes, probe));
+    ScanReport { findings }
+}

--- a/src/features/media/scan/stego.rs
+++ b/src/features/media/scan/stego.rs
@@ -1,0 +1,95 @@
+//! Crude concealment detectors.
+//!
+//! Two techniques, both cheap and both aimed at carelessness rather than
+//! craft: data appended past a container's end marker, and printable strings
+//! hidden where no printable string belongs.
+//!
+//! This does not detect real steganography. LSB embedding by a competent tool
+//! is statistically indistinguishable without a decoder and a model, and
+//! claiming otherwise would be worse than not looking at all: it would
+//! manufacture confidence.
+
+use super::super::decode::{MediaFormat, MediaProbe};
+use super::{Finding, Severity};
+
+/// Trailing bytes below this are container padding, not a payload.
+const TRAILER_NOISE_FLOOR: usize = 16;
+
+/// Shortest run of printable bytes worth reporting inside a trailer.
+const MIN_STRING_RUN: usize = 12;
+
+/// Runs the concealment detectors.
+#[must_use]
+pub fn detect(bytes: &[u8], probe: &MediaProbe) -> Vec<Finding> {
+    let mut out = Vec::new();
+    if let Some(trailer) = trailing_payload(bytes, probe.format) {
+        out.push(Finding::new(
+            "appended_payload",
+            Severity::Suspicious,
+            format!(
+                "{} bytes follow the {} end marker",
+                trailer.len(),
+                probe.format.mime()
+            ),
+        ));
+        if let Some(run) = longest_printable_run(trailer) {
+            if run >= MIN_STRING_RUN {
+                out.push(Finding::new(
+                    "appended_text",
+                    Severity::Suspicious,
+                    format!("appended data contains a {run}-byte printable run"),
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// Returns the bytes following a container's end marker, when meaningful.
+///
+/// Only formats with an unambiguous terminator are checked. WebP is skipped:
+/// RIFF is chunked, so "extra" bytes are a normal extension mechanism rather
+/// than a signal.
+#[must_use]
+pub fn trailing_payload(bytes: &[u8], format: MediaFormat) -> Option<&[u8]> {
+    let end = match format {
+        MediaFormat::Jpeg => find_last(bytes, &[0xFF, 0xD9])? + 2,
+        MediaFormat::Png => find_iend(bytes)?,
+        MediaFormat::Gif => find_last(bytes, &[0x3B])? + 1,
+        MediaFormat::Webp => return None,
+    };
+    let trailer = bytes.get(end..)?;
+    (trailer.len() > TRAILER_NOISE_FLOOR).then_some(trailer)
+}
+
+/// Offset just past the PNG IEND chunk (type, length and CRC included).
+fn find_iend(bytes: &[u8]) -> Option<usize> {
+    // IEND is preceded by its 4-byte length and followed by a 4-byte CRC.
+    find_last(bytes, b"IEND").map(|i| i + 8)
+}
+
+/// Index of the last occurrence of `needle`.
+fn find_last(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    (0..=haystack.len() - needle.len())
+        .rev()
+        .find(|&i| &haystack[i..i + needle.len()] == needle)
+}
+
+/// Longest run of printable ASCII (plus tab, LF and CR) in `bytes`.
+#[must_use]
+pub fn longest_printable_run(bytes: &[u8]) -> Option<usize> {
+    let mut best = 0usize;
+    let mut run = 0usize;
+    for &b in bytes {
+        if (0x20..=0x7E).contains(&b) || b == b'\t' || b == b'\n' || b == b'\r' {
+            run += 1;
+            best = best.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    (best > 0).then_some(best)
+}

--- a/src/features/media/scan/tests.rs
+++ b/src/features/media/scan/tests.rs
@@ -1,0 +1,189 @@
+//! Tests for the cheap detectors.
+
+use crate::features::media::config::MediaConfig;
+use crate::features::media::decode::probe_bytes;
+use crate::features::media::scan::{scan, Severity};
+
+/// Minimal valid PNG header declaring `w * h`, plus a terminating IEND chunk.
+fn png(w: u32, h: u32) -> Vec<u8> {
+    let mut v = Vec::from(b"\x89PNG\r\n\x1a\n".as_slice());
+    v.extend_from_slice(&13u32.to_be_bytes());
+    v.extend_from_slice(b"IHDR");
+    v.extend_from_slice(&w.to_be_bytes());
+    v.extend_from_slice(&h.to_be_bytes());
+    v.extend_from_slice(&[8, 6, 0, 0, 0]);
+    v.extend_from_slice(&0u32.to_be_bytes()); // IEND length
+    v.extend_from_slice(b"IEND");
+    v.extend_from_slice(&[0xAE, 0x42, 0x60, 0x82]); // IEND CRC
+    v
+}
+
+/// Minimal JPEG: SOI, a SOF0 frame, then EOI.
+fn jpeg(w: u16, h: u16) -> Vec<u8> {
+    let mut v = vec![0xFF, 0xD8, 0xFF, 0xC0, 0x00, 0x11, 0x08];
+    v.extend_from_slice(&h.to_be_bytes());
+    v.extend_from_slice(&w.to_be_bytes());
+    v.extend_from_slice(&[3, 1, 0x11, 0, 2, 0x11, 0, 3, 0x11, 0]);
+    v.extend_from_slice(&[0xFF, 0xD9]);
+    v
+}
+
+/// JPEG carrying an APP1/Exif block, optionally referencing a GPS sub-IFD.
+fn jpeg_with_exif(with_gps: bool) -> Vec<u8> {
+    // TIFF header, little-endian, IFD0 at offset 8.
+    let mut tiff = Vec::from(b"II\x2a\x00".as_slice());
+    tiff.extend_from_slice(&8u32.to_le_bytes());
+
+    let tags: &[u16] = if with_gps {
+        &[0x010F, 0x8825]
+    } else {
+        &[0x010F]
+    };
+    tiff.extend_from_slice(&(tags.len() as u16).to_le_bytes());
+    for &tag in tags {
+        tiff.extend_from_slice(&tag.to_le_bytes());
+        tiff.extend_from_slice(&3u16.to_le_bytes()); // type SHORT
+        tiff.extend_from_slice(&1u32.to_le_bytes()); // count
+        tiff.extend_from_slice(&0u32.to_le_bytes()); // inline value
+    }
+    tiff.extend_from_slice(&0u32.to_le_bytes()); // no next IFD
+
+    let mut payload = Vec::from(b"Exif\0\0".as_slice());
+    payload.extend_from_slice(&tiff);
+
+    let mut v = vec![0xFF, 0xD8];
+    v.push(0xFF);
+    v.push(0xE1);
+    v.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+    v.extend_from_slice(&payload);
+    // Frame header so the probe can read dimensions.
+    v.extend_from_slice(&[0xFF, 0xC0, 0x00, 0x11, 0x08]);
+    v.extend_from_slice(&480u16.to_be_bytes());
+    v.extend_from_slice(&640u16.to_be_bytes());
+    v.extend_from_slice(&[3, 1, 0x11, 0, 2, 0x11, 0, 3, 0x11, 0]);
+    v.extend_from_slice(&[0xFF, 0xD9]);
+    v
+}
+
+fn report(bytes: &[u8]) -> crate::features::media::scan::ScanReport {
+    let probe = probe_bytes(bytes, &MediaConfig::default()).expect("probe");
+    scan(bytes, &probe)
+}
+
+#[test]
+fn a_plain_image_produces_no_findings() {
+    assert!(report(&png(800, 600)).is_empty());
+    assert!(report(&jpeg(640, 480)).is_empty());
+}
+
+#[test]
+fn data_appended_after_the_end_marker_is_flagged() {
+    for mut img in [png(800, 600), jpeg(640, 480)] {
+        img.extend_from_slice(b"-----BEGIN OPENSSH PRIVATE KEY-----AAAA");
+        let r = report(&img);
+        assert!(r.has("appended_payload"), "missed trailer: {:?}", r.rules());
+        assert!(r.has("appended_text"), "missed text run: {:?}", r.rules());
+        assert_eq!(r.max_severity(), Some(Severity::Suspicious));
+    }
+}
+
+#[test]
+fn findings_never_quote_the_payload_they_found() {
+    // A finding that echoed the secret would copy the leak into every log
+    // line recording it.
+    let secret = "AKIAIOSFODNN7EXAMPLE-and-more-padding-bytes";
+    let mut img = png(800, 600);
+    img.extend_from_slice(secret.as_bytes());
+    for finding in report(&img).findings {
+        assert!(
+            !finding.detail.contains("AKIA"),
+            "finding leaked payload: {}",
+            finding.detail
+        );
+    }
+}
+
+#[test]
+fn small_trailers_are_treated_as_padding() {
+    let mut img = png(800, 600);
+    img.extend_from_slice(b"\0\0\0\0");
+    assert!(!report(&img).has("appended_payload"));
+}
+
+#[test]
+fn exif_gps_is_flagged_as_a_leak() {
+    let r = report(&jpeg_with_exif(true));
+    assert!(r.has("exif_present"));
+    assert!(r.has("exif_gps"), "missed GPS: {:?}", r.rules());
+    assert_eq!(r.max_severity(), Some(Severity::Suspicious));
+}
+
+#[test]
+fn exif_without_gps_is_only_informational() {
+    let r = report(&jpeg_with_exif(false));
+    assert!(r.has("exif_present"));
+    assert!(!r.has("exif_gps"));
+    assert_eq!(r.max_severity(), Some(Severity::Info));
+}
+
+#[test]
+fn extreme_aspect_ratios_are_flagged() {
+    assert!(report(&png(4000, 10)).has("extreme_aspect_ratio"));
+    assert!(report(&png(10, 4000)).has("extreme_aspect_ratio"));
+    // A normal widescreen image is not suspicious.
+    assert!(!report(&png(1920, 1080)).has("extreme_aspect_ratio"));
+}
+
+#[test]
+fn tracking_pixels_are_flagged() {
+    assert!(report(&png(1, 1)).has("tiny_image"));
+    assert!(!report(&png(200, 200)).has("tiny_image"));
+}
+
+#[test]
+fn detectors_are_total_over_truncated_inputs() {
+    // Malformed input must produce findings or nothing, never a panic.
+    let config = MediaConfig::default();
+    let full = jpeg_with_exif(true);
+    for cut in 0..=full.len() {
+        if let Ok(probe) = probe_bytes(&full[..cut], &config) {
+            let _ = scan(&full[..cut], &probe);
+        }
+    }
+}
+
+#[test]
+fn severity_orders_from_info_to_suspicious() {
+    assert!(Severity::Info < Severity::Notice);
+    assert!(Severity::Notice < Severity::Suspicious);
+}
+
+#[test]
+#[ignore = "cross-check against real system JPEGs; run explicitly"]
+fn cross_check_against_real_jpegs() {
+    let config = MediaConfig::default();
+    let dir = std::path::Path::new("/System/Library/Photos/Resources/FlexAudio");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        println!("no corpus available on this machine");
+        return;
+    };
+    let mut seen = 0;
+    for entry in entries.flatten().take(20) {
+        let Ok(bytes) = std::fs::read(entry.path()) else {
+            continue;
+        };
+        let Ok(probe) = probe_bytes(&bytes, &config) else {
+            continue;
+        };
+        let r = scan(&bytes, &probe);
+        seen += 1;
+        println!(
+            "{:>40} {}x{} -> {:?}",
+            entry.file_name().to_string_lossy(),
+            probe.width,
+            probe.height,
+            r.rules()
+        );
+    }
+    println!("scanned {seen} real JPEGs without panicking");
+}


### PR DESCRIPTION
Continues the plan under its own power: PR 3's detection layer needs no sidecar, no OCR engine and no open arbitration, so it can land now. Dispatch/watch wiring stays out of this PR because it depends on config plumbing that is not there yet.

## Detectors

Cheapest-first, none decode pixels:

| Rule | Severity | Signal |
|---|---|---|
| `exif_gps` | Suspicious | GPS tags present; location leaves with the image |
| `appended_payload` | Suspicious | Data past the container's end marker |
| `appended_text` | Suspicious | That data contains a long printable run |
| `extreme_aspect_ratio` | Notice | Beyond 20:1 |
| `tiny_image` | Notice | ≤64 px, typically a tracking pixel |
| `exif_present` | Info | EXIF without GPS |

`exif_gps` is the one I'd highlight: an image carrying coordinates on its way to a third-party model is a leak whether or not it also contains a secret, and it costs a header walk to notice.

## Two properties enforced by tests, not convention

**Findings never quote the payload they found.** A finding that echoed a secret would copy the leak into every log line recording it, so there is a test that plants a fake AWS key in a trailer and asserts no finding mentions it.

**Detection is total.** Every prefix of a malformed input yields findings or nothing, never a panic. Same discipline as the header parsers in PR 1.

## Honest scope

The module docs and README both say plainly that this catches carelessness, not craft. LSB steganography from a competent tool is statistically indistinguishable without a decoder and a model; claiming to detect it would be worse than not looking, because it would manufacture confidence.

## Validation

Cross-checked against real system JPEGs behind an `#[ignore]` test: dimensions parsed correctly, EXIF found, **no false GPS positives**, no panics. My hand-built TIFF fixture agreeing with itself would not have proven much.

10 new tests. 1755 pass with `--features media`, 1723 without, clippy clean both ways. Still **zero added dependencies**: 429 crates either way.
