### PR TITLE
chore: release v0.36.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.96](https://github.com/azerozero/grob/compare/v0.36.95...v0.36.96) - 2026-08-06
+
+### Other
+
+- delete the dead trait mocks and four redundant docs ([#543](https://github.com/azerozero/grob/pull/543))
+- *(compliance)* correct AI Act article numbers and scope NIS2 honestly ([#542](https://github.com/azerozero/grob/pull/542))
+- *(agents)* guard the streaming attribution path ([#541](https://github.com/azerozero/grob/pull/541))
+- *(agents)* record the request path and the mutation findings ([#540](https://github.com/azerozero/grob/pull/540))
+
 ## [0.36.95](https://github.com/azerozero/grob/compare/v0.36.94...v0.36.95) - 2026-08-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.95"
+version = "0.36.96"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.95"
+version = "0.36.96"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.95 -> 0.36.96

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.96](https://github.com/azerozero/grob/compare/v0.36.95...v0.36.96) - 2026-08-06

### Other

- delete the dead trait mocks and four redundant docs ([#543](https://github.com/azerozero/grob/pull/543))
- *(compliance)* correct AI Act article numbers and scope NIS2 honestly ([#542](https://github.com/azerozero/grob/pull/542))
- *(agents)* guard the streaming attribution path ([#541](https://github.com/azerozero/grob/pull/541))
- *(agents)* record the request path and the mutation findings ([#540](https://github.com/azerozero/grob/pull/540))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).