### PR TITLE
feat(agents): attribute request spend to the calling agent

### DIFF
--- a/src/features/agents/mod.rs
+++ b/src/features/agents/mod.rs
@@ -307,6 +307,83 @@ mod tests {
         );
     }
 
+    /// The failure this repository hit three times in the media slice, now
+    /// guarded here before it becomes a fourth: code merged, fully tested,
+    /// and called by nothing.
+    ///
+    /// Unit tests cannot see it, because each piece passes alone. This walks
+    /// the source and fails when a wiring point loses its caller.
+    #[test]
+    fn agent_attribution_stays_wired_into_the_request_path() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+
+        // (symbol, why it matters, file where a caller must exist).
+        let wirings = [
+            (
+                "AgentContext::from_headers",
+                "no request would ever be attributed",
+                "server/handlers.rs",
+            ),
+            (
+                "ctx.agent_id()",
+                "the parsed agent would never reach the spend record",
+                "server/dispatch/telemetry.rs",
+            ),
+            (
+                "record_attributed",
+                "attribution would stop at the budget layer",
+                "server/budget.rs",
+            ),
+            (
+                "record_spend_for_agent",
+                "nothing would reach the journal",
+                "features/token_pricing/spend.rs",
+            ),
+        ];
+
+        for (symbol, consequence, caller) in wirings {
+            let path = root.join(caller);
+            let contents = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+            assert!(
+                contents.contains(symbol),
+                "{caller} no longer references {symbol}: {consequence}. \
+                 Wire it back up or delete the feature."
+            );
+        }
+    }
+
+    /// Proves attribution survives the *whole* production path rather than
+    /// just the storage call: tracker -> store -> journal on disk.
+    #[test]
+    fn the_tracker_carries_attribution_all_the_way_to_the_journal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = crate::storage::GrobStore::open(&dir.path().join("grob.db")).expect("store");
+        let mut tracker = crate::features::token_pricing::spend::SpendTracker::with_store(
+            std::sync::Arc::new(store),
+        );
+
+        tracker.record_attributed(None, "anthropic", "sonnet", 1.5, Some("planner"));
+        // Same call shape without an agent must behave exactly as before.
+        tracker.record_attributed(None, "anthropic", "sonnet", 2.0, None);
+
+        let month = crate::features::token_pricing::spend::current_month();
+        let raw = std::fs::read_to_string(dir.path().join("spend").join(format!("{month}.jsonl")))
+            .expect("read journal");
+        let agents: Vec<Option<String>> = raw
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| {
+                serde_json::from_str::<serde_json::Value>(l)
+                    .expect("parse")
+                    .get("agent")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect();
+        assert_eq!(agents, vec![Some("planner".to_string()), None]);
+    }
+
     #[test]
     fn an_absent_agent_is_omitted_from_serialisation() {
         // Existing journals and exports must stay byte-compatible for the

--- a/src/features/token_pricing/spend.rs
+++ b/src/features/token_pricing/spend.rs
@@ -161,6 +161,33 @@ impl SpendTracker {
         }
     }
 
