### PR TITLE
test(media): kill 20 surviving mutants in the scan detectors

### DIFF
--- a/src/features/media/scan/heuristics.rs
+++ b/src/features/media/scan/heuristics.rs
@@ -159,3 +159,271 @@ fn exif_has_gps(exif: &[u8]) -> bool {
         u16_at(ifd0 + 2 + n * 12) == Some(GPS_IFD_TAG)
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::media::decode::MediaFormat;
+
+    fn probe(w: u32, h: u32) -> MediaProbe {
+        MediaProbe {
+            format: MediaFormat::Png,
+            width: w,
+            height: h,
+            byte_len: 1024,
+        }
+    }
+
+    #[test]
+    fn ratio_is_computed_as_the_longer_side_over_the_shorter() {
+        // Division, not multiplication: a 20:1 image trips, 19:1 does not,
+        // and orientation must not matter.
+        assert!(extreme_ratio(&probe(2000, 100)).is_some());
+        assert!(extreme_ratio(&probe(100, 2000)).is_some());
+        assert!(extreme_ratio(&probe(1900, 100)).is_none());
+        assert!(extreme_ratio(&probe(1920, 1080)).is_none());
+        assert!(extreme_ratio(&probe(500, 500)).is_none());
+    }
+
+    #[test]
+    fn ratio_threshold_is_inclusive_at_exactly_20() {
+        assert!(extreme_ratio(&probe(2000, 100)).is_some());
+        assert!(extreme_ratio(&probe(1999, 100)).is_none());
+    }
+
+    #[test]
+    fn degenerate_dimensions_do_not_divide_by_zero() {
+        // Either dimension zero must short-circuit, not produce infinity.
+        assert!(extreme_ratio(&probe(0, 100)).is_none());
+        assert!(extreme_ratio(&probe(100, 0)).is_none());
+        assert!(extreme_ratio(&probe(0, 0)).is_none());
+    }
+
+    /// Builds a JPEG whose APP1/Exif payload is exactly `payload`.
+    fn jpeg_with_app1(payload: &[u8]) -> Vec<u8> {
+        let mut v = vec![0xFF, 0xD8, 0xFF, 0xE1];
+        v.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+        v.extend_from_slice(payload);
+        v.extend_from_slice(&[0xFF, 0xD9]);
+        v
+    }
+
+    #[test]
+    fn exif_payload_is_located_past_the_six_byte_identifier() {
+        // Pins the Exif\0\0 skip: the returned slice must start at the TIFF
+        // header, not at the identifier.
+        let mut payload = Vec::from(b"Exif\0\0".as_slice());
+        payload.extend_from_slice(b"II\x2a\x00TIFFBODY");
+        let jpeg = jpeg_with_app1(&payload);
+        let exif = find_exif_segment(&jpeg).expect("exif");
+        assert!(exif.starts_with(b"II\x2a\x00"), "got {:?}", &exif[..4]);
+        assert_eq!(exif.len(), payload.len() - 6);
+    }
+
+    #[test]
+    fn app1_without_the_exif_identifier_is_not_exif() {
+        // XMP also lives in APP1; it must not be mistaken for EXIF.
+        let jpeg = jpeg_with_app1(b"http://ns.adobe.com/xap/1.0/\0<x:xmpmeta/>");
+        assert!(find_exif_segment(&jpeg).is_none());
+    }
+
+    #[test]
+    fn segment_walk_skips_over_intervening_segments() {
+        // Pins the 2 + len stride: an APP0/JFIF block before APP1 must be
+        // stepped over exactly, or the walk desynchronises and finds nothing.
+        let mut v = vec![0xFF, 0xD8];
+        let app0 = b"JFIF\0\x01\x02\0\0\x01\0\x01\0\0";
+        v.extend_from_slice(&[0xFF, 0xE0]);
+        v.extend_from_slice(&((app0.len() + 2) as u16).to_be_bytes());
+        v.extend_from_slice(app0);
+        let mut payload = Vec::from(b"Exif\0\0".as_slice());
+        payload.extend_from_slice(b"II\x2a\x00rest");
+        v.extend_from_slice(&[0xFF, 0xE1]);
+        v.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+        v.extend_from_slice(&payload);
+        v.extend_from_slice(&[0xFF, 0xD9]);
+
+        assert!(
+            find_exif_segment(&v).is_some(),
+            "APP0 stride desynchronised the walk"
+        );
+    }
+
+    #[test]
+    fn walk_stops_at_start_of_scan() {
+        // Past SOS the bytes are entropy-coded; treating them as segment
+        // headers would read noise as structure.
+        let mut v = vec![0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x02];
+        v.extend_from_slice(b"Exif\0\0II\x2a\x00");
+        assert!(find_exif_segment(&v).is_none());
+    }
+
+    #[test]
+    fn declared_segment_length_must_be_sane() {
+        // A length below 2 cannot include its own field; the walk must stop
+        // rather than step backwards forever.
+        let v = vec![0xFF, 0xD8, 0xFF, 0xE1, 0x00, 0x01, 0x00];
+        assert!(find_exif_segment(&v).is_none());
+    }
+
+    /// Little-endian TIFF block with the given IFD0 tags.
+    fn tiff(tags: &[u16], little: bool) -> Vec<u8> {
+        let mut t = Vec::from(if little {
+            &b"II\x2a\x00"[..]
+        } else {
+            &b"MM\x00\x2a"[..]
+        });
+        let push16 = |v: &mut Vec<u8>, x: u16| {
+            if little {
+                v.extend_from_slice(&x.to_le_bytes());
+            } else {
+                v.extend_from_slice(&x.to_be_bytes());
+            }
+        };
+        let push32 = |v: &mut Vec<u8>, x: u32| {
+            if little {
+                v.extend_from_slice(&x.to_le_bytes());
+            } else {
+                v.extend_from_slice(&x.to_be_bytes());
+            }
+        };
+        push32(&mut t, 8); // IFD0 offset
+        push16(&mut t, tags.len() as u16);
+        for &tag in tags {
+            push16(&mut t, tag);
+            push16(&mut t, 3);
+            push32(&mut t, 1);
+            push32(&mut t, 0);
+        }
+        push32(&mut t, 0);
+        t
+    }
+
+    #[test]
+    fn gps_tag_is_found_at_any_entry_index() {
+        // Pins the 12-byte entry stride: the tag must be found whether it is
+        // first, last, or in the middle of the IFD.
+        assert!(exif_has_gps(&tiff(&[0x8825], true)));
+        assert!(exif_has_gps(&tiff(&[0x010F, 0x8825], true)));
+        assert!(exif_has_gps(&tiff(&[0x010F, 0x0110, 0x8825], true)));
+        assert!(exif_has_gps(&tiff(&[0x8825, 0x010F, 0x0110], true)));
+    }
+
+    #[test]
+    fn absent_gps_tag_is_not_invented() {
+        assert!(!exif_has_gps(&tiff(&[0x010F], true)));
+        assert!(!exif_has_gps(&tiff(&[0x010F, 0x0110, 0x0112], true)));
+        assert!(!exif_has_gps(&tiff(&[], true)));
+        // 0x8824 and 0x8826 neighbour the GPS tag and must not match.
+        assert!(!exif_has_gps(&tiff(&[0x8824, 0x8826], true)));
+    }
+
+    #[test]
+    fn both_tiff_byte_orders_are_honoured() {
+        assert!(exif_has_gps(&tiff(&[0x010F, 0x8825], false)));
+        assert!(!exif_has_gps(&tiff(&[0x010F], false)));
+    }
+
+    #[test]
+    fn unknown_byte_order_is_refused() {
+        assert!(!exif_has_gps(b"XX\x2a\x00rest of block"));
+        assert!(!exif_has_gps(b""));
+        assert!(!exif_has_gps(b"I"));
+    }
+
+    #[test]
+    fn standalone_markers_are_stepped_over_by_exactly_two_bytes() {
+        // RST0-RST7, TEM and a stray SOI carry no length field. Each must
+        // advance the cursor by exactly 2, or the walk lands mid-marker and
+        // the EXIF block that follows is never found.
+        let mut payload = Vec::from(b"Exif\0\0".as_slice());
+        payload.extend_from_slice(b"II\x2a\x00rest");
+
+        for standalone in [0xD8u8, 0x01, 0xD0, 0xD3, 0xD7] {
+            let mut v = vec![0xFF, 0xD8, 0xFF, standalone];
+            v.extend_from_slice(&[0xFF, 0xE1]);
+            v.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+            v.extend_from_slice(&payload);
+            v.extend_from_slice(&[0xFF, 0xD9]);
+            assert!(
+                find_exif_segment(&v).is_some(),
+                "standalone marker 0x{standalone:02X} desynchronised the walk"
+            );
+        }
+    }
+
+    #[test]
+    fn markers_adjacent_to_the_standalone_range_still_carry_lengths() {
+        // 0xCF and 0xD9 bracket the RST range. Treating either as standalone
+        // would step 2 bytes into a length-bearing segment.
+        let mut payload = Vec::from(b"Exif\0\0".as_slice());
+        payload.extend_from_slice(b"II\x2a\x00rest");
+
+        // 0xCF is a length-bearing SOF-family marker; skipping it as if it
+        // were standalone would misread its length field as a marker.
+        let mut v = vec![0xFF, 0xD8, 0xFF, 0xCF, 0x00, 0x04, 0xAA, 0xBB];
+        v.extend_from_slice(&[0xFF, 0xE1]);
+        v.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+        v.extend_from_slice(&payload);
+        assert!(
+            find_exif_segment(&v).is_some(),
+            "length-bearing marker 0xCF was mis-stepped"
+        );
+    }
+
+    #[test]
+    fn consecutive_standalone_markers_advance_additively() {
+        // One standalone marker cannot distinguish `i += 2` from `i *= 2`,
+        // because the cursor starts at 2 and both yield 4. Two in a row can:
+        // additive reaches 6, multiplicative overshoots to 8.
+        let mut payload = Vec::from(b"Exif\0\0".as_slice());
+        payload.extend_from_slice(b"II\x2a\x00rest");
+
+        let mut v = vec![0xFF, 0xD8, 0xFF, 0xD0, 0xFF, 0xD1];
+        v.extend_from_slice(&[0xFF, 0xE1]);
+        v.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+        v.extend_from_slice(&payload);
+        v.extend_from_slice(&[0xFF, 0xD9]);
+
+        assert!(
+            find_exif_segment(&v).is_some(),
+            "cursor did not advance additively across two standalone markers"
+        );
+    }
+
+    #[test]
+    fn an_empty_segment_is_valid_and_stepped_over() {
+        // A declared length of exactly 2 is a well-formed segment with no
+        // payload. Rejecting it (rather than only lengths below 2) would
+        // abandon the walk before reaching the EXIF block that follows.
+        let mut payload = Vec::from(b"Exif\0\0".as_slice());
+        payload.extend_from_slice(b"II\x2a\x00rest");
+
+        let mut v = vec![0xFF, 0xD8, 0xFF, 0xE2, 0x00, 0x02];
+        v.extend_from_slice(&[0xFF, 0xE1]);
+        v.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+        v.extend_from_slice(&payload);
+        v.extend_from_slice(&[0xFF, 0xD9]);
+
+        assert!(
+            find_exif_segment(&v).is_some(),
+            "an empty but well-formed segment aborted the walk"
+        );
+    }
+
+    #[test]
+    fn a_lone_standalone_marker_run_terminates() {
+        // Nothing but standalone markers: the walk must reach the end and
+        // stop rather than loop or read past the buffer.
+        let v = vec![0xFF, 0xD8, 0xFF, 0xD0, 0xFF, 0xD1, 0xFF, 0xD2, 0xFF, 0xD3];
+        assert!(find_exif_segment(&v).is_none());
+    }
+
+    #[test]
+    fn truncated_tiff_blocks_do_not_panic() {
+        let full = tiff(&[0x010F, 0x8825], true);
+        for cut in 0..=full.len() {
+            let _ = exif_has_gps(&full[..cut]);
+        }
+    }
+}

