### PR TITLE
docs(media): record mutation coverage in the slice charter

### DIFF
--- a/src/features/media/README.md
+++ b/src/features/media/README.md
@@ -94,6 +94,26 @@ Two properties are enforced by tests rather than convention. Findings **never qu
 
 `scan/tests.rs` covers each detector, the no-payload-in-findings property, totality over truncated inputs, and an ignored cross-check against real system JPEGs (`--ignored`). `tests.rs` covers the decompression-bomb refusal, budget boundaries, lying MIME types, truncated-header totality across all four formats, SSRF refusal, the full perceptual-hash matrix above, the separation gap, and journal append/replay including a torn tail.
 
+## Mutation coverage
+
+Every file in the slice has been checked with `cargo-mutants`, because a passing
+test suite says nothing about whether the tests would notice a bug:
+
+| File | Survivors |
+|---|---|
+| `decode.rs` | 0 |
+| `scan/heuristics.rs`, `scan/stego.rs` | 0 |
+| `phash.rs` | 1, provably equivalent (`\|` and `^` are identical after a left shift) |
+| `registry.rs` | 0 |
+
+Two survivors could not be killed by adding tests, and both indicated a design
+problem rather than a coverage gap: a duplicated bounds check in `decode.rs` made
+the pre-decode guard unobservable, and a shift-then-set in `phash.rs` was
+indistinguishable from its xor equivalent. Both were fixed in the code.
+
+The lesson generalises to the rest of the media work: on byte-level parsing,
+asserting the outcome asserts almost nothing. The arithmetic has to be pinned.
+
 ## Related design docs
 
 - [`001-image-dlp-provenance.md`](../../../docs/design/001-image-dlp-provenance.md) — layered provenance model and the measurements behind it.


### PR DESCRIPTION
Records what #505, #507 and #508 established, so the next person does not have to rediscover it: every file in the slice is at zero surviving mutants, except one in `phash.rs` that is provably equivalent and documented as such.

Also states the general lesson in the charter, since PRs 4 and 6 will do more byte-level parsing: on offset arithmetic, asserting the outcome asserts almost nothing, and two of the survivors here could only be fixed by changing the design (a duplicated bounds check, and a shift-then-set indistinguishable from its xor form).
