### PR TITLE
chore: release v0.36.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.92](https://github.com/azerozero/grob/compare/v0.36.91...v0.36.92) - 2026-08-05
+
+### Added
+
+- *(media)* connect OCR-to-DLP to the actual request path ([#523](https://github.com/azerozero/grob/pull/523))
+- *(media)* reinject OCR text into the existing DLP engine ([#521](https://github.com/azerozero/grob/pull/521))
+- *(media)* request-path entry point for out-of-band inspection ([#518](https://github.com/azerozero/grob/pull/518))
+
+### Other
+
+- *(design)* mark PR 4 delivered ([#522](https://github.com/azerozero/grob/pull/522))
+- *(design)* mark PR 3b delivered ([#520](https://github.com/azerozero/grob/pull/520))
+
 ## [0.36.91](https://github.com/azerozero/grob/compare/v0.36.90...v0.36.91) - 2026-08-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.91"
+version = "0.36.92"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.91"
+version = "0.36.92"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.91 -> 0.36.92

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.92](https://github.com/azerozero/grob/compare/v0.36.91...v0.36.92) - 2026-08-05

### Added

- *(media)* connect OCR-to-DLP to the actual request path ([#523](https://github.com/azerozero/grob/pull/523))
- *(media)* reinject OCR text into the existing DLP engine ([#521](https://github.com/azerozero/grob/pull/521))
- *(media)* request-path entry point for out-of-band inspection ([#518](https://github.com/azerozero/grob/pull/518))

### Other

- *(design)* mark PR 4 delivered ([#522](https://github.com/azerozero/grob/pull/522))
- *(design)* mark PR 3b delivered ([#520](https://github.com/azerozero/grob/pull/520))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).