### PR TITLE
feat(media): request-path entry point for out-of-band inspection

### DIFF
--- a/src/features/media/README.md
+++ b/src/features/media/README.md
@@ -21,6 +21,7 @@ The slice is compiled out unless `--features media` is passed, and inert unless 
 | `MediaEvent`, `MediaJournal`, `current_month` | `registry.rs` | observation journal |
 | `scan`, `ScanReport`, `Finding`, `Severity` | `scan/` | cheap detectors |
 | `SidecarClient`, `SidecarConfig`, `Endpoint`, `Capability` | `sidecar/` | out-of-process capabilities |
+| `observe_request`, `collect_inline_media` | `observe.rs` | request-path entry point |
 
 ## Owns
 
@@ -83,6 +84,16 @@ Worst same-image distance is 7 and the closest different image is 16, so `MATCH_
 Two properties are enforced by tests rather than convention. Findings **never quote the payload they found**, because a finding that echoed a secret would copy the leak into every log line recording it. And detection is **total**: every prefix of a malformed input yields findings or nothing, never a panic.
 
 **Known limitation:** this catches carelessness, not craft. LSB steganography from a competent tool is statistically indistinguishable without a decoder and a model. Claiming to detect it would be worse than not looking, because it would manufacture confidence.
+
+## Observing a request
+
+`observe_request` is the entry point from the request path, and it **returns `()`**. That is the guarantee rather than a convention: a caller cannot await a verdict that does not exist, so no later refactor can quietly make inspection blocking. It lifts the inline images out of the request, hands them to a detached task, and returns. A test asserts the call itself completes in under 20 ms while the journal entry appears afterwards.
+
+Remote (URL) blocks are skipped rather than recorded. This slice never fetches them, and journaling an unfetched URL would claim knowledge of bytes nobody has seen.
+
+One image being refused does not stop the others from being inspected, which a test pins with a lying MIME type and a decompression bomb sitting in front of a valid PNG.
+
+Fingerprints are currently recorded as **absent** rather than faked: reaching pixels needs an image decoder, this slice links none on purpose, and that capability arrives over the sidecar protocol alongside OCR. A placeholder fingerprint would collide with every other undecodable image, which is worse than admitting there is none. Shape, format and findings are journaled meanwhile, and they are what an operator asks for first.
 
 ## Sidecars
 

--- a/src/features/media/mod.rs
+++ b/src/features/media/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod config;
 pub mod decode;
+pub mod observe;
 pub mod phash;
 pub mod registry;
 pub mod scan;

--- a/src/features/media/observe.rs
+++ b/src/features/media/observe.rs
@@ -1,0 +1,328 @@
+//! Entry point from the request path into the media slice.
+//!
+//! Deliberately not wired *inside* the dispatch functions. The whole promise
+//! of `mode = "async"` is that inspection adds nothing to the request path,
+//! and the cheapest way to keep that promise is a function that borrows the
+//! request, copies out the few payloads it cares about, and returns `()`.
+//!
+//! The return type is the guarantee: a caller cannot await a verdict that
+//! does not exist, so no future refactor can quietly make inspection blocking.
+
+use super::config::{MediaConfig, MediaMode};
+use super::decode::probe;
+use super::phash::{gradient_hash, GrayImage};
+use super::registry::{MediaEvent, MediaJournal};
+use super::scan::scan;
+use super::MediaRef;
+use crate::models::{CanonicalRequest, ContentBlock, KnownContentBlock, MessageContent};
+use std::path::PathBuf;
+
+/// One image lifted out of a request, owned so the request can be released.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingMedia {
+    /// Base64 payload exactly as received.
+    pub payload: String,
+    /// Declared MIME type, a hint rather than a proof.
+    pub declared_type: Option<String>,
+}
+
+/// Collects the inline images carried by a request.
+///
+/// Remote (URL) blocks are skipped: this slice never fetches them, and
+/// recording an unfetched URL as an observation would be a lie.
+#[must_use]
+pub fn collect_inline_media(request: &CanonicalRequest) -> Vec<PendingMedia> {
+    let mut out = Vec::new();
+    for message in &request.messages {
+        let MessageContent::Blocks(blocks) = &message.content else {
+            continue;
+        };
+        for block in blocks {
+            let ContentBlock::Known(KnownContentBlock::Image { source }) = block else {
+                continue;
+            };
+            let Some(MediaRef::Inline {
+                data,
+                declared_type,
+            }) = MediaRef::from_image_source(source)
+            else {
+                continue;
+            };
+            out.push(PendingMedia {
+                payload: data.to_string(),
+                declared_type: declared_type.map(str::to_string),
+            });
+        }
+    }
+    out
+}
+
+/// Inspects a request's images out of band.
+///
+/// Returns immediately, always. Inspection happens on a detached task, so a
+/// slow or failing inspection can delay nothing and block nothing.
+///
+/// `tenant` and `model` are recorded in the journal to make an observation
+/// attributable; they are never handed to a sidecar.
+pub fn observe_request(
+    request: &CanonicalRequest,
+    config: &MediaConfig,
+    home: PathBuf,
+    tenant: Option<String>,
+) {
+    if !matches!(config.mode, MediaMode::Async) {
+        return;
+    }
+    let pending = collect_inline_media(request);
+    if pending.is_empty() {
+        return;
+    }
+
+    let config = config.clone();
+    let model = request.model.clone();
+    tokio::spawn(async move {
+        inspect(pending, config, home, tenant, model);
+    });
+}
+
+/// Probes, fingerprints and journals a batch of images.
+///
+/// Every failure is swallowed on purpose: this runs detached, behind the
+/// request that already succeeded. A malformed image is a fact to record, not
+/// a reason to make noise on a path nobody is waiting on.
+fn inspect(
+    pending: Vec<PendingMedia>,
+    config: MediaConfig,
+    home: PathBuf,
+    tenant: Option<String>,
+    model: String,
+) {
+    let mut journal = if config.journal {
+        MediaJournal::open(&home).ok()
+    } else {
+        None
+    };
+
+    for item in pending {
+        let media = MediaRef::Inline {
+            data: &item.payload,
+            declared_type: item.declared_type.as_deref(),
+        };
+        let Ok((bytes, probed)) = probe(media, &config) else {
+            continue;
+        };
+
+        let report = scan(&bytes, &probed);
+        if !report.is_empty() {
+            tracing::info!(
+                rules = ?report.rules(),
+                format = probed.format.mime(),
+                "media scan findings"
+            );
+        }
+
+        let Some(journal) = journal.as_mut() else {
+            continue;
+        };
+        let mut event = MediaEvent::observed(&probed).with_model(model.clone());
+        if let Some(gray) = decode_to_gray(&bytes, &probed) {
+            event = event.with_phash(gradient_hash(&gray));
+        }
+        if let Some(tenant) = tenant.clone() {
+            event = event.with_tenant(tenant);
+        }
+        let _ = journal.append(&event);
+    }
+}
+
+/// Produces the luma buffer the fingerprint needs.
+///
+/// This slice links no image decoder, deliberately: PR 1 shipped with zero
+/// added dependencies and the decompression-bomb guard exists precisely
+/// because decoders are where the risk lives. Fingerprinting therefore waits
+/// for the decode capability to arrive over the sidecar protocol, alongside
+/// OCR and watermarking.
+///
+/// Until then the observation is still journaled, with the fingerprint marked
+/// absent rather than faked. Shape, format and findings are the parts an
+/// operator asks for first.
+fn decode_to_gray(_bytes: &[u8], _probed: &super::decode::MediaProbe) -> Option<GrayImage> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{ImageSource, Message};
+    use base64::Engine as _;
+
+    fn png(w: u32, h: u32) -> Vec<u8> {
+        let mut v = Vec::from(b"\x89PNG\r\n\x1a\n".as_slice());
+        v.extend_from_slice(&13u32.to_be_bytes());
+        v.extend_from_slice(b"IHDR");
+        v.extend_from_slice(&w.to_be_bytes());
+        v.extend_from_slice(&h.to_be_bytes());
+        v.extend_from_slice(&[8, 6, 0, 0, 0]);
+        v.extend_from_slice(&0u32.to_be_bytes());
+        v.extend_from_slice(b"IEND");
+        v.extend_from_slice(&[0xAE, 0x42, 0x60, 0x82]);
+        v
+    }
+
+    fn request_from(content: MessageContent) -> CanonicalRequest {
+        CanonicalRequest {
+            model: "test-model".into(),
+            messages: vec![Message {
+                role: "user".into(),
+                content,
+            }],
+            system: None,
+            max_tokens: 128,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: None,
+            tool_choice: None,
+            tools: None,
+            thinking: None,
+            extensions: Default::default(),
+        }
+    }
+
+    fn request_with(blocks: Vec<ContentBlock>) -> CanonicalRequest {
+        request_from(MessageContent::Blocks(blocks))
+    }
+
+    fn inline_image(bytes: &[u8]) -> ContentBlock {
+        ContentBlock::image(ImageSource {
+            r#type: "base64".into(),
+            media_type: Some("image/png".into()),
+            data: Some(base64::engine::general_purpose::STANDARD.encode(bytes)),
+            url: None,
+        })
+    }
+
+    #[test]
+    fn inline_images_are_collected_in_order() {
+        let request = request_with(vec![
+            ContentBlock::text("look at these".into(), None),
+            inline_image(&png(10, 10)),
+            inline_image(&png(20, 20)),
+        ]);
+        let found = collect_inline_media(&request);
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].declared_type.as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn remote_images_are_not_collected() {
+        // This slice never fetches URLs, so recording one as an observation
+        // would claim knowledge of bytes we never saw.
+        let request = request_with(vec![ContentBlock::image(ImageSource {
+            r#type: "url".into(),
+            media_type: None,
+            data: None,
+            url: Some("https://example.test/a.png".into()),
+        })]);
+        assert!(collect_inline_media(&request).is_empty());
+    }
+
+    #[test]
+    fn plain_text_requests_yield_nothing() {
+        let request = request_from(MessageContent::Text("no images here".into()));
+        assert!(collect_inline_media(&request).is_empty());
+    }
+
+    #[tokio::test]
+    async fn observing_is_a_no_op_when_the_slice_is_off() {
+        // The default. An operator who has not opted in must get exactly the
+        // behaviour they had before this slice existed.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let request = request_with(vec![inline_image(&png(64, 64))]);
+
+        observe_request(
+            &request,
+            &MediaConfig::default(),
+            dir.path().to_path_buf(),
+            None,
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !dir.path().join("media").exists(),
+            "an inert slice must not create a journal directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn observing_journals_the_request_out_of_band() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = MediaConfig {
+            mode: MediaMode::Async,
+            ..MediaConfig::default()
+        };
+        let request = request_with(vec![inline_image(&png(800, 600))]);
+
+        let started = std::time::Instant::now();
+        observe_request(
+            &request,
+            &config,
+            dir.path().to_path_buf(),
+            Some("acme".into()),
+        );
+        // The call itself must return without waiting for any inspection.
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(20),
+            "observe_request blocked for {:?}",
+            started.elapsed()
+        );
+
+        // The work still happens, just not on the caller's clock.
+        for _ in 0..50 {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let journal = MediaJournal::open(dir.path()).expect("open");
+            let events = journal.replay_current().expect("replay");
+            if let Some(event) = events.first() {
+                assert_eq!(event.format, "image/png");
+                assert_eq!((event.width, event.height), (800, 600));
+                assert_eq!(event.tenant.as_deref(), Some("acme"));
+                assert_eq!(event.model.as_deref(), Some("test-model"));
+                return;
+            }
+        }
+        panic!("the detached inspection never journaled anything");
+    }
+
+    #[tokio::test]
+    async fn an_undecodable_payload_does_not_wedge_the_inspection() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = MediaConfig {
+            mode: MediaMode::Async,
+            ..MediaConfig::default()
+        };
+        // A lying MIME type and a decompression bomb, together.
+        let request = request_with(vec![
+            inline_image(b"%PDF-1.7 not an image"),
+            inline_image(&png(50_000, 50_000)),
+            inline_image(&png(32, 32)),
+        ]);
+
+        observe_request(&request, &config, dir.path().to_path_buf(), None);
+
+        for _ in 0..50 {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let journal = MediaJournal::open(dir.path()).expect("open");
+            let events = journal.replay_current().expect("replay");
+            if let Some(event) = events.first() {
+                // Only the valid image is recorded; the other two are refused
+                // without stopping it from being reached.
+                assert_eq!(events.len(), 1);
+                assert_eq!((event.width, event.height), (32, 32));
+                return;
+            }
+        }
+        panic!("a refused payload prevented the valid one from being journaled");
+    }
+}

--- a/src/features/media/registry.rs
+++ b/src/features/media/registry.rs
@@ -22,7 +22,13 @@ pub struct MediaEvent {
     /// RFC-3339 observation timestamp.
     pub ts: String,
     /// Perceptual fingerprint, lowercase hex.
-    pub phash: String,
+    ///
+    /// Absent when the pixels could not be reached without an image decoder.
+    /// Recorded as absent rather than as a placeholder: a fingerprint of
+    /// nothing would collide with every other undecodable image, which is
+    /// worse than admitting we do not have one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phash: Option<String>,
     /// Sniffed MIME type.
     pub format: String,
     /// Declared width in pixels.
@@ -43,9 +49,19 @@ impl MediaEvent {
     /// Builds an event from a probe and its fingerprint.
     #[must_use]
     pub fn new(probe: &MediaProbe, phash: PerceptualHash) -> Self {
+        Self::observed(probe).with_phash(phash)
+    }
+
+    /// Builds an event for a payload whose pixels were not reached.
+    ///
+    /// Shape and findings are still worth journaling: an image that was
+    /// refused or could not be decoded is exactly the kind of event an
+    /// operator wants to see afterwards.
+    #[must_use]
+    pub fn observed(probe: &MediaProbe) -> Self {
         Self {
             ts: chrono::Utc::now().to_rfc3339(),
-            phash: phash.to_hex(),
+            phash: None,
             format: probe.format.mime().to_string(),
             width: probe.width,
             height: probe.height,
@@ -53,6 +69,13 @@ impl MediaEvent {
             tenant: None,
             model: None,
         }
+    }
+
+    /// Attaches a perceptual fingerprint.
+    #[must_use]
+    pub fn with_phash(mut self, phash: PerceptualHash) -> Self {
+        self.phash = Some(phash.to_hex());
+        self
     }
 
     /// Attaches the owning tenant.

--- a/src/features/media/tests.rs
+++ b/src/features/media/tests.rs
@@ -677,7 +677,7 @@ fn journal_appends_and_replays() {
 
     let replayed = journal.replay_current().expect("replay");
     assert_eq!(replayed.len(), 1);
-    assert_eq!(replayed[0].phash, "00000000deadbeef");
+    assert_eq!(replayed[0].phash.as_deref(), Some("00000000deadbeef"));
     assert_eq!(replayed[0].format, "image/png");
     assert_eq!(replayed[0].tenant.as_deref(), Some("acme"));
     assert_eq!((replayed[0].width, replayed[0].height), (640, 480));
@@ -704,7 +704,35 @@ fn journal_survives_a_torn_tail() {
     // The intact record is still readable; only the torn one is lost.
     let replayed = journal.replay_current().expect("replay");
     assert_eq!(replayed.len(), 1);
-    assert_eq!(replayed[0].phash, "0000000000000001");
+    assert_eq!(replayed[0].phash.as_deref(), Some("0000000000000001"));
+}
+
+#[test]
+fn an_event_without_a_fingerprint_is_still_journaled() {
+    // An image whose pixels could not be reached is exactly the kind of event
+    // an operator wants afterwards. Recording it with the fingerprint absent
+    // is honest; recording a placeholder would collide with every other
+    // undecodable image.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut journal = MediaJournal::open(dir.path()).expect("open journal");
+    let probe = probe_bytes(&png_header(320, 200), &MediaConfig::default()).unwrap();
+
+    journal
+        .append(&MediaEvent::observed(&probe).with_tenant("acme"))
+        .expect("append");
+
+    let replayed = journal.replay_current().expect("replay");
+    assert_eq!(replayed.len(), 1);
+    assert_eq!(replayed[0].phash, None);
+    assert_eq!(replayed[0].format, "image/png");
+    assert_eq!((replayed[0].width, replayed[0].height), (320, 200));
+
+    // The absent fingerprint must not appear as a null in the journal line.
+    let line = serde_json::to_string(&replayed[0]).expect("serialise");
+    assert!(
+        !line.contains("phash"),
+        "absent phash should be omitted: {line}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
PR 3b. After #516 the slice was configurable, but nothing called it: an operator who set `mode = "async"` still got nothing. This connects it to the request path.

## The non-blocking promise is a type, not a comment

`observe_request` returns `()`. A caller **cannot await a verdict that does not exist**, so no later refactor can quietly make inspection blocking. It lifts the inline images out of the request, hands them to a detached task, and returns.

A test asserts the call itself completes in under 20 ms while the journal entry appears afterwards, so the promise is measured rather than described.

I deliberately did not put this inside the dispatch functions. Keeping it a self-contained function that borrows the request is the cheapest way to keep the hot path unchanged.

## Two decisions worth flagging

**Remote URL blocks are skipped, not journaled.** This slice never fetches them, and recording an unfetched URL would claim knowledge of bytes nobody has seen.

**`MediaEvent::phash` becomes optional.** Reaching pixels needs an image decoder; this slice links none on purpose (PR 1 shipped with zero added dependencies, and the decompression-bomb guard exists precisely because decoders are where the risk lives). That capability arrives over the sidecar protocol alongside OCR. Recording a placeholder fingerprint would **collide with every other undecodable image**, which is strictly worse than recording none. Shape, format and findings are journaled meanwhile, and they are what an operator asks for first.

## Tests

Six, including the two that would catch a regression here: an inert slice creates **no journal directory at all**, and one refused payload (a lying MIME type, a decompression bomb) does not stop the valid image behind it from being inspected.

1819 tests with the feature, 1723 without, clippy clean on default, `--features media` and `--all-features`.
