### PR TITLE
chore: release v0.36.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.97](https://github.com/azerozero/grob/compare/v0.36.96...v0.36.97) - 2026-08-06
+
+### Other
+
+- drop single-impl traits, fix all 49 doc-link warnings, dedupe docs ([#544](https://github.com/azerozero/grob/pull/544))
+
 ## [0.36.96](https://github.com/azerozero/grob/compare/v0.36.95...v0.36.96) - 2026-08-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.96"
+version = "0.36.97"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.96"
+version = "0.36.97"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.96 -> 0.36.97

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.97](https://github.com/azerozero/grob/compare/v0.36.96...v0.36.97) - 2026-08-06

### Other

- drop single-impl traits, fix all 49 doc-link warnings, dedupe docs ([#544](https://github.com/azerozero/grob/pull/544))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).