### PR TITLE
fix(server): do not fail startup when the metrics recorder is unavailable

### DIFF
--- a/docs/decisions/0030-fail-closed-dependency-contract.md
+++ b/docs/decisions/0030-fail-closed-dependency-contract.md
@@ -50,7 +50,7 @@ the line requires updating this ADR.
 | HIT / tool authorization | **block (deny)** on every non-approval outcome | `src/server/dispatch/retry.rs:794-806`: explicit deny, dropped channel, and timeout all map to `AuthDecision::Deny` |
 | Secret resolution (api_key `secret:`/`$ENV`) | **block** — resolved before the registry is built; unresolved never ships | `ProviderRegistry::from_configs_with_models` (see ADR trail of #280/#284) |
 | Audit log write | **continue + flag** | audit failure is logged, not fatal |
-| Metrics / OpenTelemetry export | **continue** | export is off the decision path |
+| Metrics / OpenTelemetry export | **continue** | `src/server/init.rs`: recorder install failure is logged, not propagated (the global recorder is a process one-shot, so a second server in one process must still boot) |
 | Token estimate / pricing | **continue (degrade)** | estimate falls back locally; never blocks |
 | Startup provider health probe (`validate_on_start`) | **continue** — opt-in, backgrounded | `src/server/init.rs:84`; never blocks the bind (see the zero-network-startup rule) |
 

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -148,7 +148,16 @@ pub(crate) async fn init_observability(
     let prometheus_recorder =
         metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
     let metrics_handle = prometheus_recorder.handle();
-    install_metrics_recorder(prometheus_recorder, &config.otel)?;
+    // Metrics are an *observing* dependency (ADR-0030): their failure must
+    // degrade, never block. `set_global_recorder` can only be called once per
+    // process, so propagating this error means the second server in a process
+    // refuses to start — an observability problem taking down the serving path,
+    // which is the contract violation in the other direction. `/metrics` on this
+    // instance renders from `metrics_handle` either way; what is lost is the
+    // recording of new samples, not the ability to serve traffic.
+    if let Err(e) = install_metrics_recorder(prometheus_recorder, &config.otel) {
+        warn!("⚠️  Metrics recorder unavailable, continuing without it: {e}");
+    }
 
     // Register `# HELP` / `# TYPE` metadata for every exported metric family.
     // Must run after the recorder is installed so the descriptions land on it
@@ -978,6 +987,24 @@ mod tests {
             rendered.contains("# TYPE grob_active_requests gauge"),
             "gauges must render as `gauge`"
         );
+
+        // Second install must FAIL, and startup must tolerate that failure.
+        //
+        // `set_global_recorder` is a process-wide one-shot. Propagating its
+        // error made a second server in the same process refuse to boot: an
+        // *observing* dependency taking down the serving path, which ADR-0030
+        // forbids in both directions. The assertion is folded into this test
+        // because it is the one that legitimately owns the global recorder;
+        // a standalone test would race it for the single install slot.
+        let second = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let result = install_metrics_recorder(second, &crate::cli::OtelConfig::default());
+        assert!(
+            result.is_err(),
+            "the global recorder is a one-shot; this test's premise is that a \
+             second install fails"
+        );
+        // `init_observability` logs and continues on this error rather than
+        // using `?`. See the call site.
     }
 
     /// Recursively collects every `.rs` file under `dir`.

--- a/tests/integration/conformance_test.rs
+++ b/tests/integration/conformance_test.rs
@@ -23,9 +23,11 @@
 //!
 //! ## Why one server for the whole file
 //!
-//! [`grob::server::start_server`] installs a process-global Prometheus recorder,
-//! so a second server in the same test binary cannot boot. The suite spawns one
-//! server with several configured routes and drives them sequentially.
+//! The Prometheus recorder is a process-global one-shot, so only the first
+//! server in a test binary installs it. Startup tolerates that (a metrics
+//! failure must never block serving, per ADR-0030), but a second server would
+//! still be recording into nothing, so the suite spawns one server with several
+//! configured routes and drives them sequentially.
 
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
Fixes the red `Coverage` job currently blocking #547, #552 and #555.

## What broke

`cargo llvm-cov` runs every integration test in **one process**; nextest gives each test its own. So a latent bug stayed invisible under the default suite and only surfaced in the Coverage job, on every open PR at once — including a docs-only one, which is what made it look like flaky infra rather than a real defect.

The bug: `install_metrics_recorder` failure was propagated with `?`. `metrics::set_global_recorder` is a process-wide one-shot, so the **second** server spawned in a test binary failed to boot, and the test that waits for `/health` timed out:

```
server did not become healthy at http://127.0.0.1:40099/health
```

Adding a second server-spawning test (the conformance gate, #554) is what tipped it over.

## Why this is a real bug, not a test-only annoyance

ADR-0030 classifies metrics as an **observing** dependency: failure must degrade, never block. The ADR even warns about this direction explicitly — "an audit or metrics failure that could block a request would itself be a contract violation in the other direction". The code did the opposite: an observability failure took down the serving path.

Notably the ADR's metrics row cited *no enforcing code*, unlike every other row. That empty cell was the tell. It now points at the call site that actually honours it.

Startup logs and continues. `/metrics` still renders from `metrics_handle` either way; what is lost is the recording of new samples, not the ability to serve.

## Verification

Reproduced and fixed with the exact CI command, not a proxy:

- `cargo llvm-cov --lcov` on `main`: **FAILS** (`responses_e2e_round_trip`, server never healthy).
- Same command with this fix: **272 passed**.
- `cargo test --test lib -- responses_e2e conformance` (both servers, one process): fails before, passes after.

Plus `cargo nextest run` 1730 passed, clippy `-D warnings` clean.

The regression assertion lives in `every_metric_family_is_described_without_otel`, the one test that legitimately owns the global recorder — a standalone test would race it for the single install slot.
