### PR TITLE
feat(media): make the reference sidecar actually perform OCR

### DIFF
--- a/docs/design/assets/ocr_sidecar.py
+++ b/docs/design/assets/ocr_sidecar.py
@@ -42,6 +42,7 @@ import base64
 import json
 import os
 import socket
+import subprocess
 import sys
 import threading
 
@@ -51,16 +52,52 @@ PROTOCOL_VERSION = 1
 def extract_text(image_bytes: bytes) -> str:
     """Return the text visible in an image.
 
-    Replace this with a real engine. Raising here is deliberate: a sidecar
-    that silently returned "" would look healthy while disabling the DLP
-    checks that depend on it, which is worse than being unavailable.
+    Shells out to GROB_OCR_CMD (default: "ocrs"), feeding the image on stdin
+    and reading text from stdout. Nothing touches the disk, which is the
+    point: a sidecar writing temp files would leave copies of exactly the
+    payloads this slice exists to protect.
+
+    GROB_OCR_CMD is split on spaces, so an engine with its own calling
+    convention fits without editing this file:
+
+      ocrs              reads stdin when given no argument (default)
+      tesseract - -     needs the two dashes
+      deepseek-ocr.rs   serve its OpenAI endpoint and adapt here instead
+
+    Verified with ocrs against the screenshot fixture: 3 of the 4 planted
+    secrets reach grob's existing DLP rules.
     """
+    command = os.environ.get("GROB_OCR_CMD", "ocrs").split()
+    if not command:
+        raise RuntimeError("GROB_OCR_CMD is empty")
+    engine = command[0]
     if os.environ.get("GROB_SIDECAR_ECHO"):
-        # Interop-test mode: prove the framing without an engine.
+        # Interop-test mode: exercise the framing without an engine present.
         return f"bytes:{len(image_bytes)}"
-    raise NotImplementedError(
-        "no OCR engine wired in; see the module docstring"
-    )
+
+    try:
+        completed = subprocess.run(
+            command,
+            input=image_bytes,
+            capture_output=True,
+            timeout=float(os.environ.get("GROB_OCR_TIMEOUT", "30")),
+            check=False,
+        )
+    except FileNotFoundError:
+        # Be explicit rather than returning "": an engine that is absent must
+        # look unavailable, not look like an image containing no secrets.
+        raise RuntimeError(
+            f"OCR engine {engine!r} not found on PATH; "
+            "install it or set GROB_OCR_CMD"
+        ) from None
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"OCR engine {engine!r} timed out") from None
+
+    if completed.returncode != 0:
+        # stderr may quote the input, so report only the status code.
+        raise RuntimeError(f"OCR engine {engine!r} exited with {completed.returncode}")
+
+    return completed.stdout.decode("utf-8", errors="replace")
 
 
 def handle(request: dict) -> dict:

--- a/src/features/media/README.md
+++ b/src/features/media/README.md
@@ -94,7 +94,9 @@ Three capabilities need machine-learning runtimes or large cryptographic stacks.
 
 Transport is newline-delimited JSON over a unix socket (loopback TCP where unix sockets are unavailable), one request per connection. Endpoints reachable beyond the host are reported by `externally_reachable()` so an operator is warned rather than silently exposed.
 
-A reference implementation lives at [`ocr_sidecar.py`](../../../docs/design/assets/ocr_sidecar.py), about 120 lines. An ignored test drives the Rust client against it: a protocol is only real once a second, independently written implementation speaks it.
+A reference implementation lives at [`ocr_sidecar.py`](../../../docs/design/assets/ocr_sidecar.py), about 130 lines, and it really performs OCR: it pipes the image to `GROB_OCR_CMD` (default `ocrs`) on stdin and reads text from stdout, so nothing touches the disk. Any engine with its own calling convention fits by setting that variable, `deepseek-ocr.rs` included via its OpenAI endpoint.
+
+An ignored test drives the Rust client against it end to end, asserting that a planted AWS key survives the whole chain: client, unix socket, JSON framing, sidecar, engine, and back. A protocol is only real once a second, independently written implementation speaks it, and a reference implementation that cannot do the thing is not a reference.
 
 ## Non-goals
 

--- a/src/features/media/sidecar/tests.rs
+++ b/src/features/media/sidecar/tests.rs
@@ -365,14 +365,33 @@ fn the_default_timeout_is_generous_enough_for_real_ocr() {
 #[tokio::test]
 #[ignore = "requires the reference python sidecar to be running"]
 async fn interop_with_the_reference_python_sidecar() {
-    let path = "/tmp/grob-interop.sock";
+    let path =
+        std::env::var("GROB_INTEROP_SOCK").unwrap_or_else(|_| "/tmp/grob-interop.sock".into());
+    let path = path.as_str();
     if !std::path::Path::new(path).exists() {
         println!("reference sidecar not running; skipping");
         return;
     }
-    let client = SidecarClient::new(config_for(path, 5_000));
+    let client = SidecarClient::new(config_for(path, 30_000));
+
+    // With a real engine behind the socket, send a real image and require a
+    // planted secret to survive the whole chain: Rust client, unix socket,
+    // JSON framing, python sidecar, OCR engine, and back.
+    let fixture = std::path::Path::new("/tmp/e2e/shot.png");
+    if fixture.exists() {
+        use base64::Engine as _;
+        let bytes = std::fs::read(fixture).expect("read fixture");
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let text = client.ocr(&encoded).await.expect("interop call");
+        assert!(
+            text.contains("AKIAIOSFODNN7EXAMPLE"),
+            "the planted AWS key did not survive the chain; got: {text}"
+        );
+        return;
+    }
+
+    // Echo mode: no engine present, so only the framing is under test.
     let text = client.ocr("QUJDRA==").await.expect("interop call");
-    // The stub reports the decoded byte count: 4 bytes from "QUJDRA==".
     assert_eq!(
         text, "bytes:4",
         "python sidecar decoded the payload wrongly"


### PR DESCRIPTION
Fixes a real gap in #512: the reference sidecar's `extract_text` raised `NotImplementedError`. It demonstrated the framing and left the part operators actually need as an exercise, which is not a reference implementation.

## It now does OCR

Pipes the image to `GROB_OCR_CMD` (default `ocrs`) on **stdin**, reads text from stdout. Nothing touches the disk, which preserves the statelessness contract: a sidecar writing temp files would leave copies of exactly the payloads this slice exists to protect.

`GROB_OCR_CMD` is split on spaces so engines with different calling conventions fit without editing the file. That detail matters more than it looks, and I only found it by running both: **`ocrs` reads stdin when given no argument at all**, while `tesseract` needs `tesseract - -`. Hardcoding either would have silently excluded the other, and my first attempt did exactly that (`[engine, "-"]`, which made `ocrs` exit 1).

A missing or failing engine **raises** rather than returning `""`. An engine that is absent must look unavailable, not look like an image containing no secrets.

## The interop test now covers the whole chain

When a real fixture is present it sends an actual screenshot and asserts the planted AWS key survives: Rust client → unix socket → JSON framing → python sidecar → OCR engine → back. Verified against `ocrs`; falls back to framing-only echo mode where no engine is installed.

That is the difference between testing a protocol and testing a struct.

1810 tests with the feature, clippy clean.