+    /// Record spend carrying optional agent attribution.
+    ///
+    /// Falls back to the plain tenant/global paths when no agent is present or
+    /// no store is configured, so attribution never changes *whether* money is
+    /// recorded, only how precisely it is labelled.
+    pub fn record_attributed(
+        &mut self,
+        tenant: Option<&str>,
+        provider: &str,
+        model: &str,
+        cost: f64,
+        agent: Option<&str>,
+    ) {
+        let (Some(agent), Some(store)) = (agent, self.store.as_ref()) else {
+            match tenant {
+                Some(tenant) => self.record_tenant(tenant, provider, model, cost),
+                None => self.record(provider, model, cost),
+            }
+            return;
+        };
+        store.record_spend_for_agent(tenant, cost, provider, model, Some(agent));
+        // Mirror the non-agent paths: refresh the global view so request-count
+        // accessors stay consistent. Tenant-tagged dollars stay out of the
+        // global total, exactly as `record_tenant` documents.
+        self.data = store.load_spend(None);
+    }
+
     /// Get total spend for current month
     pub fn total(&self) -> f64 {
         self.data.total
@@ -409,6 +436,17 @@ impl crate::traits::SpendTracking for SpendTracker {
 
     fn record_tenant(&mut self, tenant: &str, provider: &str, model: &str, cost: f64) {
         self.record_tenant(tenant, provider, model, cost);
+    }
+
+    fn record_attributed(
+        &mut self,
+        tenant: Option<&str>,
+        provider: &str,
+        model: &str,
+        cost: f64,
+        agent: Option<&str>,
+    ) {
+        self.record_attributed(tenant, provider, model, cost, agent);
     }
 
     fn check_budget(

--- a/src/server/budget.rs
+++ b/src/server/budget.rs
@@ -213,6 +213,7 @@ pub(crate) async fn record_spend(
     model_name: &str,
     cost: f64,
     tenant_id: Option<&str>,
+    agent_id: Option<&str>,
 ) {
     if cost <= 0.0 {
         return;
@@ -223,7 +224,7 @@ pub(crate) async fn record_spend(
 
     match mode {
         crate::cli::TokenCountingMode::Api => {
-            commit_spend(state, provider_name, model_name, cost, tenant_id).await;
+            commit_spend(state, provider_name, model_name, cost, tenant_id, agent_id).await;
         }
         crate::cli::TokenCountingMode::Estimate => {
             // Consolidate the API-reported cost asynchronously so the response
@@ -232,8 +233,17 @@ pub(crate) async fn record_spend(
             let provider = provider_name.to_string();
             let model = model_name.to_string();
             let tenant = tenant_id.map(str::to_string);
+            let agent = agent_id.map(str::to_string);
             tokio::spawn(async move {
-                commit_spend(&state, &provider, &model, cost, tenant.as_deref()).await;
+                commit_spend(
+                    &state,
+                    &provider,
+                    &model,
+                    cost,
+                    tenant.as_deref(),
+                    agent.as_deref(),
+                )
+                .await;
             });
         }
     }
@@ -246,13 +256,10 @@ async fn commit_spend(
     model_name: &str,
     cost: f64,
     tenant_id: Option<&str>,
+    agent_id: Option<&str>,
 ) {
     let mut tracker = state.observability.spend_tracker.lock().await;
-    if let Some(tenant) = tenant_id {
-        tracker.record_tenant(tenant, provider_name, model_name, cost);
-    } else {
-        tracker.record(provider_name, model_name, cost);
-    }
+    tracker.record_attributed(tenant_id, provider_name, model_name, cost, agent_id);
 }
 
 /// Returns `true` when token counting runs in off-hot-path estimate mode.

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -33,6 +33,24 @@ use super::{
 use crate::features::watch::events::{DlpDirection, WatchEvent};
 
 /// All context needed to dispatch a request through the provider pipeline.
+impl DispatchContext<'_> {
+    /// Agent this request's spend is attributed to, if any.
+    ///
+    /// Two bodies rather than a gated call site: every caller stays
+    /// feature-agnostic, and a build without `agents` attributes to nothing
+    /// instead of failing to compile.
+    #[cfg(feature = "agents")]
+    pub(crate) fn agent_id(&self) -> Option<&str> {
+        self.agent.id()
+    }
+
+    /// Agent attribution is unavailable without the `agents` feature.
+    #[cfg(not(feature = "agents"))]
+    pub(crate) fn agent_id(&self) -> Option<&str> {
+        None
+    }
+}
+
 pub(crate) struct DispatchContext<'a> {
     pub state: &'a Arc<AppState>,
     pub inner: &'a Arc<ReloadableState>,
@@ -43,6 +61,12 @@ pub(crate) struct DispatchContext<'a> {
     pub is_streaming: bool,
     /// Tenant identifier from JWT claims (multi-tenant deployments).
     pub tenant_id: Option<String>,
+    /// Calling-agent attribution parsed from request headers.
+    ///
+    /// Carried, never inferred: a wrong attribution is worse than none,
+    /// because it points an investigation at the wrong agent.
+    #[cfg(feature = "agents")]
+    pub agent: crate::features::agents::AgentContext,
     /// Virtual-key model scope. When non-empty, the resolved model must be in
     /// this list; `None`/empty means the key is unscoped. Enforced post-routing.
     pub allowed_models: Option<Vec<String>>,
@@ -876,6 +900,7 @@ async fn record_fan_out_costs(
             actual_model,
             counter.estimated_cost_usd,
             ctx.tenant_id.as_deref(),
+            ctx.agent_id(),
         )
         .await;
     }
@@ -1109,6 +1134,8 @@ actual_model = "beta"
             model: "alpha".to_string(),
             is_streaming: false,
             tenant_id: None,
+            #[cfg(feature = "agents")]
+            agent: crate::features::agents::AgentContext::default(),
             allowed_models: Some(vec!["alpha".to_string()]),
             allowed_providers: Vec::new(),
             peer_ip: "127.0.0.1".to_string(),
@@ -1201,6 +1228,8 @@ context_window_tokens = 100
             model: "alpha".to_string(),
             is_streaming: false,
             tenant_id: None,
+            #[cfg(feature = "agents")]
+            agent: crate::features::agents::AgentContext::default(),
             allowed_models: None,
             allowed_providers: Vec::new(),
             peer_ip: "127.0.0.1".to_string(),
@@ -1354,6 +1383,8 @@ provider = "{provider}"
             model: "alpha".to_string(),
             is_streaming: false,
             tenant_id: tenant.map(|s| s.to_string()),
+            #[cfg(feature = "agents")]
+            agent: crate::features::agents::AgentContext::default(),
             allowed_models: None,
             allowed_providers: Vec::new(),
             peer_ip: "127.0.0.1".to_string(),
@@ -1613,6 +1644,8 @@ actual_model = "alpha"
             model: "alpha".to_string(),
             is_streaming: false,
             tenant_id: None,
+            #[cfg(feature = "agents")]
+            agent: crate::features::agents::AgentContext::default(),
             allowed_models: None,
             allowed_providers: Vec::new(),
             peer_ip: "127.0.0.1".to_string(),
@@ -1750,6 +1783,8 @@ actual_model = "alpha"
             model: "alpha".to_string(),
             is_streaming: false,
             tenant_id: None,
+            #[cfg(feature = "agents")]
+            agent: crate::features::agents::AgentContext::default(),
             allowed_models: None,
             allowed_providers: Vec::new(),
             peer_ip: "127.0.0.1".to_string(),

--- a/src/server/dispatch/retry.rs
+++ b/src/server/dispatch/retry.rs
@@ -342,6 +342,7 @@ pub(super) async fn dispatch_streaming(
                 actual_model: mapping.actual_model.clone(),
                 route_type: attempt.decision.route_type,
                 tenant_id: ctx.tenant_id.clone(),
+                agent_id: ctx.agent_id().map(str::to_string),
                 is_subscription: attempt.is_subscription,
                 estimated_input_tokens,
                 start_time: ctx.start_time,

--- a/src/server/dispatch/spend_stream.rs
+++ b/src/server/dispatch/spend_stream.rs
@@ -72,6 +72,8 @@ pub(crate) struct SpendStreamContext {
     pub route_type: RouteType,
     /// Tenant the spend is isolated to (multi-tenant deployments).
     pub tenant_id: Option<String>,
+    /// Calling agent the spend is attributed to, when the client supplied one.
+    pub agent_id: Option<String>,
     /// `true` when the provider is OAuth-backed (subscription = `$0`).
     pub is_subscription: bool,
     /// Local input-token estimate captured before the request was consumed.
@@ -603,6 +605,7 @@ fn record_stream_spend(ctx: &SpendStreamContext, usage: &StreamUsage) {
     let actual_model = ctx.actual_model.clone();
     let route_type = ctx.route_type;
     let tenant_id = ctx.tenant_id.clone();
+    let agent_id = ctx.agent_id.clone();
     let is_subscription = ctx.is_subscription;
     // Cache reads are priced separately (a fraction of input), so they are not
     // folded into the billed input count above; pass them through only when the
@@ -641,6 +644,7 @@ fn record_stream_spend(ctx: &SpendStreamContext, usage: &StreamUsage) {
             &model_name,
             cost.estimated_cost_usd,
             tenant_id.as_deref(),
+            agent_id.as_deref(),
         )
         .await;
     });

--- a/src/server/dispatch/telemetry.rs
+++ b/src/server/dispatch/telemetry.rs
@@ -107,6 +107,7 @@ pub(crate) async fn record_success_telemetry(
         &decision.model_name,
         cost_usd,
         ctx.tenant_id.as_deref(),
+        ctx.agent_id(),
     )
     .await;
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -674,6 +674,8 @@ pub(crate) async fn handle_openai_chat_completions(
         evaluate_policy_if_configured(&state, prelude.tenant_id.as_deref(), &model, &headers);
     let audited_flag = prelude.audited.clone();
     let ctx = dispatch::DispatchContext {
+        #[cfg(feature = "agents")]
+        agent: crate::features::agents::AgentContext::from_headers(&headers),
         state: &state,
         inner: &prelude.inner,
         dlp: &prelude.dlp,
@@ -793,6 +795,8 @@ pub(crate) async fn handle_responses(
         evaluate_policy_if_configured(&state, prelude.tenant_id.as_deref(), &model, &headers);
     let audited_flag = prelude.audited.clone();
     let ctx = dispatch::DispatchContext {
+        #[cfg(feature = "agents")]
+        agent: crate::features::agents::AgentContext::from_headers(&headers),
         state: &state,
         inner: &prelude.inner,
         dlp: &prelude.dlp,
@@ -922,6 +926,8 @@ pub(crate) async fn handle_messages(
         evaluate_policy_if_configured(&state, prelude.tenant_id.as_deref(), &model, &headers);
     let audited_flag = prelude.audited.clone();
     let ctx = dispatch::DispatchContext {
+        #[cfg(feature = "agents")]
+        agent: crate::features::agents::AgentContext::from_headers(&headers),
         state: &state,
         inner: &prelude.inner,
         dlp: &prelude.dlp,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -196,6 +196,27 @@ pub trait SpendTracking: Send {
     /// Records a cost entry scoped to a tenant.
     fn record_tenant(&mut self, tenant: &str, provider: &str, model: &str, cost: f64);
 
+    /// Records a cost entry carrying optional agent attribution.
+    ///
+    /// The default implementation **drops the agent** and delegates to
+    /// [`Self::record`] / [`Self::record_tenant`], so every existing
+    /// implementor keeps compiling and behaving identically. Attribution is
+    /// additive metadata: an implementor that cannot store it must still
+    /// record the money, because losing spend is worse than losing a label.
+    fn record_attributed(
+        &mut self,
+        tenant: Option<&str>,
+        provider: &str,
+        model: &str,
+        cost: f64,
+        _agent: Option<&str>,
+    ) {
+        match tenant {
+            Some(tenant) => self.record_tenant(tenant, provider, model, cost),
+            None => self.record(provider, model, cost),
+        }
+    }
+
     /// Checks budget limits and returns an error if exceeded.
     fn check_budget(
         &self,


### PR DESCRIPTION
A1 shipped the agent slice with **nothing calling it**: the fourth occurrence of the merged-but-unreachable failure in this repo, and the guard from #525 missed it because it only covers the media slice.

## The path

```
headers -> AgentContext -> DispatchContext::agent_id()
        -> record_spend -> record_attributed -> journal
```

`record_attributed` is a trait method whose **default body drops the agent** and delegates to the existing calls, so every implementor keeps compiling and an implementor that cannot store attribution still records the money. Losing spend is worse than losing a label.

`agent_id()` has two bodies instead of a gated call site: callers stay feature-agnostic, and a build without `agents` attributes to nothing rather than failing to compile.

## Evidence

- the guard asserts all four connection points, and I verified the assertion fires on a copy with the call renamed away rather than trusting it
- one test drives tracker -> store -> journal on disk and reads the JSONL back, so attribution is proven end to end and not just at the storage call
- the agent-less record still omits the key entirely rather than writing null, so existing exports parse byte-identically

1916 tests with `--all-features`, clippy clean with and without. The four `policies::hit` failures under `--no-default-features` are pre-existing on main, verified by stashing.
