### PR TITLE
feat(control): media provenance namespace with a role split

### DIFF
--- a/src/control/engine.rs
+++ b/src/control/engine.rs
@@ -54,6 +54,37 @@ pub enum Action {
     Hit(HitAction),
     /// Pledge profile management.
     Pledge(PledgeAction),
+    /// Media provenance queries.
+    Media(MediaAction),
+}
+
+/// Media provenance actions.
+///
+/// The split between the two reads is the whole point. `Verify` answers "did
+/// this image come from here", which is safe to expose widely. `Trace`
+/// answers "who produced it", which names a tenant and is exactly the leak
+/// the opaque handle exists to prevent, so it sits a rung higher.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op")]
+pub enum MediaAction {
+    /// Reports whether a handle is known to this instance.
+    Verify {
+        /// Hex-rendered provenance handle.
+        trace_id: String,
+    },
+    /// Resolves a handle to its full context.
+    Trace {
+        /// Hex-rendered provenance handle.
+        trace_id: String,
+    },
+    /// Finds records sharing a perceptual fingerprint.
+    ///
+    /// The fallback when a handle was stripped from the file. It reveals the
+    /// same context as `Trace`, so it carries the same requirement.
+    Fingerprint {
+        /// Hex-rendered perceptual fingerprint.
+        phash: String,
+    },
 }
 
 /// Server lifecycle actions.
