### PR TITLE
chore: release v0.36.98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.98](https://github.com/azerozero/grob/compare/v0.36.97...v0.36.98) - 2026-09-01
+
+### Added
+
+- *(errors)* expose upstream provider errors as structured JSON ([#489](https://github.com/azerozero/grob/pull/489))
+
+### Fixed
+
+- *(media)* satisfy the beta clippy chunks_exact_to_as_chunks lint ([#551](https://github.com/azerozero/grob/pull/551))
+
+### Other
+
+- *(adr)* document the fail-closed dependency contract (ADR-0030) ([#487](https://github.com/azerozero/grob/pull/487))
+
 ## [0.36.97](https://github.com/azerozero/grob/compare/v0.36.96...v0.36.97) - 2026-08-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.97"
+version = "0.36.98"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.97"
+version = "0.36.98"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.97 -> 0.36.98

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.98](https://github.com/azerozero/grob/compare/v0.36.97...v0.36.98) - 2026-09-01

### Added

- *(errors)* expose upstream provider errors as structured JSON ([#489](https://github.com/azerozero/grob/pull/489))

### Fixed

- *(media)* satisfy the beta clippy chunks_exact_to_as_chunks lint ([#551](https://github.com/azerozero/grob/pull/551))

### Other

- *(adr)* document the fail-closed dependency contract (ADR-0030) ([#487](https://github.com/azerozero/grob/pull/487))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).