--- a/src/features/media/scan/stego.rs
+++ b/src/features/media/scan/stego.rs
@@ -93,3 +93,111 @@ pub fn longest_printable_run(bytes: &[u8]) -> Option<usize> {
     }
     (best > 0).then_some(best)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// PNG whose IEND chunk ends at a known offset, followed by `trailer`.
+    fn png_with_trailer(trailer: &[u8]) -> (Vec<u8>, usize) {
+        let mut v = Vec::from(b"\x89PNG\r\n\x1a\n".as_slice());
+        v.extend_from_slice(&0u32.to_be_bytes());
+        v.extend_from_slice(b"IEND");
+        v.extend_from_slice(&[0xAE, 0x42, 0x60, 0x82]);
+        let end = v.len();
+        v.extend_from_slice(trailer);
+        (v, end)
+    }
+
+    #[test]
+    fn png_trailer_starts_exactly_after_the_iend_crc() {
+        // Pins the +8 offset: IEND's 4-byte type plus its 4-byte CRC. An
+        // off-by-any-amount would shift the returned slice.
+        let marker = b"0123456789ABCDEFGHIJ";
+        let (bytes, end) = png_with_trailer(marker);
+        let trailer = trailing_payload(&bytes, MediaFormat::Png).expect("trailer");
+        assert_eq!(trailer, marker);
+        assert_eq!(trailer.len(), bytes.len() - end);
+    }
+
+    #[test]
+    fn jpeg_trailer_starts_exactly_after_the_eoi_marker() {
+        // Pins the +2 offset past FF D9.
+        let mut bytes = vec![0xFF, 0xD8, 0xFF, 0xD9];
+        let marker = b"TRAILING-PAYLOAD-DATA";
+        bytes.extend_from_slice(marker);
+        let trailer = trailing_payload(&bytes, MediaFormat::Jpeg).expect("trailer");
+        assert_eq!(trailer, marker);
+    }
+
+    #[test]
+    fn gif_trailer_starts_exactly_after_the_terminator() {
+        // Pins the +1 offset past 0x3B.
+        let mut bytes = Vec::from(b"GIF89a".as_slice());
+        bytes.extend_from_slice(&[0, 0, 0, 0, 0x3B]);
+        let marker = b"TRAILING-PAYLOAD-DATA";
+        bytes.extend_from_slice(marker);
+        let trailer = trailing_payload(&bytes, MediaFormat::Gif).expect("trailer");
+        assert_eq!(trailer, marker);
+    }
+
+    #[test]
+    fn trailer_noise_floor_is_strictly_greater_than() {
+        // Exactly at the floor: padding. One byte more: a payload.
+        let (at_floor, _) = png_with_trailer(&[b'x'; TRAILER_NOISE_FLOOR]);
+        assert!(trailing_payload(&at_floor, MediaFormat::Png).is_none());
+
+        let (over, _) = png_with_trailer(&[b'x'; TRAILER_NOISE_FLOOR + 1]);
+        assert_eq!(
+            trailing_payload(&over, MediaFormat::Png).map(<[u8]>::len),
+            Some(TRAILER_NOISE_FLOOR + 1)
+        );
+    }
+
+    #[test]
+    fn webp_is_deliberately_exempt() {
+        // RIFF is chunked, so trailing bytes are a normal extension mechanism.
+        let mut bytes = Vec::from(b"RIFF____WEBPVP8 ".as_slice());
+        bytes.extend_from_slice(&[b'x'; 64]);
+        assert!(trailing_payload(&bytes, MediaFormat::Webp).is_none());
+    }
+
+    #[test]
+    fn find_last_returns_the_final_occurrence() {
+        assert_eq!(find_last(b"abcabcabc", b"abc"), Some(6));
+        assert_eq!(find_last(b"abc", b"abc"), Some(0));
+        assert_eq!(find_last(b"xxxabc", b"abc"), Some(3));
+    }
+
+    #[test]
+    fn find_last_handles_degenerate_inputs() {
+        // Needle longer than haystack must not underflow the range.
+        assert_eq!(find_last(b"ab", b"abc"), None);
+        assert_eq!(find_last(b"", b"a"), None);
+        assert_eq!(find_last(b"abc", b""), None);
+        assert_eq!(find_last(b"abc", b"z"), None);
+    }
+
+    #[test]
+    fn printable_run_counts_only_maximal_runs() {
+        assert_eq!(longest_printable_run(b"abc\0defgh"), Some(5));
+        assert_eq!(longest_printable_run(b"\0\0\0"), None);
+        assert_eq!(longest_printable_run(b""), None);
+        // Runs reset on a non-printable byte rather than accumulating.
+        assert_eq!(longest_printable_run(b"ab\0ab\0ab"), Some(2));
+    }
+
+    #[test]
+    fn printable_run_boundaries_are_exact() {
+        // 0x20 (space) and 0x7E (~) are printable; 0x1F and 0x7F are not.
+        assert_eq!(longest_printable_run(&[0x20, 0x7E]), Some(2));
+        assert_eq!(longest_printable_run(&[0x1F]), None);
+        assert_eq!(longest_printable_run(&[0x7F]), None);
+        // Whitespace counts, since it appears in real embedded text.
+        assert_eq!(longest_printable_run(b"a\tb\nc\rd"), Some(7));
+        // Each whitespace form individually, so none can be dropped silently.
+        assert_eq!(longest_printable_run(b"\t"), Some(1));
+        assert_eq!(longest_printable_run(b"\n"), Some(1));
+        assert_eq!(longest_printable_run(b"\r"), Some(1));
+    }
+}


