### PR TITLE
chore: release v0.36.101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.101](https://github.com/azerozero/grob/compare/v0.36.100...v0.36.101) - 2026-09-02
+
+### Fixed
+
+- *(lint)* silence the async_trait double_must_use false positive ([#560](https://github.com/azerozero/grob/pull/560))
+
+### Other
+
+- fix the instructions that actively mislead their reader ([#547](https://github.com/azerozero/grob/pull/547))
+
 ## [0.36.100](https://github.com/azerozero/grob/compare/v0.36.99...v0.36.100) - 2026-09-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.100"
+version = "0.36.101"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.100"
+version = "0.36.101"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.100 -> 0.36.101

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.101](https://github.com/azerozero/grob/compare/v0.36.100...v0.36.101) - 2026-09-02

### Fixed

- *(lint)* silence the async_trait double_must_use false positive ([#560](https://github.com/azerozero/grob/pull/560))

### Other

- fix the instructions that actively mislead their reader ([#547](https://github.com/azerozero/grob/pull/547))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).