### PR TITLE
feat(media): reinject OCR text into the existing DLP engine

### DIFF
--- a/src/features/media/scan/mod.rs
+++ b/src/features/media/scan/mod.rs
@@ -9,9 +9,11 @@
 //! implying a guarantee it cannot keep.
 
 pub mod heuristics;
+pub mod normalize;
 pub mod stego;
 #[cfg(test)]
 mod tests;
+pub mod text;
 
 use super::decode::MediaProbe;
 
@@ -94,4 +96,137 @@ pub fn scan(bytes: &[u8], probe: &MediaProbe) -> ScanReport {
     findings.extend(heuristics::detect(bytes, probe));
     findings.extend(stego::detect(bytes, probe));
     ScanReport { findings }
+}
+
+#[cfg(test)]
+mod text_tests {
+    use super::normalize::{fold_confusions, scan_variants};
+    use super::text::scan_ocr_text;
+    use crate::features::dlp::config::{DlpConfig, PiiConfig};
+    use crate::features::dlp::DlpEngine;
+
+    /// Production-shaped engine: builtins on, PII on.
+    fn engine() -> std::sync::Arc<DlpEngine> {
+        let config = DlpConfig {
+            enabled: true,
+            scan_input: true,
+            scan_output: true,
+            no_builtins: false,
+            pii: PiiConfig {
+                credit_cards: true,
+                iban: true,
+                bic: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        DlpEngine::from_config(config).expect("engine")
+    }
+
+    /// Verbatim macOS Vision output on the screenshot fixture, transcription
+    /// errors included: AKIAI read as AKIAT, sk_live as sk_Live, x as U+00D7.
+    const VISION_OCR: &str = concat!(
+        "$cat ,env\n",
+        "AWS_ACCESS_KEY_ID=AKIATOSFODNN7EXAMPLE\n",
+        "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
+        "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz1234567890\n",
+        "DATABASE_URL=postgres://admin:hunter2@10.0.0.4:5432/prod\n",
+        "STRIPE_KEY=sk_Live_51H8\u{d7}YzABCDEFGHIJKLMNOPqr\n",
+    );
+
+    /// Verbatim ocrs output on the same fixture: underscores dropped.
+    const OCRS_OCR: &str = concat!(
+        "$ cat .env\n",
+        "AWS ACCESS KEY ID=AKIAIOSFODNN7EXAMPLE\n",
+        "AWS SECRET ACCESS KEY=WJalrXUtnFEMI/K7MDENG/bPXRfiCYEXAMPLEKEY\n",
+        "GITHUB TOKEN=ghp_abcdefghijklmnopqrstuvWxyz1234567890\n",
+        "DATABASE URL=postgres://admin:hunter2@10.0, 0.4:5432/prod\n",
+        "STRIPE KEY=sk Live_51H8XYzABCDEFGHIJKLMNOPqr\n",
+    );
+
+    #[test]
+    fn normalisation_recovers_the_secret_raw_ocr_loses() {
+        // The measured baseline was 3 of 4 on raw Vision output, the miss
+        // being Stripe because its errors landed in a literal prefix.
+        let engine = engine();
+        let found = scan_ocr_text(&engine, VISION_OCR);
+
+        assert!(
+            found.rules.iter().any(|r| r.contains("aws_access_key")),
+            "AWS key should survive raw OCR: {:?}",
+            found.rules
+        );
+        assert!(
+            found.rules.iter().any(|r| r.contains("stripe")),
+            "normalisation should recover the Stripe key raw OCR loses: {:?}",
+            found.rules
+        );
+    }
+
+    #[test]
+    fn both_engines_reach_the_same_findings_after_normalisation() {
+        // Vision and ocrs fail differently. Normalisation should close both
+        // gaps, otherwise the engine choice would leak into the security
+        // properties instead of staying a deployment preference.
+        let engine = engine();
+        let vision = scan_ocr_text(&engine, VISION_OCR);
+        let ocrs = scan_ocr_text(&engine, OCRS_OCR);
+
+        for expected in ["aws_access_key", "github", "postgres", "stripe"] {
+            assert!(
+                vision.rules.iter().any(|r| r.contains(expected)),
+                "Vision path missed {expected}: {:?}",
+                vision.rules
+            );
+            assert!(
+                ocrs.rules.iter().any(|r| r.contains(expected)),
+                "ocrs path missed {expected}: {:?}",
+                ocrs.rules
+            );
+        }
+    }
+
+    #[test]
+    fn findings_never_carry_the_text_that_produced_them() {
+        // The OCR text contains the secrets; a report quoting them would copy
+        // the leak into every log line recording it.
+        let engine = engine();
+        let findings = scan_ocr_text(&engine, VISION_OCR);
+        for rule in &findings.rules {
+            assert!(!rule.contains("AKIA"), "finding leaked a secret: {rule}");
+            assert!(!rule.contains("hunter2"), "finding leaked a secret: {rule}");
+        }
+    }
+
+    #[test]
+    fn clean_text_produces_no_findings() {
+        let engine = engine();
+        assert!(scan_ocr_text(&engine, "just a screenshot of a cat").is_empty());
+    }
+
+    #[test]
+    fn confusion_folding_covers_only_observed_substitutions() {
+        assert_eq!(fold_confusions("51H8\u{d7}Yz"), "51H8xYz");
+        assert_eq!(fold_confusions("a\u{2013}b"), "a-b");
+        assert_eq!(fold_confusions("a\u{00a0}b"), "a b");
+        // Characters engines do not confuse pass through untouched: every
+        // extra mapping widens the false-positive surface.
+        assert_eq!(fold_confusions("0O1lI"), "0O1lI");
+        assert_eq!(fold_confusions("normal text"), "normal text");
+    }
+
+    #[test]
+    fn the_original_text_is_always_scanned_first() {
+        // A rule that already matches must not be perturbed by normalisation.
+        let variants = scan_variants("sk_Live_51H8\u{d7}Yz");
+        assert_eq!(variants[0], "sk_Live_51H8\u{d7}Yz");
+        assert!(variants.len() > 1, "a confusable input should add variants");
+    }
+
+    #[test]
+    fn variants_are_deduplicated() {
+        // Lowercase input with no spaces or confusables costs exactly one
+        // pass, so the common case of clean OCR adds no extra scans.
+        assert_eq!(scan_variants("already_lowercase").len(), 1);
+    }
 }

--- a/src/features/media/scan/normalize.rs
+++ b/src/features/media/scan/normalize.rs
@@ -1,0 +1,77 @@
+//! OCR text normalisation for the image path.
+//!
+//! Measured, not guessed: feeding real OCR output to the existing DLP engine
+//! caught 3 of 4 planted secrets, and the miss was instructive. Repairing the
+//! errors one at a time showed that a *single* wrong character defeats a rule,
+//! and that survival depends on the shape of the pattern rather than on the
+//! quality of the OCR:
+//!
+//! - `AKIA[0-9A-Z]{16}` survived `AKIAI` being read as `AKIAT`, because the
+//!   error landed inside a character class.
+//! - `sk_live_…` did not survive `sk_Live_` plus a multiplication sign, because
+//!   those errors landed in a literal prefix, which forgives nothing.
+//!
+//! So the useful lever is not a better OCR engine, it is folding the confusions
+//! engines actually make before the scan. That is cheap and aimed squarely at
+//! the observed failure mode.
+//!
+//! This applies to the **image path only**. Loosening the text path would
+//! manufacture false positives for every request that never involved an image.
+
+/// Folds visually confusable characters into their canonical form.
+///
+/// Only substitutions observed in real OCR output are folded. Every extra
+/// mapping widens the false-positive surface, so the list stays short and
+/// evidence-driven rather than exhaustive.
+#[must_use]
+pub fn fold_confusions(text: &str) -> String {
+    text.chars()
+        .map(|c| match c {
+            // Vision rendered "51H8xYz" as "51H8×Yz".
+            '\u{d7}' => 'x',                 // multiplication sign
+            '\u{2212}' => '-',               // minus sign
+            '\u{2013}' | '\u{2014}' => '-',  // en/em dash
+            '\u{2018}' | '\u{2019}' => '\'', // curly quotes
+            '\u{201c}' | '\u{201d}' => '"',
+            '\u{00a0}' => ' ', // non-breaking space
+            other => other,
+        })
+        .collect()
+}
+
+/// Produces the variants of `text` worth scanning.
+///
+/// The original always comes first: a rule that already matches must not be
+/// affected by any of this. Extra variants are only added when they actually
+/// differ, so the common case of clean OCR costs one scan.
+///
+/// The lowercase variant exists because literal prefixes are where OCR errors
+/// are fatal, and case is the single most common such error (`sk_live_` read
+/// as `sk_Live_`). Underscore repair covers engines that drop them entirely,
+/// which is what `ocrs` did on the same fixture.
+#[must_use]
+pub fn scan_variants(text: &str) -> Vec<String> {
+    let mut variants = vec![text.to_string()];
+
+    let folded = fold_confusions(text);
+    if folded != text {
+        variants.push(folded.clone());
+    }
+
+    // The repairs have to compose, not merely coexist. `ocrs` rendered
+    // "sk_live_" as "sk Live_": a dropped underscore *and* a case error in
+    // the same literal. Fixing either alone leaves the rule unmatched, which
+    // is exactly the trap measured on the raw output.
+    let lowered = folded.to_lowercase();
+    // `ocrs` also rendered "AWS_ACCESS_KEY_ID" as "AWS ACCESS KEY ID".
+    let underscored = folded.replace(' ', "_");
+    let both = lowered.replace(' ', "_");
+
+    for candidate in [lowered, underscored, both] {
+        if !variants.contains(&candidate) {
+            variants.push(candidate);
+        }
+    }
+
+    variants
+}

--- a/src/features/media/scan/text.rs
+++ b/src/features/media/scan/text.rs
@@ -1,0 +1,69 @@
+//! Reinjects OCR text into the existing DLP engine.
+//!
+//! The whole point of the image path is that it adds no rules. A screenshot
+//! containing an AWS key is caught by the same code that catches one in a
+//! chat message, so operators maintain one rule set and every future DLP
+//! improvement reaches images for free.
+
+use super::normalize::scan_variants;
+use crate::features::dlp::{DlpEngine, DlpRuleType};
+use std::collections::BTreeSet;
+
+/// What the DLP engine found in an image's text.
+///
+/// Carries rule identifiers only. The OCR text itself never appears here,
+/// because it contains the secrets that triggered the findings: a report that
+/// quoted them would copy the leak into every log line that records it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TextFindings {
+    /// Identifiers of the rules that fired, deduplicated and ordered.
+    pub rules: BTreeSet<String>,
+}
+
+impl TextFindings {
+    /// Returns whether anything was found.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Number of distinct rules that fired.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+}
+
+/// Scans OCR output with the configured DLP engine.
+///
+/// Each normalisation variant is scanned and the findings are unioned, since
+/// a rule may only match one of them: the folded form recovers a mis-read
+/// character, the underscored form recovers a dropped separator.
+///
+/// Deduplication by rule identifier means a secret found in three variants is
+/// reported once, so the count reflects secrets rather than passes.
+#[must_use]
+pub fn scan_ocr_text(engine: &DlpEngine, text: &str) -> TextFindings {
+    let mut rules = BTreeSet::new();
+    for variant in scan_variants(text) {
+        let (_sanitized, reports) = engine.sanitize_text_reported(&variant);
+        for report in reports {
+            rules.insert(rule_id(&report.rule_type, &report.detail));
+        }
+    }
+    TextFindings { rules }
+}
+
+/// Builds a stable identifier for a report.
+///
+/// The engine's `detail` already carries the rule name for secrets
+/// (`rule=aws_access_key`); for other categories it may include the matched
+/// value, so those are reduced to their category. A stable identifier is what
+/// makes deduplication across variants meaningful, and it keeps matched values
+/// out of the record.
+fn rule_id(rule_type: &DlpRuleType, detail: &str) -> String {
+    if let Some(name) = detail.strip_prefix("rule=") {
+        return format!("{rule_type:?}:{name}");
+    }
+    format!("{rule_type:?}")
+}


### PR DESCRIPTION
PR 4. I said this one was blocked on choosing an OCR engine. It was not: the sidecar protocol already makes the engine interchangeable, so the code that turns OCR text into DLP findings could be written today.

## No new rules

A screenshot containing an AWS key is caught by the same code that catches one in a chat message. Operators maintain one rule set, and every future DLP improvement reaches images for free.

## The measurement said the lever is not a better engine

Repairing real OCR errors one at a time showed a single wrong character defeats a rule, and that survival depends on the **shape of the pattern**:

- `AKIA[0-9A-Z]{16}` survived `AKIAI` → `AKIAT`, because the error landed inside a character class.
- `sk_live_…` did **not** survive `sk_Live_`, because a literal prefix forgives nothing.

So normalisation folds the confusions engines actually make. Applied to the **image path only**: loosening the text path would manufacture false positives for every request that never involved an image.

## The repairs must compose, not merely coexist

This took a second attempt. `ocrs` rendered `sk_live_` as `sk Live_` — a dropped underscore **and** a case error in the same literal. Fixing either alone leaves the rule unmatched, so the variant set now includes the combined repair. Pinned by a test.

## Result

Both engines lost one secret on raw output, in different places. After normalisation:

| Engine | Raw | Normalised |
|---|---|---|
| macOS Vision | 3/4 | **4/4** |
| ocrs | 3/4 | **4/4** |

The engine choice therefore stays a deployment preference instead of leaking into the security properties, which is what the sidecar protocol promised.

Findings carry rule identifiers only, never the OCR text, since that text contains the very secrets that triggered them. A test asserts no finding mentions `AKIA` or `hunter2`.

7 tests, 1826 with the feature, 1723 without, clippy clean on `--all-features`. (One pre-existing flaky test in `shared::net` is an ephemeral-port race, unrelated.)