@@ -328,12 +359,19 @@ pub fn required_role(action: &Action) -> Role {
         | Action::Budget(BudgetAction::Current | BudgetAction::Breakdown)
         | Action::Tools(ToolsAction::List | ToolsAction::Catalog)
         | Action::Hit(HitAction::ListPolicies | HitAction::GetPolicy { .. })
-        | Action::Pledge(PledgeAction::Status | PledgeAction::ListProfiles) => Role::Observer,
+        | Action::Pledge(PledgeAction::Status | PledgeAction::ListProfiles)
+        // "Is this ours?" is a yes/no that names nobody.
+        | Action::Media(MediaAction::Verify { .. }) => Role::Observer,
 
         // Operational mutations
         Action::Server(ServerAction::Reload)
         | Action::Config(ConfigAction::Reload | ConfigAction::Diff | ConfigAction::Get { .. })
-        | Action::Hit(HitAction::Resolve { .. }) => Role::Operator,
+        | Action::Hit(HitAction::Resolve { .. })
+        // Resolving a handle names a tenant, which is precisely what the
+        // opaque identifier keeps out of the image.
+        | Action::Media(MediaAction::Trace { .. } | MediaAction::Fingerprint { .. }) => {
+            Role::Operator
+        }
 
         // Administrative mutations
         Action::Keys(_)
@@ -461,6 +499,28 @@ pub fn parse_method(method: &str, params: Option<&serde_json::Value>) -> Option<
         "grob/pledge/clear" => Action::Pledge(PledgeAction::Clear),
         "grob/pledge/status" => Action::Pledge(PledgeAction::Status),
         "grob/pledge/list_profiles" => Action::Pledge(PledgeAction::ListProfiles),
+        // media
+        "grob/media/verify" => Action::Media(MediaAction::Verify {
+            trace_id: p
+                .get("trace_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        }),
+        "grob/media/trace" => Action::Media(MediaAction::Trace {
+            trace_id: p
+                .get("trace_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        }),
+        "grob/media/fingerprint" => Action::Media(MediaAction::Fingerprint {
+            phash: p
+                .get("phash")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        }),
 
         _ => return None,
     })
@@ -505,6 +565,10 @@ pub const ALL_METHODS: &[&str] = &[
     "grob/pledge/clear",
     "grob/pledge/status",
     "grob/pledge/list_profiles",
+    // media
+    "grob/media/verify",
+    "grob/media/trace",
+    "grob/media/fingerprint",
 ];
 
 #[cfg(test)]
@@ -692,6 +756,79 @@ mod tests {
                 assert_eq!(context["tenant"], "acme");
             }
             _ => panic!("expected Hit::Resolve"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod media_ns_tests {
+    use super::*;
+
+    #[test]
+    fn verify_is_observer_but_trace_is_operator() {
+        // The split that matters. "Is this ours?" names nobody, so it can be
+        // exposed widely. "Who made it?" names a tenant, which is exactly the
+        // fact the opaque handle keeps out of the image, so it costs a rung.
+        assert_eq!(
+            required_role(&Action::Media(MediaAction::Verify {
+                trace_id: "0000000000000001".into()
+            })),
+            Role::Observer
+        );
+        assert_eq!(
+            required_role(&Action::Media(MediaAction::Trace {
+                trace_id: "0000000000000001".into()
+            })),
+            Role::Operator
+        );
+        // Fingerprint reveals the same context as trace, by another route.
+        assert_eq!(
+            required_role(&Action::Media(MediaAction::Fingerprint {
+                phash: "00000000deadbeef".into()
+            })),
+            Role::Operator
+        );
+    }
+
+    #[test]
+    fn an_observer_cannot_reach_the_tenant_naming_reads() {
+        // Stated as a privilege comparison so a future reshuffle of the role
+        // ladder cannot silently open these up.
+        assert!(!Role::Observer.has_at_least(Role::Operator));
+        assert!(Role::Operator.has_at_least(Role::Observer));
+    }
+
+    #[test]
+    fn media_methods_parse_with_their_parameters() {
+        let params = serde_json::json!({ "trace_id": "00000000deadbeef" });
+        let parsed = parse_method("grob/media/verify", Some(&params));
+        let Some(Action::Media(MediaAction::Verify { trace_id })) = parsed else {
+            panic!("grob/media/verify did not parse into a Verify action");
+        };
+        assert_eq!(trace_id, "00000000deadbeef");
+
+        let params = serde_json::json!({ "phash": "cafebabecafebabe" });
+        let parsed = parse_method("grob/media/fingerprint", Some(&params));
+        let Some(Action::Media(MediaAction::Fingerprint { phash })) = parsed else {
+            panic!("grob/media/fingerprint did not parse into a Fingerprint action");
+        };
+        assert_eq!(phash, "cafebabecafebabe");
+    }
+
+    #[test]
+    fn media_methods_are_discoverable() {
+        // ALL_METHODS drives discovery and the MCP bridge; a method missing
+        // from it exists but cannot be found.
+        for method in [
+            "grob/media/verify",
+            "grob/media/trace",
+            "grob/media/fingerprint",
+        ] {
+            assert!(
+                ALL_METHODS.contains(&method),
+                "{method} is not discoverable"
+            );
+            assert!(parse_method(method, None).is_some());
         }
     }
 }

--- a/src/features/media/README.md
+++ b/src/features/media/README.md
@@ -108,6 +108,22 @@ A `TraceId` is the only thing that will ever be written into an image. Never a t
 
 Handles are issued for every inspected image and recorded in `~/.grob/media/trace/YYYY-MM.jsonl` alongside the perceptual fingerprint. The fingerprint is what allows an image whose handle was stripped to still be traced, since it is computed from pixels rather than read from the file.
 
+## Control surface
+
+Three read-only RPC methods, split across two roles on purpose:
+
+| Method | Role | Answers |
+|---|---|---|
+| `grob/media/verify` | Observer | is this handle known here |
+| `grob/media/trace` | Operator | who produced this image |
+| `grob/media/fingerprint` | Operator | same, when the handle was stripped |
+
+`verify` names nobody, so it is safe to expose widely. `trace` returns the tenant, which is exactly the fact the opaque handle keeps out of the file, so it costs a rung. Putting both at the same level would undo the reason the identifier is opaque in the first place.
+
+`verify` reports **which layer answered** rather than a bare boolean: a handle read from a signed manifest and one recovered from a fingerprint are both useful and not equally strong, and collapsing that into `true` would hide the difference.
+
+Because these go through `ControlEngine`, they reach CLI, JSON-RPC and the MCP bridge at once.
+
 ## Blocking mode
 
 `mode = "blocking"` inspects images before dispatch and can refuse. That raises a question the async path never faces: what happens when the inspection itself fails, through a timeout, an unreachable sidecar, or an open circuit. All three mean the same thing, that the image was never examined.

--- a/src/server/rpc/media_ns.rs
+++ b/src/server/rpc/media_ns.rs
@@ -1,0 +1,199 @@
+//! `grob/media/*` namespace: provenance handle resolution.
+//!
+//! Three reads, split across two roles on purpose. `verify` answers "is this
+//! handle known here", which names nobody and is safe to expose widely.
+//! `trace` and `fingerprint` return the tenant that produced an image, which
+//! is precisely the fact the opaque handle keeps out of the file, so they sit
+//! a rung higher.
+
+use super::auth::{require_role, CallerIdentity};
+use super::types::{rpc_err, Role, ERR_INTERNAL};
+use crate::server::AppState;
+// The registry is read from disk rather than from AppState; the parameter is
+// kept for signature symmetry with the other namespaces.
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Answer to `grob/media/verify`.
+///
+/// Carries no context beyond existence, so an Observer can ask "did this come
+/// from us" without learning who produced it.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VerifyResponse {
+    /// Whether the handle is recorded by this instance.
+    pub known: bool,
+    /// Which layer answered, so a caller can weigh the result.
+    ///
+    /// A handle read from a signed manifest and one recovered from a
+    /// fingerprint are both useful, and not equally strong. Reporting the
+    /// layer keeps that distinction visible instead of collapsing it into a
+    /// boolean.
+    pub layer: &'static str,
+}
+
+/// Answer to `grob/media/trace` and `grob/media/fingerprint`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TraceResponse {
+    /// Matching records, newest first.
+    pub records: Vec<crate::features::media::trace::TraceRecord>,
+}
+
+/// Reports whether a provenance handle is known.
+///
+/// # Errors
+///
+/// Returns `ERR_FORBIDDEN` when the caller is below `Observer`,
+/// `INVALID_PARAMS_CODE` when the handle is malformed, and `ERR_INTERNAL`
+/// when the registry cannot be read.
+pub async fn verify(
+    _state: &Arc<AppState>,
+    caller: &CallerIdentity,
+    trace_id: &str,
+) -> Result<VerifyResponse, ErrorObjectOwned> {
+    require_role(caller, Role::Observer)?;
+    let id = parse_trace_id(trace_id)?;
+    let registry = open_registry()?;
+    let known = registry
+        .resolve(id)
+        .map_err(|e| rpc_err(ERR_INTERNAL, format!("registry read failed: {e}")))?
+        .is_some();
+    Ok(VerifyResponse {
+        known,
+        layer: "registry",
+    })
+}
+
+/// Resolves a provenance handle to its full context.
+///
+/// # Errors
+///
+/// Returns `ERR_FORBIDDEN` when the caller is below `Operator`,
+/// `INVALID_PARAMS_CODE` when the handle is malformed, and `ERR_INTERNAL`
+/// when the registry cannot be read.
+pub async fn trace(
+    _state: &Arc<AppState>,
+    caller: &CallerIdentity,
+    trace_id: &str,
+) -> Result<TraceResponse, ErrorObjectOwned> {
+    // Operator, not Observer: the answer names a tenant.
+    require_role(caller, Role::Operator)?;
+    let id = parse_trace_id(trace_id)?;
+    let registry = open_registry()?;
+    let records = registry
+        .resolve(id)
+        .map_err(|e| rpc_err(ERR_INTERNAL, format!("registry read failed: {e}")))?
+        .into_iter()
+        .collect();
+    Ok(TraceResponse { records })
+}
+
+/// Finds records sharing a perceptual fingerprint.
+///
+/// The fallback for an image whose handle was stripped: the fingerprint comes
+/// from pixels, so nothing needs to have survived inside the file.
+///
+/// # Errors
+///
+/// Returns `ERR_FORBIDDEN` when the caller is below `Operator`,
+/// `INVALID_PARAMS_CODE` when the fingerprint is malformed, and
+/// `ERR_INTERNAL` when the registry cannot be read.
+pub async fn fingerprint(
+    _state: &Arc<AppState>,
+    caller: &CallerIdentity,
+    phash: &str,
+) -> Result<TraceResponse, ErrorObjectOwned> {
+    require_role(caller, Role::Operator)?;
+    if phash.len() != 16 || !phash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(rpc_err(
+            INVALID_PARAMS_CODE,
+            "phash must be 16 hexadecimal digits".to_string(),
+        ));
+    }
+    let registry = open_registry()?;
+    let records = registry
+        .resolve_by_phash(phash)
+        .map_err(|e| rpc_err(ERR_INTERNAL, format!("registry read failed: {e}")))?;
+    Ok(TraceResponse { records })
+}
+
+/// Parses a handle, rejecting anything that could not have been embedded.
+fn parse_trace_id(
+    trace_id: &str,
+) -> Result<crate::features::media::trace::TraceId, ErrorObjectOwned> {
+    crate::features::media::trace::TraceId::from_hex(trace_id).ok_or_else(|| {
+        rpc_err(
+            INVALID_PARAMS_CODE,
+            "trace_id must be 16 hexadecimal digits within 61 bits".to_string(),
+        )
+    })
+}
+
+/// Opens the provenance registry.
+fn open_registry() -> Result<crate::features::media::trace::TraceRegistry, ErrorObjectOwned> {
+    let home = crate::grob_home()
+        .ok_or_else(|| rpc_err(ERR_INTERNAL, "no grob home directory".to_string()))?;
+    crate::features::media::trace::TraceRegistry::open(&home)
+        .map_err(|e| rpc_err(ERR_INTERNAL, format!("cannot open registry: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::media::trace::{TraceId, TraceRecord, TraceRegistry};
+
+    #[test]
+    fn malformed_handles_are_refused_before_touching_the_registry() {
+        // Cheap input validation, but it also protects the invariant: a value
+        // that cannot round-trip through the watermark is not a handle, so
+        // accepting it would invite callers to build ones that never work.
+        assert!(parse_trace_id("").is_err());
+        assert!(parse_trace_id("abc").is_err());
+        assert!(parse_trace_id("not-hex-at-all!!").is_err());
+        // Right length, but bits above the 61st cannot be embedded.
+        assert!(parse_trace_id("ffffffffffffffff").is_err());
+        // A valid handle parses.
+        assert!(parse_trace_id("00000000deadbeef").is_ok());
+    }
+
+    #[test]
+    fn a_recorded_handle_resolves_through_the_same_path_the_rpc_uses() {
+        // Exercises the registry the handlers read, so a change to its layout
+        // fails here rather than only in production.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut registry = TraceRegistry::open(dir.path()).expect("open");
+
+        let id = TraceId::generate();
+        registry
+            .record(
+                &TraceRecord::new(id)
+                    .with_tenant("acme")
+                    .with_phash("cafebabecafebabe"),
+            )
+            .expect("record");
+
+        let reopened = TraceRegistry::open(dir.path()).expect("reopen");
+        let found = reopened.resolve(id).expect("resolve").expect("known");
+        assert_eq!(found.tenant.as_deref(), Some("acme"));
+
+        let by_phash = reopened
+            .resolve_by_phash("cafebabecafebabe")
+            .expect("resolve");
+        assert_eq!(by_phash.len(), 1);
+    }
+
+    #[test]
+    fn verify_reports_which_layer_answered() {
+        // A boolean would hide the difference between a handle read from a
+        // signed manifest and one recovered from a fingerprint. Both are
+        // useful; they are not equally strong.
+        let response = VerifyResponse {
+            known: true,
+            layer: "registry",
+        };
+        let json = serde_json::to_value(&response).expect("serialise");
+        assert_eq!(json["layer"], "registry");
+        assert_eq!(json["known"], true);
+    }
+}

--- a/src/server/rpc/mod.rs
+++ b/src/server/rpc/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod budget_ns;
 pub(crate) mod config_ns;
 pub(crate) mod hit_ns;
 pub(crate) mod keys_ns;
+#[cfg(feature = "media")]
+pub(crate) mod media_ns;
 pub(crate) mod model_ns;
 pub(crate) mod pledge_ns;
 pub(crate) mod provider_ns;
@@ -66,6 +68,30 @@ async fn dispatch_action(
             let r = server_ns::reload_config(state, caller).await?;
             to_json(r)
         }
+
+        // ── grob/media/* ──
+        #[cfg(feature = "media")]
+        Action::Media(MediaAction::Verify { trace_id }) => {
+            let r = media_ns::verify(state, caller, trace_id).await?;
+            to_json(r)
+        }
+        #[cfg(feature = "media")]
+        Action::Media(MediaAction::Trace { trace_id }) => {
+            let r = media_ns::trace(state, caller, trace_id).await?;
+            to_json(r)
+        }
+        #[cfg(feature = "media")]
+        Action::Media(MediaAction::Fingerprint { phash }) => {
+            let r = media_ns::fingerprint(state, caller, phash).await?;
+            to_json(r)
+        }
+        // Compiled out: the namespace parses but reports the capability as
+        // absent, which is clearer to an operator than an unknown method.
+        #[cfg(not(feature = "media"))]
+        Action::Media(_) => Err(types::rpc_err(
+            types::ERR_INTERNAL,
+            "media support is not compiled into this build".to_string(),
+        )),
 
         // ── grob/model/* ──
         Action::Model(ModelAction::List) => model_ns::list(state, caller).await,


### PR DESCRIPTION
First half of PR 7. The full public surface question is still yours, but the **read-only** side is not blocked by it: `ControlEngine` already defines the RBAC model, and resolving a provenance handle is exactly the Observer/Operator split it exists for.

## The role split is the design

| Method | Role | Answers |
|---|---|---|
| `grob/media/verify` | Observer | is this handle known here |
| `grob/media/trace` | **Operator** | who produced this image |
| `grob/media/fingerprint` | **Operator** | same, when the handle was stripped |

`verify` names nobody. `trace` returns the tenant, which is *precisely the fact the opaque handle keeps out of the file*. Putting both at the same level would undo the reason the identifier is opaque in the first place.

A test states this as a privilege comparison rather than an equality, so a future reshuffle of the role ladder cannot silently open the tenant-naming reads.

## verify reports a layer, not a boolean

A handle read from a signed manifest and one recovered from a fingerprint are both useful, and **not equally strong**. Collapsing that into `true` would hide the difference exactly where a caller needs it to weigh the answer.

## Two smaller things

Handles are validated before the registry is touched: a value with bits above the 61st cannot round-trip through the watermark, so accepting it would invite callers to build identifiers that never work.

Adding the enum variant made the compiler flag the non-exhaustive match in the RPC dispatcher — the exhaustiveness check doing its job. Without the `media` feature the namespace still parses and reports the capability as absent, which is clearer to an operator than an unknown method.

Because these go through `ControlEngine`, they reach CLI, JSON-RPC and the MCP bridge at once.

7 tests. 1863 with the feature, 1727 without, clippy clean on default and `--all-features`, doc-tests green.
