### PR TITLE
test(media): close the mutation gap on perceptual hashing

### DIFF
--- a/src/features/media/phash.rs
+++ b/src/features/media/phash.rs
@@ -75,7 +75,12 @@ impl GrayImage {
     }
 
     /// Samples the luma value at `(x, y)`, clamped to the image bounds.
-    fn sample(&self, x: u32, y: u32) -> u8 {
+    ///
+    /// The clamp is defensive: [`downsample`] never asks for a coordinate
+    /// outside the image. It is kept, and tested directly, so that a future
+    /// change to the grid geometry fails a test instead of reading out of
+    /// bounds.
+    pub(crate) fn sample(&self, x: u32, y: u32) -> u8 {
         let x = x.min(self.width - 1) as usize;
         let y = y.min(self.height - 1) as usize;
         self.luma[y * self.width as usize + x]
@@ -127,10 +132,12 @@ pub fn gradient_hash(img: &GrayImage) -> PerceptualHash {
         for col in 0..GRID_W - 1 {
             let left = grid[row * GRID_W + col];
             let right = grid[row * GRID_W + col + 1];
-            bits <<= 1;
-            if left > right {
-                bits |= 1;
-            }
+            // Shift and set in one expression. Note that `|` and `^` are
+            // provably interchangeable here, because the low bit is always
+            // zero immediately after the shift; no test can distinguish them,
+            // so mutation testing reports that as a surviving mutant and it
+            // is a false positive rather than a coverage gap.
+            bits = (bits << 1) | u64::from(left > right);
         }
     }
     PerceptualHash(bits)
@@ -161,4 +168,45 @@ fn downsample(img: &GrayImage) -> [u8; GRID_W * GRID_H] {
         }
     }
     grid
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_clamps_to_the_last_valid_pixel() {
+        // Exercised directly because `downsample` never requests an
+        // out-of-range coordinate, so this bound is otherwise unobservable.
+        // An off-by-one here would read past the buffer the moment the grid
+        // geometry changes.
+        let img = GrayImage::new(2, 2, vec![10, 20, 30, 40]).expect("image");
+        assert_eq!(img.sample(0, 0), 10);
+        assert_eq!(img.sample(1, 0), 20);
+        assert_eq!(img.sample(0, 1), 30);
+        assert_eq!(img.sample(1, 1), 40);
+
+        // Past either edge clamps rather than wrapping or panicking.
+        assert_eq!(img.sample(2, 0), 20);
+        assert_eq!(img.sample(99, 0), 20);
+        assert_eq!(img.sample(0, 2), 30);
+        assert_eq!(img.sample(0, 99), 30);
+        assert_eq!(img.sample(99, 99), 40);
+        assert_eq!(img.sample(u32::MAX, u32::MAX), 40);
+    }
+
+    #[test]
+    fn sample_handles_single_pixel_and_single_axis_images() {
+        let one = GrayImage::new(1, 1, vec![7]).expect("image");
+        assert_eq!(one.sample(0, 0), 7);
+        assert_eq!(one.sample(u32::MAX, u32::MAX), 7);
+
+        let row = GrayImage::new(3, 1, vec![1, 2, 3]).expect("image");
+        assert_eq!(row.sample(2, 0), 3);
+        assert_eq!(row.sample(9, 9), 3);
+
+        let column = GrayImage::new(1, 3, vec![1, 2, 3]).expect("image");
+        assert_eq!(column.sample(0, 2), 3);
+        assert_eq!(column.sample(9, 9), 3);
+    }
 }

--- a/src/features/media/tests.rs
+++ b/src/features/media/tests.rs
@@ -531,6 +531,123 @@ fn mirroring_is_a_documented_limitation() {
 }
 
 #[test]
