### PR TITLE
chore: release v0.36.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.93](https://github.com/azerozero/grob/compare/v0.36.92...v0.36.93) - 2026-08-05
+
+### Added
+
+- *(media)* blocking inspection, fail-closed by default ([#526](https://github.com/azerozero/grob/pull/526))
+
+### Other
+
+- *(media)* guard against entry points losing their callers ([#525](https://github.com/azerozero/grob/pull/525))
+
 ## [0.36.92](https://github.com/azerozero/grob/compare/v0.36.91...v0.36.92) - 2026-08-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.92"
+version = "0.36.93"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.92"
+version = "0.36.93"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.92 -> 0.36.93

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.93](https://github.com/azerozero/grob/compare/v0.36.92...v0.36.93) - 2026-08-05

### Added

- *(media)* blocking inspection, fail-closed by default ([#526](https://github.com/azerozero/grob/pull/526))

### Other

- *(media)* guard against entry points losing their callers ([#525](https://github.com/azerozero/grob/pull/525))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).