### PR TITLE
test(media): cover the OCR success path in blocking mode

### DIFF
--- a/src/features/media/README.md
+++ b/src/features/media/README.md
@@ -172,6 +172,7 @@ test suite says nothing about whether the tests would notice a bug:
 | `phash.rs` | 1, provably equivalent (`\|` and `^` are identical after a left shift) |
 | `registry.rs` | 0 |
 | `sidecar/proto.rs`, `sidecar/config.rs` | 0 |
+| `blocking.rs` | 0 |
 
 Two survivors could not be killed by adding tests, and both indicated a design
 problem rather than a coverage gap: a duplicated bounds check in `decode.rs` made

--- a/src/features/media/blocking.rs
+++ b/src/features/media/blocking.rs
@@ -406,6 +406,83 @@ mod tests {
         );
     }
 
+    /// Runs a stub OCR sidecar returning `text` for any image.
+    fn start_ocr_stub(text: &'static str) -> (SidecarConfig, tempfile::TempDir) {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ocr.sock");
+        let listener = tokio::net::UnixListener::bind(&path).expect("bind");
+
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let (reader, mut writer) = tokio::io::split(stream);
+                    let mut line = String::new();
+                    if BufReader::new(reader).read_line(&mut line).await.is_err() {
+                        return;
+                    }
+                    let reply = format!(
+                        r#"{{"version":1,"text":{}}}"#,
+                        serde_json::to_string(text).expect("encode")
+                    );
+                    let _ = writer.write_all(format!("{reply}\n").as_bytes()).await;
+                    let _ = writer.flush().await;
+                });
+            }
+        });
+
+        let mut endpoints = HashMap::new();
+        endpoints.insert(
+            "ocr".to_string(),
+            Endpoint::Unix {
+                path: path.to_string_lossy().into_owned(),
+            },
+        );
+        (
+            SidecarConfig {
+                endpoints,
+                timeout_ms: Some(5_000),
+            },
+            dir,
+        )
+    }
+
+    #[tokio::test]
+    async fn a_secret_read_from_an_image_refuses_the_request() {
+        // The path blocking mode exists for: OCR succeeds, the text contains
+        // a secret, and the request is refused before it reaches a provider.
+        let (sidecar, _sock) = start_ocr_stub("AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE");
+        let config = blocking_config(sidecar, OnFailure::Deny);
+
+        let verdict =
+            inspect_blocking(&request_with_image(&png(400, 300)), &config, Some(&dlp())).await;
+
+        match verdict {
+            Verdict::Deny { reason, rules } => {
+                // Findings, not NotInspected: the sidecar worked perfectly.
+                assert_eq!(reason, DenyReason::Findings);
+                assert!(
+                    rules.iter().any(|r| r.contains("aws_access_key")),
+                    "expected the AWS rule: {rules:?}"
+                );
+            }
+            Verdict::Allow => panic!("a secret read from an image must refuse the request"),
+        }
+    }
+
+    #[tokio::test]
+    async fn clean_text_read_from_an_image_allows_the_request() {
+        // The counterpart: OCR succeeds and finds nothing, so the request
+        // proceeds. Without this, refusing everything would look like success.
+        let (sidecar, _sock) = start_ocr_stub("just a screenshot of a cat");
+        let config = blocking_config(sidecar, OnFailure::Deny);
+
+        let verdict =
+            inspect_blocking(&request_with_image(&png(400, 300)), &config, Some(&dlp())).await;
+        assert!(verdict.is_allowed(), "clean OCR text must not refuse");
+    }
+
     #[tokio::test]
     async fn the_deadline_bounds_the_request_and_denies_by_default() {
         // A wedged sidecar must not hold a request open, and the timeout is


### PR DESCRIPTION
Ran `cargo-mutants` on the blocking module from #526. One survivor:

```
MISSED src/features/media/blocking.rs:135:20: delete ! in examine
```

Deleting the negation in the findings check changed nothing, because **no test ever had a live OCR sidecar returning a secret while in blocking mode**. That is the exact path the mode exists for: the whole point of blocking is refusing a request whose image contains something.

## Two tests close it

- A stub sidecar returning a planted AWS key must refuse, with reason `Findings` rather than `NotInspected`. The distinction matters here: the sidecar worked perfectly, so it is the request that must change, not the infrastructure.
- Clean OCR text must **allow**. Without that side, a bug refusing everything would read as success.

**0 survivors on `blocking.rs`.** 1841 tests with the feature, clippy clean.

Worth noting the pattern: CI's mutation job passed on #526, and the local run found this. Same as #505, #507 and #508 earlier in this slice. The per-diff CI budget does not dig as deep as a targeted run on one file.
