### PR TITLE
feat: enforce the 100% doc coverage invariant with a lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@
 
 // NOTE: deny (not forbid) so that the few justified unsafe blocks can #[allow].
 #![deny(unsafe_code)]
+// The crate documents every public item. That was a convention enforced by
+// review alone, which is a slow and unreliable way to hold an invariant; the
+// lint makes an undocumented addition fail the build instead.
+#![deny(missing_docs)]
 
 use std::path::PathBuf;
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -271,6 +271,7 @@ pub use registry::ProviderRegistry;
 
 // ── Test mocks ───────────────────────────────────────────────────────────────
 
+/// Mock provider implementations for tests and downstream integration suites.
 #[cfg(any(test, feature = "test-util"))]
 pub mod mocks {
     use super::*;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -285,12 +285,14 @@ pub trait ProviderAvailability: Send + Sync {
 
 // ── Test Mocks ──
 
+/// Mock trait implementations for tests and downstream integration suites.
 #[cfg(any(test, feature = "test-util"))]
 pub mod mocks {
     use super::*;
 
     /// Mock router that always returns a fixed decision.
     pub struct MockRouter {
+        /// Model name returned by every routing decision.
         pub model_name: String,
     }
 


### PR DESCRIPTION
While checking that my ~40 new public items in the media slice honoured the repo's documented invariant, I noticed the invariant was not actually enforced anywhere.

AGENTS.md states the crate has **100% doc coverage**. Nothing checked it: no lint, no CI step. The property rested on review alone, which is a slow and unreliable way to hold something that every new public item can silently break.

`#![deny(missing_docs)]` makes an undocumented addition fail the build instead. Turning it on immediately found **three real gaps** that review had already let through, all in the `test-util` mock modules that downstream integration suites depend on:

- `providers::mocks` (module)
- `traits::mocks` (module)
- `MockRouter::model_name` (field)

The media slice itself was already clean, which is the answer to the question that led me here.

Verified across default, `--no-default-features`, `--features media`, and `--all-features`. The last one is what surfaced the gaps, since `test-util` is not in the default set: a single-configuration check would have kept reporting a green invariant that was not true.

1794 tests with the feature, 1723 without, clippy clean on `--all-features`, doc-tests green.
