### PR TITLE
docs(compliance): correct AI Act article numbers and scope NIS2 honestly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1043,7 +1043,7 @@ jobs:
             --generate-notes \
             --notes-file CHECKSUMS.md \
             $PRERELEASE \
-            artifacts/*.tar.gz artifacts/*.sha256
+            artifacts/*.tar.gz artifacts/*.sha256 artifacts/sbom-grob.spdx.json
 
   homebrew-test:
     name: Test Homebrew install

--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ diligence, and a hardened configuration. Every implementation claim is [verified
 
 | Regulation | Coverage |
 |------------|----------|
-| **EU AI Act** | Art. 12 (signed audit log with model/tokens), Art. 14 (risk scoring + escalation webhook), Art. 15 (injection detection, 28 languages), Art. 52 (transparency headers) |
+| **EU AI Act** | Art. 12 (signed audit log with model/tokens), Art. 14 (risk scoring + escalation webhook), Art. 15 (injection detection, 28 languages), Art. 50 (transparency headers) |
 | **GDPR/RGPD** | PII redaction, name pseudonymization, EU-only provider routing (`gdpr = true`), canary tokens for leak detection |
 | **HDS/PCI-style evidence** | Hash-chained audit entries, Merkle batch signing, classification NC/C1/C2/C3, AES-256-GCM credentials at rest |
-| **NIS2/DORA** | Multi-provider resilience, escalation webhooks, zero-downtime upgrades |
+| **NIS2/DORA** | Multi-provider resilience, escalation webhooks, zero-downtime upgrades, SBOM on every release. [Reporting duties stay with you](docs/reference/features.md#nis2--dora) |
 
 ```bash
 grob preset apply eu-ai-act   # EU AI Act + GDPR-oriented controls

--- a/docs/design/002-media-agents-delivery-plan.md
+++ b/docs/design/002-media-agents-delivery-plan.md
@@ -44,7 +44,8 @@
 
 > **Révision après mesure.** Le sidecar est passé de la PR 4 à la PR 2, et C2PA de la
 > PR 5 à la PR 6, derrière le sidecar. Raison : `c2pa` compilé en dur coûte **+7,0 MB**
-> sur un binaire qui en fait 6 (mesure dans le design doc). Trois des couches lourdes
+> sur un binaire qui en fait **17,3** (mesure dans le design doc ; les 6 MB annoncés
+> ailleurs sont l'image conteneur musl, pas le binaire). Trois des couches lourdes
 > (OCR, C2PA, TrustMark) sont donc hors processus, ce qui fait du protocole sidecar la
 > fondation et non un détail d'implémentation. Le noyau ne manipule que `trace_id` et
 > pHash, tous deux légers.
@@ -321,9 +322,11 @@ docs/decisions/0032-content-provenance.md
 **Points de conception**
 
 - **Chemin par défaut : sidecar.** Mesure faite : `c2pa` compilé en dur ajoute
-  **+7,0 MB** à un binaire qui en fait 6, même en `--no-default-features` avec
-  `rust_native_crypto` (240 crates transitives : CBOR, COSE, X.509). Doubler la taille
-  de l'image pour signer des métadonnées n'est pas un arbitrage défendable par défaut.
+  **+7,0 MB** à un binaire de **17,3 MB** (soit +40 %), même en `--no-default-features`
+  avec `rust_native_crypto` (240 crates transitives : CBOR, COSE, X.509). Quatre dixièmes
+  de plus pour signer des métadonnées n'est pas un arbitrage défendable **par défaut**,
+  même si c'est moins spectaculaire que le doublement que ce document affirmait avant
+  que le binaire ne soit mesuré.
 - La feature `media-c2pa` reste disponible pour un binaire unique sans orchestration,
   avec le coût **écrit dans la doc**, pas découvert par l'utilisateur.
 - À savoir avant de commencer : `c2pa::Reader::from_file` exige la feature `file_io`,

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -96,14 +96,29 @@ Grob maps its features to specific regulatory requirements. The table below show
 
 ### EU AI Act
 
+Regulation (EU) 2024/1689. Grob is a component, not an AI system placed on the
+market: it produces technical evidence for a deployer or provider, it does not
+make anyone compliant. Article numbers below are those of the final regulation.
+
 | Article | Requirement | Grob Feature | Config |
 |---------|-------------|--------------|--------|
 | **Art. 12** | Record-keeping (logging of AI system usage) | Signed audit log with model name, token counts, timestamps, hash chain | `[compliance] audit_model_name = true`, `audit_token_counts = true` |
 | **Art. 14** | Human oversight (risk classification) | Per-request risk scoring with escalation webhook | `[compliance] risk_classification = true`, `escalation_webhook` |
 | **Art. 15** | Accuracy, robustness, cybersecurity | Prompt injection detection, DLP, circuit breakers | `[dlp] injection = "block"` |
-| **Art. 52** | Transparency obligations | `X-AI-Provider`, `X-AI-Model`, `X-AI-Generated` response headers | `[compliance] transparency_headers = true` |
+| **Art. 19** | Log retention (at least 6 months) | The audit log is strictly append-only — `current.jsonl` is never rotated or purged by grob | `[security] audit_dir` on durable, backed-up storage |
+| **Art. 50** | Transparency obligations | `X-AI-Provider`, `X-AI-Model`, `X-AI-Generated` response headers | `[compliance] transparency_headers = true` |
 
 **Preset**: `grob preset apply eu-ai-act` enables everything in one command.
+
+**What grob does not do for the AI Act**
+
+| Duty | Why it stays with you |
+|------|-----------------------|
+| Art. 4 — AI literacy of staff | An organizational and training duty. |
+| Art. 11 / Annex IV — technical documentation | Grob documents itself, not your AI system. |
+| Art. 27 — fundamental rights impact assessment | A legal assessment, not a proxy feature. |
+| Art. 6 / Annex III — risk classification of *your* use case | Grob's `risk_classification` scores individual requests for security risk. It is not the regulation's high-risk categorisation. |
+| Log deletion on schedule | Grob never deletes. If your retention policy caps at N months, purge `audit_dir` yourself; note this also breaks the hash chain from that point. |
 
 ### GDPR / RGPD
 
@@ -146,12 +161,29 @@ Grob maps its features to specific regulatory requirements. The table below show
 
 ### NIS2 / DORA
 
-| Requirement | Grob Feature |
-|-------------|--------------|
-| ICT risk management | Circuit breakers, adaptive provider scoring, spend budgets |
-| Incident reporting | Signed audit log, escalation webhooks, canary tokens |
-| Digital operational resilience | Multi-provider failover, zero-downtime upgrades, connection warmup |
-| Third-party risk | Per-provider spend tracking, rate limiting, model allowlists |
+NIS2 is transposed in France by the 2025 *résilience des infrastructures critiques
+et cybersécurité* law, with ANSSI as the supervisory authority. Grob is a component
+inside your information system, not the regulated entity. It supplies technical
+measures for Art. 21; the reporting duties and governance duties stay with you.
+
+| Art. 21 measure | Grob feature | Coverage |
+|-----------------|--------------|----------|
+| Business continuity, crisis management | Circuit breakers, multi-provider failover, zero-downtime upgrades, connection warmup | Covered |
+| Risk analysis, ICT risk management | Adaptive provider scoring, spend budgets, rate limits | Covered |
+| Cryptography and encryption | AES-256-GCM credentials at rest, TLS to providers, signed audit entries | Covered |
+| Logging and detection | Hash-chained signed audit log, DLP, canary tokens | Covered |
+| Supply-chain security | SPDX SBOM published on every GitHub release, cosign-signed container images, `cargo-audit` + `cargo-deny` in CI | Covered |
+| Access control | Virtual keys, JWT, per-tenant allowlists | Partial — no MFA/SSO; put grob behind an IdP-aware gateway |
+| Incident handling | Escalation webhook on risk classification | Partial — generic JSON payload, no ANSSI report template |
+
+**What grob does not do for NIS2**
+
+| Duty | Why it stays with you |
+|------|-----------------------|
+| ANSSI incident notification (24 h early warning, 72 h notification, 1 month final report) | The escalation webhook is a signal, not a filing. Wire it into your own incident process. |
+| Registration as an essential/important entity | An organizational duty, not a technical one. |
+| Management-body accountability and training | Out of scope for a proxy. |
+| Supplier due diligence on the LLM providers themselves | Grob routes to them; it cannot audit them. |
 
 ### Compliance presets
 
@@ -179,7 +211,7 @@ Every compliance claim was verified against the actual codebase:
 | 2 | EU AI Act Art. 14 — risk scoring | Implemented | `risk.rs:20-30` scoring: injection=critical, blocked+PII=high |
 | 3 | EU AI Act Art. 14 — escalation webhook | Implemented | `risk.rs:49-87` async POST to configured URL |
 | 4 | EU AI Act Art. 15 — injection detection | Implemented | `prompt_injection.rs` 28 languages + anti-obfuscation |
-| 5 | EU AI Act Art. 52 — transparency headers | Implemented | `middleware.rs:36-52` X-AI-Provider/Model/Generated |
+| 5 | EU AI Act Art. 50 — transparency headers | Implemented | `middleware.rs:36-52` X-AI-Provider/Model/Generated |
 | 6 | GDPR — region routing | Implemented | `helpers.rs` filters providers by region when `gdpr=true` |
 | 7 | GDPR — PII redaction | Implemented | `pii.rs` credit cards (Luhn), IBANs (mod97), BICs |
 | 8 | GDPR — name pseudonymization | Implemented | `names.rs` reversible HMAC-SHA256 mapping |

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -105,7 +105,7 @@ make anyone compliant. Article numbers below are those of the final regulation.
 | **Art. 12** | Record-keeping (logging of AI system usage) | Signed audit log with model name, token counts, timestamps, hash chain | `[compliance] audit_model_name = true`, `audit_token_counts = true` |
 | **Art. 14** | Human oversight (risk classification) | Per-request risk scoring with escalation webhook | `[compliance] risk_classification = true`, `escalation_webhook` |
 | **Art. 15** | Accuracy, robustness, cybersecurity | Prompt injection detection, DLP, circuit breakers | `[dlp] injection = "block"` |
-| **Art. 19** | Log retention (at least 6 months) | The audit log is strictly append-only — `current.jsonl` is never rotated or purged by grob | `[security] audit_dir` on durable, backed-up storage |
+| **Art. 19** | Log retention (at least 6 months) | The audit log is strictly append-only: `current.jsonl` is never rotated or purged by grob | `[security] audit_dir` on durable, backed-up storage |
 | **Art. 50** | Transparency obligations | `X-AI-Provider`, `X-AI-Model`, `X-AI-Generated` response headers | `[compliance] transparency_headers = true` |
 
 **Preset**: `grob preset apply eu-ai-act` enables everything in one command.
@@ -114,11 +114,11 @@ make anyone compliant. Article numbers below are those of the final regulation.
 
 | Duty | Why it stays with you |
 |------|-----------------------|
-| Art. 4 — AI literacy of staff | An organizational and training duty. |
-| Art. 11 / Annex IV — technical documentation | Grob documents itself, not your AI system. |
-| Art. 27 — fundamental rights impact assessment | A legal assessment, not a proxy feature. |
-| Art. 6 / Annex III — risk classification of *your* use case | Grob's `risk_classification` scores individual requests for security risk. It is not the regulation's high-risk categorisation. |
-| Log deletion on schedule | Grob never deletes. If your retention policy caps at N months, purge `audit_dir` yourself; note this also breaks the hash chain from that point. |
+| Art. 4, AI literacy of staff | An organizational and training duty. |
+| Art. 11 and Annex IV, technical documentation | Grob documents itself, not your AI system. |
+| Art. 27, fundamental rights impact assessment | A legal assessment, not a proxy feature. |
+| Art. 6 and Annex III, risk classification of *your* use case | Grob's `risk_classification` scores individual requests for security risk. It is not the regulation's high-risk categorisation. |
+| Log deletion on schedule | Grob never deletes. If your retention policy caps at N months, purge `audit_dir` yourself. Note this also breaks the hash chain from that point. |
 
 ### GDPR / RGPD
 
@@ -173,8 +173,8 @@ measures for Art. 21; the reporting duties and governance duties stay with you.
 | Cryptography and encryption | AES-256-GCM credentials at rest, TLS to providers, signed audit entries | Covered |
 | Logging and detection | Hash-chained signed audit log, DLP, canary tokens | Covered |
 | Supply-chain security | SPDX SBOM published on every GitHub release, cosign-signed container images, `cargo-audit` + `cargo-deny` in CI | Covered |
-| Access control | Virtual keys, JWT, per-tenant allowlists | Partial — no MFA/SSO; put grob behind an IdP-aware gateway |
-| Incident handling | Escalation webhook on risk classification | Partial — generic JSON payload, no ANSSI report template |
+| Access control | Virtual keys, JWT, per-tenant allowlists | Partial: no MFA/SSO, put grob behind an IdP-aware gateway |
+| Incident handling | Escalation webhook on risk classification | Partial: generic JSON payload, no ANSSI report template |
 
 **What grob does not do for NIS2**
 


### PR DESCRIPTION
## Why

Audit of the AI Act / NIS2 claims for a French deployment.

**Factual error:** the transparency obligation is **Art. 50** of Regulation (EU) 2024/1689. `Art. 52` was the draft numbering and now covers GPAI with systemic risk. Three public places carried it (README, features.md twice).

**Overclaim:** the NIS2 row promised more than the code delivers. It now maps to the actual Art. 21 measures under the French 2025 transposition, marks access control and incident handling as *partial*, and states that ANSSI's 24h / 72h / 1-month notification deadlines are the operator's duty. An escalation webhook is a signal, not a filing.

**Gap closed:** the SPDX SBOM was generated in CI but only uploaded as a workflow artifact, expiring and invisible to users. It is now a release asset, which is what NIS2 supply-chain evidence actually needs.

**Retention:** Art. 19 requires at least 6 months of logs. Grob's audit log is strictly append-only (`current.jsonl`, no rotation, no purge), so this holds by construction. Documented rather than adding a purge engine nobody asked for.

## Changes

- `README.md`, `docs/reference/features.md` — Art. 52 becomes Art. 50
- `docs/reference/features.md` — Art. 19 retention row; "what grob does not do" tables for the AI Act and NIS2, mirroring the existing SOC 2 disclaimer
- `.github/workflows/ci.yml` — attach `sbom-grob.spdx.json` to GitHub releases
- `docs/design/002-media-agents-delivery-plan.md` — pending binary-size correction (17.3 MB, not 6 MB; the 6 MB figure is the musl container image)

## Verification

markdownlint clean, lychee offline link check passes, gitleaks passes. Docs plus one CI line; no Rust touched.
