### PR TITLE
chore: release v0.36.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.88](https://github.com/azerozero/grob/compare/v0.36.87...v0.36.88) - 2026-08-05
+
+### Added
+
+- enforce the 100% doc coverage invariant with a lint ([#510](https://github.com/azerozero/grob/pull/510))
+
+### Other
+
+- *(media)* record mutation coverage in the slice charter ([#509](https://github.com/azerozero/grob/pull/509))
+- *(media)* close the mutation gap on perceptual hashing ([#508](https://github.com/azerozero/grob/pull/508))
+- *(media)* close the mutation gap on the decode safety boundary ([#507](https://github.com/azerozero/grob/pull/507))
+- *(design)* mark PR 3 delivered and record the mutation-testing lesson ([#506](https://github.com/azerozero/grob/pull/506))
+- *(media)* kill 20 surviving mutants in the scan detectors ([#505](https://github.com/azerozero/grob/pull/505))
+
 ## [0.36.87](https://github.com/azerozero/grob/compare/v0.36.86...v0.36.87) - 2026-08-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.87"
+version = "0.36.88"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.87"
+version = "0.36.88"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.87 -> 0.36.88

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.88](https://github.com/azerozero/grob/compare/v0.36.87...v0.36.88) - 2026-08-05

### Added

- enforce the 100% doc coverage invariant with a lint ([#510](https://github.com/azerozero/grob/pull/510))

### Other

- *(media)* record mutation coverage in the slice charter ([#509](https://github.com/azerozero/grob/pull/509))
- *(media)* close the mutation gap on perceptual hashing ([#508](https://github.com/azerozero/grob/pull/508))
- *(media)* close the mutation gap on the decode safety boundary ([#507](https://github.com/azerozero/grob/pull/507))
- *(design)* mark PR 3 delivered and record the mutation-testing lesson ([#506](https://github.com/azerozero/grob/pull/506))
- *(media)* kill 20 surviving mutants in the scan detectors ([#505](https://github.com/azerozero/grob/pull/505))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).