### PR TITLE
feat(media): make the media configuration reachable from config.toml

### DIFF
--- a/benches/routing.rs
+++ b/benches/routing.rs
@@ -41,6 +41,8 @@ fn make_router() -> Router {
         tool_layer: Default::default(),
         #[cfg(feature = "mcp")]
         mcp: Default::default(),
+        #[cfg(feature = "media")]
+        media: Default::default(),
         version: None,
         user: Default::default(),
         otel: Default::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,10 @@ pub struct AppConfig {
     #[cfg(feature = "mcp")]
     #[serde(default)]
     pub mcp: McpConfig,
+    /// Media inspection: bounded decoding, fingerprinting, sidecars.
+    #[cfg(feature = "media")]
+    #[serde(default)]
+    pub media: crate::features::media::config::MediaConfig,
     /// User-defined section preserved across preset applies
     #[serde(default)]
     pub user: UserConfig,

--- a/src/features/media/config.rs
+++ b/src/features/media/config.rs
@@ -21,6 +21,19 @@ pub enum MediaMode {
 }
 
 /// Media slice configuration.
+///
+/// Reachable from `~/.grob/config.toml` as `[media]`:
+///
+/// ```toml
+/// [media]
+/// mode = "async"          # off (default) | async
+/// max_bytes = 8388608
+/// max_pixels = 40000000
+/// fetch_remote = false    # leave off: fetching client URLs is an SSRF primitive
+///
+/// [media.sidecar.endpoints.ocr]
+/// unix = { path = "/tmp/grob-ocr.sock" }
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MediaConfig {
@@ -37,6 +50,8 @@ pub struct MediaConfig {
     pub fetch_remote: bool,
     /// Whether observations are appended to the media journal.
     pub journal: bool,
+    /// Out-of-process capabilities (OCR, watermarking, provenance).
+    pub sidecar: super::sidecar::SidecarConfig,
 }
 
 impl Default for MediaConfig {
@@ -47,6 +62,7 @@ impl Default for MediaConfig {
             max_pixels: DEFAULT_MAX_PIXELS,
             fetch_remote: false,
             journal: true,
+            sidecar: super::sidecar::SidecarConfig::default(),
         }
     }
 }

--- a/src/features/media/tests.rs
+++ b/src/features/media/tests.rs
@@ -717,6 +717,48 @@ fn replaying_an_absent_month_is_empty_not_an_error() {
 // --- config --------------------------------------------------------------
 
 #[test]
+fn an_operator_can_enable_the_slice_from_toml() {
+    // The point of this test: PRs 1 and 2 shipped these config structs, but
+    // nothing referenced them from the top-level Config, so no TOML file
+    // could reach them. A feature nobody can switch on is not shipped.
+    let toml = r#"
+[router]
+default = "smart"
+
+[media]
+mode = "async"
+max_bytes = 1048576
+max_pixels = 5000000
+fetch_remote = false
+
+[media.sidecar.endpoints.ocr]
+unix = { path = "/tmp/grob-ocr.sock" }
+"#;
+    let config: crate::config::AppConfig = toml::from_str(toml).expect("parse config");
+
+    assert!(config.media.is_enabled());
+    assert_eq!(config.media.max_bytes, 1_048_576);
+    assert_eq!(config.media.max_pixels, 5_000_000);
+    assert!(!config.media.fetch_remote);
+
+    use super::sidecar::Capability;
+    assert!(config.media.sidecar.is_enabled(Capability::Ocr));
+    assert!(!config.media.sidecar.is_enabled(Capability::Watermark));
+}
+
+#[test]
+fn an_absent_media_section_leaves_the_slice_off() {
+    // Every existing deployment has no [media] section, and must keep
+    // behaving exactly as before.
+    let minimal = "[router]\ndefault = \"smart\"\n";
+    let config: crate::config::AppConfig =
+        toml::from_str(minimal).expect("parse config without a media section");
+    assert!(!config.media.is_enabled());
+    assert!(!config.media.fetch_remote);
+    assert!(config.media.sidecar.endpoints.is_empty());
+}
+
+#[test]
 fn slice_is_inert_by_default() {
     let config = MediaConfig::default();
     assert!(!config.is_enabled(), "media must be off unless asked for");

--- a/src/routing/classify/tests.rs
+++ b/src/routing/classify/tests.rs
@@ -41,6 +41,8 @@ fn create_test_config() -> AppConfig {
         policies: vec![],
         #[cfg(feature = "mcp")]
         mcp: Default::default(),
+        #[cfg(feature = "media")]
+        media: Default::default(),
         tool_layer: Default::default(),
         tee: Default::default(),
         fips: Default::default(),

--- a/src/routing/endpoints.rs
+++ b/src/routing/endpoints.rs
@@ -424,6 +424,8 @@ mod tests {
             harness: Default::default(),
             #[cfg(feature = "mcp")]
             mcp: Default::default(),
+            #[cfg(feature = "media")]
+            media: Default::default(),
         }
     }
 

--- a/tests/helpers/fixtures.rs
+++ b/tests/helpers/fixtures.rs
@@ -169,5 +169,7 @@ pub fn test_app_config() -> grob::cli::AppConfig {
         harness: Default::default(),
         #[cfg(feature = "mcp")]
         mcp: Default::default(),
+        #[cfg(feature = "media")]
+        media: Default::default(),
     }
 }

--- a/tests/integration/http_test.rs
+++ b/tests/integration/http_test.rs
@@ -139,6 +139,8 @@ api_key = "my-secret-key"
             harness: Default::default(),
             #[cfg(feature = "mcp")]
             mcp: Default::default(),
+            #[cfg(feature = "media")]
+            media: Default::default(),
         };
 
         let router = grob::routing::classify::Router::new(config);
@@ -210,6 +212,8 @@ api_key = "my-secret-key"
             harness: Default::default(),
             #[cfg(feature = "mcp")]
             mcp: Default::default(),
+            #[cfg(feature = "media")]
+            media: Default::default(),
         };
 
         let router = grob::routing::classify::Router::new(config);

--- a/tests/integration/server_test.rs
+++ b/tests/integration/server_test.rs
@@ -421,6 +421,8 @@ mod tests {
             harness: Default::default(),
             #[cfg(feature = "mcp")]
             mcp: Default::default(),
+            #[cfg(feature = "media")]
+            media: Default::default(),
         })
     }
 