+fn matches_rejects_hashes_beyond_the_threshold() {
+    // Without this, `matches` could return true unconditionally and every
+    // test above would still pass: they only ever assert that similar images
+    // stay close, never that dissimilar ones are refused.
+    let base = PerceptualHash(0);
+    assert!(base.matches(PerceptualHash(0)));
+
+    // Exactly at the threshold matches; one bit further does not.
+    let at = PerceptualHash((1u64 << MATCH_THRESHOLD) - 1);
+    assert_eq!(base.distance(at), MATCH_THRESHOLD);
+    assert!(base.matches(at));
+
+    let over = PerceptualHash((1u64 << (MATCH_THRESHOLD + 1)) - 1);
+    assert_eq!(base.distance(over), MATCH_THRESHOLD + 1);
+    assert!(
+        !base.matches(over),
+        "one bit past the threshold must not match"
+    );
+
+    assert!(!base.matches(PerceptualHash(u64::MAX)));
+}
+
+#[test]
+fn display_and_hex_agree_and_are_not_empty() {
+    // Display is used in journals and diagnostics; an empty or default
+    // rendering would silently erase provenance identifiers.
+    for raw in [0u64, 1, 0xdead_beef, u64::MAX] {
+        let h = PerceptualHash(raw);
+        let shown = h.to_string();
+        assert_eq!(shown, h.to_hex());
+        assert_eq!(shown.len(), 16, "hash must render as 16 hex digits");
+        assert_eq!(u64::from_str_radix(&shown, 16).expect("hex"), raw);
+    }
+}
+
+#[test]
+fn luma_conversion_weights_the_channels_correctly() {
+    // Pins the BT.601 arithmetic and the stride over RGB triples: a wrong
+    // stride reads the wrong channel, and wrong weights flatten the image.
+    let gray = GrayImage::from_rgb(3, 1, &[255, 0, 0, 0, 255, 0, 0, 0, 255]).expect("rgb");
+    // Red 0.299, green 0.587, blue 0.114 of 255.
+    assert_eq!(gray.luma, vec![76, 150, 29]);
+
+    // Neutral colours map to themselves regardless of weighting.
+    let neutral = GrayImage::from_rgb(2, 1, &[0, 0, 0, 255, 255, 255]).expect("rgb");
+    assert_eq!(neutral.luma, vec![0, 255]);
+
+    // Pixel count must follow width * height, not width + height.
+    assert!(GrayImage::from_rgb(3, 2, &[128; 18]).is_some());
+    assert!(GrayImage::from_rgb(3, 2, &[128; 15]).is_none());
+}
+
+#[test]
+fn images_smaller_than_the_grid_are_sampled_without_panicking() {
+    // The 9x8 grid is larger than these images, so every cell samples past
+    // the edge. Clamping must hold: an off-by-one in the bound would index
+    // out of range, and folding the clamp differently would collapse
+    // distinct images onto the same hash.
+    let one = GrayImage::new(1, 1, vec![128]).expect("image");
+    assert_eq!(gradient_hash(&one).0, 0, "a single pixel has no gradient");
+
+    let two_by_one_dark_left = GrayImage::new(2, 1, vec![0, 255]).expect("image");
+    let two_by_one_dark_right = GrayImage::new(2, 1, vec![255, 0]).expect("image");
+    assert_ne!(
+        gradient_hash(&two_by_one_dark_left),
+        gradient_hash(&two_by_one_dark_right),
+        "clamping must not collapse opposite gradients onto one hash"
+    );
+
+    // A range of sub-grid sizes, all of which must complete.
+    for (w, h) in [(1, 1), (1, 8), (8, 1), (2, 3), (5, 5), (9, 8)] {
+        let img = GrayImage::new(w, h, vec![64; (w * h) as usize]).expect("image");
+        assert_eq!(gradient_hash(&img).0, 0);
+    }
+}
+
+#[test]
+fn hash_encodes_horizontal_gradients_not_a_constant() {
+    // A flat image has no left-to-right differences, so every comparison bit
+    // is zero. A gradient must produce a non-zero, direction-dependent hash.
+    let flat = GrayImage::new(16, 16, vec![128; 256]).expect("image");
+    assert_eq!(
+        gradient_hash(&flat).0,
+        0,
+        "flat image must hash to all zeros"
+    );
+
+    let mut ramp = Vec::with_capacity(256);
+    for _ in 0..16 {
+        for x in 0..16u32 {
+            ramp.push((x * 16) as u8);
+        }
+    }
+    // A strictly rising ramp makes every "left brighter than right" test
+    // false, so it also hashes to zero. That is correct, and it is the reason
+    // the direction matters: reversing the ramp must invert every bit.
+    let rising = GrayImage::new(16, 16, ramp.clone()).expect("image");
+    assert_eq!(gradient_hash(&rising).0, 0);
+
+    let falling_luma: Vec<u8> = ramp
+        .chunks_exact(16)
+        .flat_map(|row| row.iter().rev().copied())
+        .collect();
+    let falling = GrayImage::new(16, 16, falling_luma).expect("image");
+    assert_eq!(
+        gradient_hash(&falling).0,
+        u64::MAX,
+        "a strictly falling ramp must set every comparison bit"
+    );
+    assert_ne!(
+        gradient_hash(&rising),
+        gradient_hash(&falling),
+        "opposite gradients must not collide"
+    );
+}
+
+#[test]
 fn hash_renders_as_16_hex_digits() {
     assert_eq!(PerceptualHash(0).to_hex(), "0000000000000000");
     assert_eq!(PerceptualHash(u64::MAX).to_hex(), "ffffffffffffffff");


### PR DESCRIPTION
Completes the sweep started in #505 (`scan/`) and #507 (`decode.rs`). I had asserted `phash.rs` was "already covered"; `cargo-mutants` disagreed with **10 survivors**. I also checked `registry.rs` and `decision_token.rs` (the security fix from #500) in the same run: both came back clean, zero survivors.

## The one that matters

Replacing `matches` with a constant `true` survived every existing test. They only ever asserted that *similar* images stay close, never that *dissimilar* ones are refused, so the match threshold could have been silently meaningless while the suite stayed green.

## Tests added

- `matches` at exactly the threshold, and one bit past it.
- BT.601 luma weights and the RGB triple stride.
- Gradient direction: a flat image hashes to zero, a strictly falling ramp to all ones, and the two ramp directions cannot collide.
- `Display` agrees with `to_hex` and round-trips as 16 hex digits.
- Sub-grid images (1×1 through 9×8) sample without panicking.

## Two needed code changes, not tests

`bits <<= 1` followed by `bits |= 1` is indistinguishable from `^= 1`, so the shift-and-set is now a single expression. And `sample`'s clamp is unreachable from `downsample`, making it unobservable; it is now `pub(crate)` and tested directly, with a doc comment saying why the clamp is kept: a future change to the grid geometry should fail a test rather than read out of bounds.

## One survivor remains, and it is provably equivalent

After a left shift the low bit is zero, so `|` and `^` are identical — verified exhaustively, not assumed. No test can distinguish them. Documented in place so the next reader does not re-investigate it.

**10 missed → 1 provably-equivalent.** 1794 tests with `--features media`, 1723 without, clippy clean.

A test of mine was wrong again on first write: I asserted a rising ramp hashes to non-zero, but a monotonic rise makes every "left brighter than right" comparison false, so zero is correct. The test now asserts the real property (rising → 0, falling → all ones), which is strictly stronger.
