### PR TITLE
test(agents): guard the streaming attribution path

### DIFF
--- a/src/features/agents/README.md
+++ b/src/features/agents/README.md
@@ -59,6 +59,25 @@ headers -> AgentContext -> DispatchContext::agent_id()
 
 A generic "no slice is orphaned" check was considered and rejected: every slice already has external references, so such a check passes trivially while a slice is half-wired. Naming the specific connection points is what makes the guard able to fail.
 
+## Verified against a live server
+
+Unit tests prove the pieces and the wiring guard proves the connections, but
+neither can prove a real request produces a real journal line. Run against a
+live `grob` with a mock backend:
+
+| request | journal line |
+|---|---|
+| `x-grob-agent-id: planner-7` | `"agent":"planner-7"` |
+| no header | key absent entirely |
+| `x-grob-agent-id: bad id!!` | HTTP 200, key absent |
+| streaming, `streamer-1` | `"agent":"streamer-1"` |
+
+The streaming case matters most: it bills through `SpendStreamContext`, a
+different code path from the non-streaming one. Attribution that worked only
+for non-streaming responses would be **worse than none**, because the gap
+would be invisible in the journal. `agent_id` in `dispatch/retry.rs` is in the
+wiring guard for exactly that reason.
+
 ## What mutation testing found here
 
 Two survivors, both **defects rather than missing tests**: `Display for AgentId` and `is_identified` had no caller outside the tests asserting on them, and `is_self_parented` detected a cyclic lineage then stored it anyway, leaving every consumer to re-check.

--- a/src/features/agents/mod.rs
+++ b/src/features/agents/mod.rs
@@ -321,6 +321,13 @@ mod tests {
                 "server/budget.rs",
             ),
             (
+                "agent_id",
+                "streamed responses would bill to nobody while \
+                 non-streaming ones stayed attributed, which is worse than \
+                 no attribution because the gap is invisible",
+                "server/dispatch/retry.rs",
+            ),
+            (
                 "record_spend_for_agent",
                 "nothing would reach the journal",
                 "features/token_pricing/spend.rs",


### PR DESCRIPTION
Attribution was verified against a live server with a mock backend, which
is the one claim no unit test can make: a real request producing a real
journal line. Both paths carry the agent, both omit the key when absent,
and a malformed header still returns 200.

That exercise exposed a hole in the guard: it covered the non-streaming
call site but not `SpendStreamContext`, a separate code path. Attribution
that worked only for non-streaming responses would be worse than none,
because the gap would be invisible in the journal.
