### PR TITLE
docs(design): mark PR 3 delivered and record the mutation-testing lesson

### DIFF
--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -25,7 +25,8 @@
 |---|---|---|---|---|
 | 1 | Squelette `media` : décodage borné + pHash + journal | `media` | non | ✅ **livré** (#501) |
 | 2 | **Protocole sidecar** (fondation partagée) | `media` | non | à faire |
-| 3 | Détecteurs bon marché (heuristiques, stégano) + wiring async | `media` | non | à faire |
+| 3 | Détecteurs bon marché (heuristiques, stégano) | `media` | non | ✅ **livré** (#504, #505) |
+| 3b | Wiring async dans dispatch + events watch/tap | `media` | non | à faire |
 | 4 | OCR → DLP via sidecar | `media` | non | à faire |
 | 5 | Mode `blocking` + intégration policies | `media` | oui | à faire |
 | 6 | Provenance L1 (C2PA) + registre `trace_id` | sidecar, ou `media-c2pa` | non | à faire |
@@ -164,6 +165,17 @@ et son absence ne change rien au comportement du proxy.
 ---
 
 ### PR 3 — Détecteurs bon marché + branchement asynchrone
+
+> **✅ Détecteurs livrés (#504), durcis (#505).** Le wiring dispatch/watch est sorti de
+> cette PR (devenu 3b) : il dépend d'un plumbing de config qui n'existe pas encore, et
+> le mélanger à la couche de détection aurait fait une PR non testable isolément.
+>
+> Leçon de #505, qui vaut au-delà de ce slice : le job de mutation testing de la CI est
+> passé au vert sur #504, mais un `cargo-mutants` local sur `scan/` a trouvé **20 mutants
+> survivants**. Les tests vérifiaient que les findings se déclenchaient, jamais que
+> l'arithmétique d'offsets qui les produit était juste. Corrigé à **0 survivant**. À
+> retenir pour les PRs suivantes : sur du parsing d'offsets, tester le résultat ne teste
+> rien ; il faut épingler l'arithmétique.
 
 **Fichiers**
 


### PR DESCRIPTION
Keeps the plan truthful: PR 3's detectors are delivered (#504, hardened in #505), and the dispatch/watch wiring is split out as 3b because it depends on config plumbing that does not exist yet.

Also records the lesson from #505, which generalises beyond this slice: CI's mutation job went green on #504, but a local `cargo-mutants` run over `scan/` found 20 survivors. The tests checked that findings fired, never that the offset arithmetic producing them was correct. On offset parsing, asserting the outcome asserts almost nothing; the arithmetic has to be pinned. Worth having written down before PRs 4 and 6 do more byte-level work.
