### PR TITLE
docs(design): split PR 7 and mark the RPC surface delivered

### DIFF
--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -31,7 +31,8 @@
 | 5 | Mode `blocking` (fail-closed par défaut) | `media` | oui | ✅ **livré** (#526, #528) |
 | 6a | Registre `trace_id` (61 bits, opaque) | `media` | non | ✅ **livré** (#530) |
 | 6b | Provenance L1 (C2PA) via sidecar | sidecar, ou `media-c2pa` | non | à faire |
-| 7 | Surfaces : RPC `media/*`, HTTP verify, CLI | `media` | non | à faire |
+| 7a | RPC `media/*` en lecture seule (Observer/Operator) | `media` | non | ✅ **livré** (#533) |
+| 7b | Endpoint HTTP verify + CLI | `media` | non | à faire |
 | 8 | Watermark L2 via sidecar TrustMark | `media` | non | à faire |
 | 9 | Lib JS `grob-media-verify` | — | non | à faire |
 | 10 | Vidéo : L1 conteneur + keyframes L3 | `media` | non | à faire |


### PR DESCRIPTION
PR 7 split: the read-only RPC namespace (#533) did not depend on the wider public-surface arbitration, so it shipped with the Observer/Operator split the leak model requires. 7b, the HTTP endpoint and CLI, still waits on that decision.