### PR TITLE
fix(media): satisfy the beta clippy chunks_exact_to_as_chunks lint

### DIFF
--- a/src/features/media/phash.rs
+++ b/src/features/media/phash.rs
@@ -63,7 +63,9 @@ impl GrayImage {
             return None;
         }
         let luma = rgb
-            .chunks_exact(3)
+            .as_chunks::<3>()
+            .0
+            .iter()
             .map(|p| {
                 let y = 0.299 * f32::from(p[0]) + 0.587 * f32::from(p[1]) + 0.114 * f32::from(p[2]);
                 // Saturating cast: the coefficients sum to 1, so y stays in range,
@@ -149,7 +151,7 @@ pub fn gradient_hash(img: &GrayImage) -> PerceptualHash {
 /// the hash stable under rescaling and JPEG noise.
 fn downsample(img: &GrayImage) -> [u8; GRID_W * GRID_H] {
     let mut grid = [0u8; GRID_W * GRID_H];
-    for (row, cell_row) in grid.chunks_exact_mut(GRID_W).enumerate() {
+    for (row, cell_row) in grid.as_chunks_mut::<GRID_W>().0.iter_mut().enumerate() {
         let y0 = (row as u64 * img.height as u64 / GRID_H as u64) as u32;
         let y1 = (((row as u64 + 1) * img.height as u64 / GRID_H as u64) as u32).max(y0 + 1);
         for (col, cell) in cell_row.iter_mut().enumerate() {

--- a/src/features/media/tests.rs
+++ b/src/features/media/tests.rs
@@ -631,7 +631,9 @@ fn hash_encodes_horizontal_gradients_not_a_constant() {
     assert_eq!(gradient_hash(&rising).0, 0);
 
     let falling_luma: Vec<u8> = ramp
-        .chunks_exact(16)
+        .as_chunks::<16>()
+        .0
+        .iter()
         .flat_map(|row| row.iter().rev().copied())
         .collect();
     let falling = GrayImage::new(16, 16, falling_luma).expect("image");


### PR DESCRIPTION
The nightly toolchain job has been red since 2026-08-05 (#524). Two lints were involved:

- `clippy::chunks_exact_to_as_chunks` — new in beta, fires on `chunks_exact`/`chunks_exact_mut` with a compile-time constant size. Three sites: `phash.rs` `from_rgb` (RGB triples), `phash.rs` `downsample` (grid rows), and one in the media tests. Replaced with `as_chunks::<N>()` / `as_chunks_mut::<N>()`, which hands back fixed-size arrays instead of slices, so the indexing inside is no longer bounds-checked at runtime.
- `clippy::double_must_use` on `#[async_trait]` traits — an upstream false positive, already gone in `1.99.0-beta.3`. No change needed.

Verified locally with the exact CI command (`cargo clippy --all-targets --all-features -- -D warnings`) on all three toolchains: stable 1.97.1, beta 1.99.0-beta.3, nightly 1.100.0. `cargo nextest run`: 1727 passed.

Closes #524.