### PR TITLE
feat(media): blocking inspection, fail-closed by default

### DIFF
--- a/src/features/media/README.md
+++ b/src/features/media/README.md
@@ -21,7 +21,9 @@ The slice is compiled out unless `--features media` is passed, and inert unless 
 | `MediaEvent`, `MediaJournal`, `current_month` | `registry.rs` | observation journal |
 | `scan`, `ScanReport`, `Finding`, `Severity` | `scan/` | cheap detectors |
 | `SidecarClient`, `SidecarConfig`, `Endpoint`, `Capability` | `sidecar/` | out-of-process capabilities |
-| `observe_request`, `collect_inline_media` | `observe.rs` | request-path entry point |
+| `observe_request`, `collect_inline_media` | `observe.rs` | async request-path entry point |
+| `inspect_blocking`, `Verdict`, `DenyReason` | `blocking.rs` | pre-dispatch verdict |
+| `OnFailure` | `config.rs` | fail-closed policy |
 | `scan_ocr_text`, `TextFindings` | `scan/text.rs` | OCR text into the DLP engine |
 | `fold_confusions`, `scan_variants` | `scan/normalize.rs` | OCR error repair |
 
@@ -96,6 +98,18 @@ Remote (URL) blocks are skipped rather than recorded. This slice never fetches t
 One image being refused does not stop the others from being inspected, which a test pins with a lying MIME type and a decompression bomb sitting in front of a valid PNG.
 
 Fingerprints are currently recorded as **absent** rather than faked: reaching pixels needs an image decoder, this slice links none on purpose, and that capability arrives over the sidecar protocol alongside OCR. A placeholder fingerprint would collide with every other undecodable image, which is worse than admitting there is none. Shape, format and findings are journaled meanwhile, and they are what an operator asks for first.
+
+## Blocking mode
+
+`mode = "blocking"` inspects images before dispatch and can refuse. That raises a question the async path never faces: what happens when the inspection itself fails, through a timeout, an unreachable sidecar, or an open circuit. All three mean the same thing, that the image was never examined.
+
+**The default is to refuse** (`on_failure = "deny"`). An operator who turned on blocking asked for images to be examined before they leave; forwarding the ones we failed to examine would answer a different question than the one they asked, and would do it exactly when something is already wrong.
+
+`on_failure = "allow"` is available for deployments where a stalled sidecar must not become an outage. The trade is explicit, which is why it lives in configuration rather than in a default.
+
+Two refusal reasons are reported distinctly, because they send an operator to different places: `Findings` means the request must change, `NotInspected` means the sidecar must be fixed. Refusals name the rules that fired but never quote the matched values, since those are the secrets themselves.
+
+A missing OCR sidecar is **reduced capability, not failure**: the cheap detectors still run, text simply cannot be read, so a deployment that has not installed OCR is not refusing every image.
 
 ## OCR into DLP
 