--- a/tests/unit/router_test.rs
+++ b/tests/unit/router_test.rs
@@ -48,6 +48,8 @@ mod tests {
             harness: Default::default(),
             #[cfg(feature = "mcp")]
             mcp: Default::default(),
+            #[cfg(feature = "media")]
+            media: Default::default(),
         }
     }
 


### PR DESCRIPTION
PRs 1 and 2 shipped `MediaConfig` and `SidecarConfig`. Nothing referenced them from `AppConfig`.

```
$ grep -rn "MediaConfig\|SidecarConfig" src/ --include=*.rs | grep -v "src/features/media/"
$
```

No TOML file could reach either, so **no operator could switch any of it on**. Everything I built in those two PRs was unreachable configuration.

The test suite could not have caught it: every test constructs the config in Rust rather than parsing it, so the structs looked exercised while the path an operator actually uses did not exist.

## The fix

A `[media]` section on `AppConfig`, feature-gated exactly like `[mcp]`, with sidecar endpoints nested under it:

```toml
[media]
mode = "async"
fetch_remote = false     # leave off: fetching client URLs is an SSRF primitive

[media.sidecar.endpoints.ocr]
unix = { path = "/tmp/grob-ocr.sock" }
```

Plus a doc example on `MediaConfig` so the shape is discoverable from the type rather than from this PR description.

## Two tests, testing the property rather than the structs

- Parse that TOML and assert the slice comes out enabled with its OCR sidecar configured.
- Parse a config with **no** `[media]` section and assert everything stays off. That is what every existing deployment looks like, and it must keep behaving identically.

1812 tests with the feature, 1723 without, clippy clean on default, `--features media` and `--all-features`.
