### PR TITLE
test(media): guard against entry points losing their callers

### DIFF
--- a/src/features/media/README.md
+++ b/src/features/media/README.md
@@ -140,6 +140,12 @@ An ignored test drives the Rust client against it end to end, asserting that a p
 
 `scan/tests.rs` covers each detector, the no-payload-in-findings property, totality over truncated inputs, and an ignored cross-check against real system JPEGs (`--ignored`). `tests.rs` covers the decompression-bomb refusal, budget boundaries, lying MIME types, truncated-header totality across all four formats, SSRF refusal, the full perceptual-hash matrix above, the separation gap, and journal append/replay including a torn tail.
 
+## Reachability
+
+Three times in this slice's history, working and fully tested code shipped while nothing called it: the config in #516, the observation entry point in #518, the OCR bridge in #523. Unit tests cannot catch that, because every piece passes in isolation.
+
+`every_entry_point_has_a_caller_outside_its_own_file` reads the source at test time and asserts each entry point still has its caller: `observe_request` in the dispatch path, `scan_ocr_text` in the observation path, `MediaConfig` in the top-level config. Deleting any of those wirings fails the test instead of silently disabling the feature.
+
 ## Mutation coverage
 
 Every file in the slice has been checked with `cargo-mutants`, because a passing

--- a/src/features/media/tests.rs
+++ b/src/features/media/tests.rs
@@ -786,6 +786,50 @@ fn an_absent_media_section_leaves_the_slice_off() {
     assert!(config.media.sidecar.endpoints.is_empty());
 }
 
+/// Guards against the failure this slice hit three times: code that is
+/// written, tested and merged while nothing calls it.
+///
+/// Unit tests cannot catch it, because each piece passes in isolation. This
+/// walks the source instead and fails when an entry point loses every caller
+/// outside the file that defines it.
+#[test]
+fn every_entry_point_has_a_caller_outside_its_own_file() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+
+    // (symbol, file that defines it, where a caller must exist).
+    let entry_points = [
+        // The dispatch path must call into the slice, or no request is ever
+        // inspected.
+        (
+            "observe_request",
+            "features/media/observe.rs",
+            "server/dispatch/mod.rs",
+        ),
+        // The observation path must use the OCR bridge, or extracted text
+        // never reaches the DLP engine.
+        (
+            "scan_ocr_text",
+            "features/media/scan/text.rs",
+            "features/media/observe.rs",
+        ),
+        // The top-level config must expose the section, or no operator can
+        // switch any of this on.
+        ("MediaConfig", "features/media/config.rs", "config.rs"),
+    ];
+
+    for (symbol, home, expected_caller) in entry_points {
+        let caller = root.join(expected_caller);
+        let contents = std::fs::read_to_string(&caller)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", caller.display()));
+        assert!(
+            contents.contains(symbol),
+            "{symbol} is defined in {home} but {expected_caller} does not \
+             reference it: the feature is unreachable in production. Wire it \
+             up or delete it."
+        );
+    }
+}
+
 #[test]
 fn slice_is_inert_by_default() {
     let config = MediaConfig::default();


### PR DESCRIPTION
Three times in this slice's short history, working and fully tested code shipped while nothing called it:

| PR | What was unreachable |
|---|---|
| fixed in #516 | `MediaConfig` — no TOML file could reach it |
| fixed in #518 | the slice — configurable but never invoked |
| fixed in #523 | `scan_ocr_text` — the OCR bridge, uncalled |

Every unit test passed each time. That is the point: unit tests verify pieces, never the connections between them, so a missing wire is invisible to them by construction.

## The guard

`every_entry_point_has_a_caller_outside_its_own_file` reads the source at test time and asserts each entry point still has its caller:

- `observe_request` in `server/dispatch/mod.rs`
- `scan_ocr_text` in `features/media/observe.rs`
- `MediaConfig` in `config.rs`

Deleting any of those wirings now fails a test instead of silently disabling the feature.

I verified the guard actually fires rather than trusting it: checked its assertion against a copy of the dispatch module with the call renamed away, which returns false as intended. A guard that cannot fail is decoration.

1829 tests with the feature, 1723 without, clippy clean on `--all-features`.