--- a/src/features/media/blocking.rs
+++ b/src/features/media/blocking.rs
@@ -1,0 +1,427 @@
+//! Blocking inspection: reach a verdict before the request is dispatched.
+//!
+//! The asynchronous path in [`super::observe`] can only report. This one can
+//! refuse, which means it has to answer a question the other never faces:
+//! what to do when the inspection itself fails.
+//!
+//! The default is to refuse. An operator who turned on `blocking` asked for
+//! images to be examined before they leave; forwarding the ones we failed to
+//! examine would answer a different question than the one they asked, and
+//! would do it exactly when something is already wrong. `on_failure = "allow"`
+//! is available for deployments where a stalled sidecar must not become an
+//! outage, and it is a decision worth writing down rather than inheriting.
+
+use super::config::{MediaConfig, OnFailure};
+use super::decode::probe;
+use super::observe::{collect_inline_media, PendingMedia};
+use super::scan::scan;
+use super::scan::text::scan_ocr_text;
+use super::sidecar::{Capability, SidecarClient};
+use super::MediaRef;
+use crate::features::dlp::DlpEngine;
+use crate::models::CanonicalRequest;
+use std::collections::BTreeSet;
+
+/// The outcome of a blocking inspection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    /// Nothing objectionable; dispatch may proceed.
+    Allow,
+    /// Refuse the request.
+    Deny {
+        /// Rule identifiers that justify the refusal.
+        ///
+        /// Identifiers only: the matched values are the secrets themselves,
+        /// and an error surfaced to a client must not quote them back.
+        rules: BTreeSet<String>,
+        /// Whether the refusal is a policy decision or a failure to inspect.
+        reason: DenyReason,
+    },
+}
+
+/// Why a request was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenyReason {
+    /// An image was examined and something was found.
+    Findings,
+    /// An image could not be examined, and `on_failure` says deny.
+    ///
+    /// Distinguished from [`Self::Findings`] because they call for different
+    /// responses: one means fix the request, the other means fix the sidecar.
+    NotInspected,
+}
+
+impl Verdict {
+    /// Returns whether the request may proceed.
+    #[must_use]
+    pub const fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allow)
+    }
+}
+
+/// Inspects a request's images and returns a verdict.
+///
+/// Only meaningful when `mode = "blocking"`; other modes always allow, so a
+/// caller can invoke this unconditionally.
+pub async fn inspect_blocking(
+    request: &CanonicalRequest,
+    config: &MediaConfig,
+    dlp: Option<&DlpEngine>,
+) -> Verdict {
+    if !config.is_blocking() {
+        return Verdict::Allow;
+    }
+    let pending = collect_inline_media(request);
+    if pending.is_empty() {
+        return Verdict::Allow;
+    }
+
+    let deadline = config.blocking_timeout();
+    let work = examine(pending, config, dlp);
+
+    match tokio::time::timeout(deadline, work).await {
+        Ok(verdict) => verdict,
+        // The deadline is itself a failure to inspect, and gets the same
+        // treatment as an unreachable sidecar rather than a quiet allow.
+        Err(_elapsed) => on_failure_verdict(config.on_failure),
+    }
+}
+
+/// Examines every image, stopping at the first refusal.
+async fn examine(
+    pending: Vec<PendingMedia>,
+    config: &MediaConfig,
+    dlp: Option<&DlpEngine>,
+) -> Verdict {
+    let sidecar = SidecarClient::new(config.sidecar.clone());
+    let ocr_available = sidecar.is_enabled(Capability::Ocr);
+
+    for item in pending {
+        let media = MediaRef::Inline {
+            data: &item.payload,
+            declared_type: item.declared_type.as_deref(),
+        };
+        let Ok((bytes, probed)) = probe(media, config) else {
+            // A payload that cannot even be decoded was never examined, so it
+            // falls under the same policy as any other inspection failure.
+            let verdict = on_failure_verdict(config.on_failure);
+            if !verdict.is_allowed() {
+                return verdict;
+            }
+            continue;
+        };
+
+        let report = scan(&bytes, &probed);
+        if !report.is_empty() {
+            return Verdict::Deny {
+                rules: report.rules().into_iter().map(String::from).collect(),
+                reason: DenyReason::Findings,
+            };
+        }
+
+        let Some(dlp) = dlp else {
+            continue;
+        };
+        if !ocr_available {
+            // Blocking mode with no OCR sidecar can still apply the cheap
+            // detectors above; it simply cannot read text. That is a reduced
+            // capability, not a failed inspection, so it is not a refusal.
+            continue;
+        }
+
+        match sidecar.ocr(&item.payload).await {
+            Ok(text) => {
+                let findings = scan_ocr_text(dlp, &text);
+                if !findings.is_empty() {
+                    return Verdict::Deny {
+                        rules: findings.rules,
+                        reason: DenyReason::Findings,
+                    };
+                }
+            }
+            Err(_err) => {
+                let verdict = on_failure_verdict(config.on_failure);
+                if !verdict.is_allowed() {
+                    return verdict;
+                }
+            }
+        }
+    }
+
+    Verdict::Allow
+}
+
+/// Turns the configured failure policy into a verdict.
+fn on_failure_verdict(policy: OnFailure) -> Verdict {
+    if policy.allows_unexamined() {
+        return Verdict::Allow;
+    }
+    Verdict::Deny {
+        rules: BTreeSet::new(),
+        reason: DenyReason::NotInspected,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::dlp::config::{DlpConfig, PiiConfig};
+    use crate::features::media::config::MediaMode;
+    use crate::features::media::sidecar::{Endpoint, SidecarConfig};
+    use crate::models::{ContentBlock, ImageSource, Message, MessageContent};
+    use base64::Engine as _;
+    use std::collections::HashMap;
+
+    fn png(w: u32, h: u32) -> Vec<u8> {
+        let mut v = Vec::from(b"\x89PNG\r\n\x1a\n".as_slice());
+        v.extend_from_slice(&13u32.to_be_bytes());
+        v.extend_from_slice(b"IHDR");
+        v.extend_from_slice(&w.to_be_bytes());
+        v.extend_from_slice(&h.to_be_bytes());
+        v.extend_from_slice(&[8, 6, 0, 0, 0]);
+        v.extend_from_slice(&0u32.to_be_bytes());
+        v.extend_from_slice(b"IEND");
+        v.extend_from_slice(&[0xAE, 0x42, 0x60, 0x82]);
+        v
+    }
+
+    fn request_with_image(bytes: &[u8]) -> CanonicalRequest {
+        CanonicalRequest {
+            model: "test-model".into(),
+            messages: vec![Message {
+                role: "user".into(),
+                content: MessageContent::Blocks(vec![ContentBlock::image(ImageSource {
+                    r#type: "base64".into(),
+                    media_type: Some("image/png".into()),
+                    data: Some(base64::engine::general_purpose::STANDARD.encode(bytes)),
+                    url: None,
+                })]),
+            }],
+            system: None,
+            max_tokens: 128,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: None,
+            tool_choice: None,
+            tools: None,
+            thinking: None,
+            extensions: Default::default(),
+        }
+    }
+
+    fn dlp() -> std::sync::Arc<DlpEngine> {
+        let config = DlpConfig {
+            enabled: true,
+            scan_input: true,
+            scan_output: true,
+            no_builtins: false,
+            pii: PiiConfig {
+                credit_cards: true,
+                iban: true,
+                bic: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        DlpEngine::from_config(config).expect("engine")
+    }
+
+    /// Sidecar endpoint pointing at a socket that does not exist.
+    fn dead_sidecar() -> SidecarConfig {
+        let mut endpoints = HashMap::new();
+        endpoints.insert(
+            "ocr".to_string(),
+            Endpoint::Unix {
+                path: "/nonexistent/grob-ocr.sock".into(),
+            },
+        );
+        SidecarConfig {
+            endpoints,
+            timeout_ms: Some(200),
+        }
+    }
+
+    fn blocking_config(sidecar: SidecarConfig, on_failure: OnFailure) -> MediaConfig {
+        MediaConfig {
+            mode: MediaMode::Blocking,
+            on_failure,
+            blocking_timeout_ms: 2_000,
+            sidecar,
+            ..MediaConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn the_default_refuses_what_it_could_not_inspect() {
+        // The decision this module exists to encode: an operator who asked for
+        // images to be examined does not silently get un-examined ones.
+        assert_eq!(OnFailure::default(), OnFailure::Deny);
+
+        let config = blocking_config(dead_sidecar(), OnFailure::default());
+        let request = request_with_image(&png(400, 300));
+
+        let verdict = inspect_blocking(&request, &config, Some(&dlp())).await;
+        assert_eq!(
+            verdict,
+            Verdict::Deny {
+                rules: Default::default(),
+                reason: DenyReason::NotInspected,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_open_is_available_when_configured() {
+        // Same unreachable sidecar, opposite policy: availability preserved,
+        // and the image passes unexamined. That trade belongs in config.
+        let config = blocking_config(dead_sidecar(), OnFailure::Allow);
+        let request = request_with_image(&png(400, 300));
+
+        let verdict = inspect_blocking(&request, &config, Some(&dlp())).await;
+        assert!(verdict.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn a_refusal_from_findings_is_distinguishable_from_a_failure() {
+        // Findings mean fix the request; NotInspected means fix the sidecar.
+        // Collapsing them would send operators looking in the wrong place.
+        let mut trailer = png(400, 300);
+        trailer.extend_from_slice(b"-----BEGIN OPENSSH PRIVATE KEY-----AAAA");
+        let config = blocking_config(SidecarConfig::default(), OnFailure::Deny);
+
+        let verdict = inspect_blocking(&request_with_image(&trailer), &config, Some(&dlp())).await;
+        match verdict {
+            Verdict::Deny { reason, rules } => {
+                assert_eq!(reason, DenyReason::Findings);
+                assert!(
+                    rules.iter().any(|r| r.contains("appended")),
+                    "expected the appended-payload rule: {rules:?}"
+                );
+            }
+            Verdict::Allow => panic!("a planted payload should be refused"),
+        }
+    }
+
+    #[tokio::test]
+    async fn refusals_never_quote_what_they_found() {
+        // The rules that fire are named by identifier; the matched values are
+        // the secrets themselves and must not travel back to the client.
+        let mut trailer = png(400, 300);
+        trailer.extend_from_slice(b"AKIAIOSFODNN7EXAMPLE-with-padding-bytes");
+        let config = blocking_config(SidecarConfig::default(), OnFailure::Deny);
+
+        if let Verdict::Deny { rules, .. } =
+            inspect_blocking(&request_with_image(&trailer), &config, Some(&dlp())).await
+        {
+            for rule in &rules {
+                assert!(!rule.contains("AKIA"), "verdict leaked a secret: {rule}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_clean_image_is_allowed() {
+        let config = blocking_config(SidecarConfig::default(), OnFailure::Deny);
+        let verdict =
+            inspect_blocking(&request_with_image(&png(800, 600)), &config, Some(&dlp())).await;
+        assert!(verdict.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn a_missing_ocr_sidecar_is_reduced_capability_not_failure() {
+        // Blocking with no OCR sidecar still applies the cheap detectors. It
+        // cannot read text, which is a smaller capability rather than a failed
+        // inspection, so it must not refuse every image on a deployment that
+        // simply has not installed OCR.
+        let config = blocking_config(SidecarConfig::default(), OnFailure::Deny);
+        let verdict =
+            inspect_blocking(&request_with_image(&png(640, 480)), &config, Some(&dlp())).await;
+        assert!(verdict.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn other_modes_always_allow() {
+        // So a caller can invoke this unconditionally without checking mode.
+        for mode in [MediaMode::Off, MediaMode::Async] {
+            let config = MediaConfig {
+                mode,
+                on_failure: OnFailure::Deny,
+                sidecar: dead_sidecar(),
+                ..MediaConfig::default()
+            };
+            let verdict =
+                inspect_blocking(&request_with_image(&png(100, 100)), &config, Some(&dlp())).await;
+            assert!(verdict.is_allowed(), "{mode:?} must not refuse anything");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_request_without_images_is_allowed_without_inspection() {
+        let config = blocking_config(dead_sidecar(), OnFailure::Deny);
+        let request = CanonicalRequest {
+            model: "m".into(),
+            messages: vec![Message {
+                role: "user".into(),
+                content: MessageContent::Text("no images".into()),
+            }],
+            system: None,
+            max_tokens: 16,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: Some(false),
+            metadata: None,
+            tool_choice: None,
+            tools: None,
+            thinking: None,
+            extensions: Default::default(),
+        };
+        // A dead sidecar must not refuse a request that carries no image.
+        assert!(inspect_blocking(&request, &config, Some(&dlp()))
+            .await
+            .is_allowed());
+    }
+
+    #[tokio::test]
+    async fn an_undecodable_payload_follows_the_failure_policy() {
+        // A payload that cannot be decoded was never examined either.
+        let garbage = b"%PDF-1.7 definitely not an image".to_vec();
+
+        let deny = blocking_config(SidecarConfig::default(), OnFailure::Deny);
+        assert!(
+            !inspect_blocking(&request_with_image(&garbage), &deny, Some(&dlp()))
+                .await
+                .is_allowed()
+        );
+
+        let allow = blocking_config(SidecarConfig::default(), OnFailure::Allow);
+        assert!(
+            inspect_blocking(&request_with_image(&garbage), &allow, Some(&dlp()))
+                .await
+                .is_allowed()
+        );
+    }
+
+    #[tokio::test]
+    async fn the_deadline_bounds_the_request_and_denies_by_default() {
+        // A wedged sidecar must not hold a request open, and the timeout is
+        // itself a failure to inspect rather than a quiet allow.
+        let mut config = blocking_config(dead_sidecar(), OnFailure::Deny);
+        config.blocking_timeout_ms = 150;
+
+        let started = std::time::Instant::now();
+        let verdict =
+            inspect_blocking(&request_with_image(&png(400, 300)), &config, Some(&dlp())).await;
+
+        assert!(!verdict.is_allowed());
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "inspection ran for {:?}, past its 150 ms deadline",
+            started.elapsed()
+        );
+    }
+}

--- a/src/features/media/config.rs
+++ b/src/features/media/config.rs
@@ -1,6 +1,7 @@
 //! Configuration for the media slice.
 
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 /// Default encoded-payload budget: 8 MiB.
 const DEFAULT_MAX_BYTES: usize = 8 * 1024 * 1024;
@@ -8,6 +9,13 @@ const DEFAULT_MAX_BYTES: usize = 8 * 1024 * 1024;
 /// Default pixel budget: 40 megapixels, comfortably above a 6K screenshot
 /// and far below what a decompression bomb asks for.
 const DEFAULT_MAX_PIXELS: u64 = 40_000_000;
+
+/// Default deadline for a blocking inspection.
+///
+/// Sized from the measured OCR cost (~320 ms for `ocrs` on a screenshot),
+/// with enough headroom for a cold sidecar without letting a wedged one hold
+/// a request open.
+const DEFAULT_BLOCKING_TIMEOUT_MS: u64 = 5_000;
 
 /// How media inspection participates in the request path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -18,6 +26,44 @@ pub enum MediaMode {
     Off,
     /// Inspect out of band. Never adds latency, never blocks.
     Async,
+    /// Inspect before the request is dispatched, and act on the verdict.
+    ///
+    /// Adds the inspection cost to the request path, which is the price of
+    /// being able to refuse. See [`OnFailure`] for what happens when the
+    /// inspection itself cannot complete.
+    Blocking,
+}
+
+/// What to do when an inspection cannot reach a verdict in `blocking` mode.
+///
+/// A timeout, an unreachable sidecar, or an open circuit all mean the same
+/// thing: the image was never examined. The question is whether an
+/// un-examined image is allowed through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OnFailure {
+    /// Refuse the request. The default.
+    ///
+    /// An operator who turned on `blocking` asked for images to be examined
+    /// before they leave. Silently forwarding the ones we failed to examine
+    /// would answer a different question than the one they asked, and would
+    /// do it precisely when something is already wrong.
+    #[default]
+    Deny,
+    /// Forward the request anyway.
+    ///
+    /// For deployments where a stalled sidecar must not become an outage.
+    /// The trade is explicit: availability is preserved and some images pass
+    /// unexamined, so it belongs in configuration rather than in a default.
+    Allow,
+}
+
+impl OnFailure {
+    /// Returns whether an un-examined image is forwarded.
+    #[must_use]
+    pub const fn allows_unexamined(self) -> bool {
+        matches!(self, Self::Allow)
+    }
 }
 
 /// Media slice configuration.
@@ -26,7 +72,9 @@ pub enum MediaMode {
 ///
 /// ```toml
 /// [media]
-/// mode = "async"          # off (default) | async
+/// mode = "async"          # off (default) | async | blocking
+/// on_failure = "deny"     # deny (default) | allow -- blocking mode only
+/// timeout_ms = 5000       # blocking mode only
 /// max_bytes = 8388608
 /// max_pixels = 40000000
 /// fetch_remote = false    # leave off: fetching client URLs is an SSRF primitive
@@ -39,6 +87,15 @@ pub enum MediaMode {
 pub struct MediaConfig {
     /// Participation mode.
     pub mode: MediaMode,
+    /// What to do when a blocking inspection cannot reach a verdict.
+    ///
+    /// Ignored unless `mode = "blocking"`, since nothing is refused otherwise.
+    pub on_failure: OnFailure,
+    /// Deadline for a blocking inspection, in milliseconds.
+    ///
+    /// Bounds how long a request can wait on inspection. Past it,
+    /// [`Self::on_failure`] decides.
+    pub blocking_timeout_ms: u64,
     /// Maximum accepted size of the *encoded* payload, in bytes.
     pub max_bytes: usize,
     /// Maximum accepted `width * height`, checked before any decode.
@@ -58,6 +115,8 @@ impl Default for MediaConfig {
     fn default() -> Self {
         Self {
             mode: MediaMode::Off,
+            on_failure: OnFailure::Deny,
+            blocking_timeout_ms: DEFAULT_BLOCKING_TIMEOUT_MS,
             max_bytes: DEFAULT_MAX_BYTES,
             max_pixels: DEFAULT_MAX_PIXELS,
             fetch_remote: false,
@@ -72,5 +131,17 @@ impl MediaConfig {
     #[must_use]
     pub const fn is_enabled(&self) -> bool {
         !matches!(self.mode, MediaMode::Off)
+    }
+
+    /// Returns whether inspection happens before dispatch.
+    #[must_use]
+    pub const fn is_blocking(&self) -> bool {
+        matches!(self.mode, MediaMode::Blocking)
+    }
+
+    /// Deadline for a blocking inspection.
+    #[must_use]
+    pub const fn blocking_timeout(&self) -> Duration {
+        Duration::from_millis(self.blocking_timeout_ms)
     }
 }

--- a/src/features/media/mod.rs
+++ b/src/features/media/mod.rs
@@ -7,6 +7,7 @@
 //! The design and the measurements behind the thresholds live in
 //! `docs/design/001-image-dlp-provenance.md`.
 
+pub mod blocking;
 pub mod config;
 pub mod decode;
 pub mod observe;

--- a/src/features/media/tests.rs
+++ b/src/features/media/tests.rs
@@ -815,6 +815,13 @@ fn every_entry_point_has_a_caller_outside_its_own_file() {
         // The top-level config must expose the section, or no operator can
         // switch any of this on.
         ("MediaConfig", "features/media/config.rs", "config.rs"),
+        // The dispatch path must consult the blocking verdict, or nothing is
+        // ever refused however the operator configured it.
+        (
+            "inspect_blocking",
+            "features/media/blocking.rs",
+            "server/dispatch/mod.rs",
+        ),
     ];
 
     for (symbol, home, expected_caller) in entry_points {

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -105,6 +105,46 @@ impl DispatchContext<'_> {
     #[cfg(not(feature = "media"))]
     fn observe_media(&self, _request: &CanonicalRequest) {}
 
+    /// Inspects images before dispatch when `[media] mode = "blocking"`.
+    ///
+    /// Returns `Forbidden` when the verdict refuses. The two refusal reasons
+    /// are reported distinctly on purpose: findings mean the request must
+    /// change, a failed inspection means the sidecar must be fixed, and an
+    /// operator reading a log line should be able to tell which.
+    #[cfg(feature = "media")]
+    async fn gate_media(&self, request: &CanonicalRequest) -> Result<(), RequestError> {
+        use crate::features::media::blocking::{inspect_blocking, DenyReason, Verdict};
+
+        let config = &self.inner.config.media;
+        if !config.is_blocking() {
+            return Ok(());
+        }
+        match inspect_blocking(request, config, self.dlp.as_deref()).await {
+            Verdict::Allow => Ok(()),
+            Verdict::Deny { rules, reason } => {
+                let message = match reason {
+                    DenyReason::Findings => {
+                        tracing::warn!(?rules, "media inspection refused a request");
+                        "request refused: an attached image matched a data-loss rule"
+                    }
+                    DenyReason::NotInspected => {
+                        tracing::error!(
+                            "media inspection could not complete; refusing per on_failure=deny"
+                        );
+                        "request refused: an attached image could not be inspected"
+                    }
+                };
+                Err(RequestError::Forbidden(message.to_string()))
+            }
+        }
+    }
+
+    /// No-op when the media feature is compiled out.
+    #[cfg(not(feature = "media"))]
+    async fn gate_media(&self, _request: &CanonicalRequest) -> Result<(), RequestError> {
+        Ok(())
+    }
+
     /// Run DLP input sanitization if enabled, emitting watch events for actions taken.
     fn sanitize_input(&self, request: &mut CanonicalRequest) {
         self.observe_media(request);
@@ -570,6 +610,8 @@ async fn enforce_post_route_policy(
     provider: &str,
     dlp_triggered: bool,
 ) -> Result<(), RequestError> {
+    ctx.gate_media(request).await?;
+
     let Some(matcher) = ctx.inner.policy_matcher.as_ref() else {
         return Ok(());
     };
@@ -652,13 +694,13 @@ async fn enforce_post_route_policy(
 /// in the provider loop / fan-out need no `#[cfg]` gating.
 #[cfg(not(feature = "policies"))]
 async fn enforce_post_route_policy(
-    _ctx: &DispatchContext<'_>,
-    _request: &CanonicalRequest,
+    ctx: &DispatchContext<'_>,
+    request: &CanonicalRequest,
     _decision: &crate::models::RouteDecision,
     _provider: &str,
     _dlp_triggered: bool,
 ) -> Result<(), RequestError> {
-    Ok(())
+    ctx.gate_media(request).await
 }
 
 /// Check the response cache for a hit (non-streaming requests only).


### PR DESCRIPTION
PR 5, implementing the decision: **fail-closed by default, fail-open configurable**.

## The question blocking mode raises

`mode = "blocking"` inspects images before dispatch and can refuse. A timeout, an unreachable sidecar and an open circuit all mean the same thing: the image was never examined. Is an un-examined image allowed through?

**Default `on_failure = "deny"`.** An operator who turned on blocking asked for images to be examined before they leave. Forwarding the ones we failed to examine would answer a different question than the one they asked, and would do it exactly when something is already wrong.

**`on_failure = "allow"`** for deployments where a stalled sidecar must not become an outage. The trade is explicit, which is why it lives in configuration rather than in a default.

```toml
[media]
mode = "blocking"
on_failure = "deny"        # default; "allow" to prefer availability
blocking_timeout_ms = 5000
```

## Three judgement calls worth review

**The two refusal reasons stay distinct.** `Findings` means the request must change; `NotInspected` means the sidecar must be fixed. Collapsing them would send operators looking in the wrong place during an incident.

**Refusals never quote what they found.** They name the rules that fired, because the matched values are the secrets themselves and must not travel back to a client. A test asserts no verdict contains `AKIA`.

**A missing OCR sidecar is reduced capability, not failure.** The cheap detectors still run; text simply cannot be read. Otherwise a deployment that has not installed OCR would refuse every image, which would make the safe default unusable.

## Wiring

Hooked into `enforce_post_route_policy`, already the pre-dispatch gate returning `RequestError`, and added to the reachability guard so it cannot quietly lose its caller the way three earlier entry points did.

10 tests, covering both failure policies, the deadline genuinely bounding the request (asserted on elapsed time), an undecodable payload following the same policy, and other modes never refusing so callers can invoke it unconditionally.

1839 tests with the feature, 1723 without, clippy clean on default, `--features media`, `--all-features`, and `--no-default-features --features media`.