### PR DESCRIPTION
CI's mutation job passed on #504, so I ran `cargo-mutants` locally over `scan/` to check whether that meant anything. It did not: **20 mutants survived**. The tests asserted that findings fired, never that the offset arithmetic producing them was correct.

Every survivor was the same class of bug, the kind that stays invisible: the JPEG segment walk could mis-stride and still look fine on my own fixtures, the PNG trailer offset could drift off the IEND CRC, the printable-run scan could accumulate across non-printable bytes.

## Tests that pin arithmetic instead of outcomes

- Trailer offsets pinned per format: IEND+8, EOI+2, GIF terminator+1.
- Aspect ratio as longer/shorter, inclusive exactly at 20, safe on zero dimensions.
- EXIF payload located past the `Exif` identifier; APP1-carrying-XMP correctly rejected as not-EXIF.
- Segment stride verified across an intervening APP0 block and across an empty-but-valid segment.
- GPS tag found at any IFD index, in both TIFF byte orders, with the tags neighbouring `0x8825` rejected.

## Two survivors that needed actual thought

`i += 2` and `i *= 2` are **indistinguishable** when the cursor starts at 2, which is why my first attempt failed to kill it. The test now uses two consecutive standalone markers, where additive reaches 6 and multiplicative overshoots to 8. Similarly `len < 2` versus `len == 2` needed a well-formed empty segment to separate them.

## Result

**20 missed → 0 missed** (49 caught, 3 unviable). 37 scan tests, 1782 passing with `--features media`, 1723 without, clippy clean.

Worth noting for the repo: the mutation gate passed a diff whose tests could not detect deliberate corruption of its own arithmetic. Green CI meant less here than it looked.
