### PR TITLE
feat(security): rate limit by OIDC client, and run the limiter after auth

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -251,6 +251,7 @@ Control rate limiting, security headers, body size limits, circuit breakers, and
 enabled = true                  # Master switch for all security middleware (default: true)
 rate_limit_rps = 0              # Requests per second per tenant/IP (default: 0 = disabled)
 rate_limit_burst = 0            # Burst allowance (default: 0; used only when rate_limit_rps > 0)
+rate_limit_by_client = false    # Key the limiter on the OIDC client, not the subject (default: false)
 max_body_size = 0               # Max request body in bytes (default: 0 = unlimited)
 security_headers = true         # Apply OWASP security headers (default: true)
 circuit_breaker = true          # Enable circuit breaker per provider (default: true)
@@ -267,6 +268,42 @@ scoring_persist = false         # Reserved; score persistence is not implemented
 ```
 
 When `enabled = false`, rate limiting, security headers, and circuit breaker middleware are all skipped. Individual features can also be toggled independently.
+
+### Rate limiting by OIDC client
+
+By default the limiter keys on the tenant, which for a user token is the `sub`
+claim — the individual **end user**. One application serving a thousand users
+therefore gets a thousand independent buckets and is not bounded at all. That is
+usually not what an API quota means.
+
+Set `rate_limit_by_client = true` to key client-scoped tokens on the OIDC client
+(`azp`, falling back to `client_id`) instead:
+
+```toml
+[security]
+rate_limit_rps = 10
+rate_limit_burst = 20
+rate_limit_by_client = true
+
+# Optional per-client overrides. A client absent from this map uses
+# rate_limit_rps, so only the exceptions need naming.
+[security.rate_limit_clients]
+"batch-indexer" = 200   # a trusted job that may push harder
+"partner-app"   = 5     # a third-party integration that must not
+```
+
+An override scales the burst by the same factor as the rate, so a client granted
+10x the throughput also gets 10x the burst rather than inheriting one sized for
+the default.
+
+Tokens carrying **no** client claim (a self-signed HMAC token, an API key, an
+anonymous request) keep their existing tenant/IP key, so enabling this cannot
+merge unrelated callers into one bucket.
+
+Two limits worth knowing: buckets are in-memory and therefore **per replica**
+(with N replicas the effective limit is N × `rate_limit_rps`), and the limiter
+runs after authentication, so rejected credentials never consume a legitimate
+caller's quota.
 
 The circuit breaker opens after 5 consecutive failures (30s timeout, 3 successes to close). When open, requests skip the provider and fall through to the next mapping.
 

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -7,7 +7,10 @@ use std::sync::RwLock;
 use crate::security::cache::{jwt_validation_cache, JwtValidationCache};
 
 /// JWT claims expected by Grob.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `Default` is derived so call sites can spread `..Default::default()` and stay
+/// source-compatible as optional claims are added.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GrobClaims {
     /// Subject — user ID, used as tenant_id when no explicit tenant claim
     pub sub: String,
@@ -22,12 +25,39 @@ pub struct GrobClaims {
     /// Audience
     #[serde(default)]
     pub aud: Option<String>,
+    /// Authorized party (OIDC `azp`) — the OAuth client the token was issued to.
+    ///
+    /// Distinct from [`GrobClaims::sub`], which identifies the *end user*. One
+    /// client serving many users has one `azp` and many `sub`s, so throttling on
+    /// `sub` does not bound what a single application can send.
+    #[serde(default)]
+    pub azp: Option<String>,
+    /// `client_id` claim, used by IdPs that do not emit `azp`.
+    ///
+    /// Keycloak and Auth0 send `azp`; others (and RFC 9068 access tokens) send
+    /// `client_id`. Accepting both means no IdP-specific configuration.
+    #[serde(default)]
+    pub client_id: Option<String>,
 }
 
 impl GrobClaims {
     /// Returns the effective tenant ID: explicit `tenant` claim, or `sub`.
     pub fn tenant_id(&self) -> &str {
         self.tenant.as_deref().unwrap_or(&self.sub)
+    }
+
+    /// Returns the OIDC client identity: `azp`, else `client_id`.
+    ///
+    /// `None` when the token carries neither, which is the normal shape of a
+    /// plain self-signed HMAC token. Callers must treat `None` as "not a
+    /// client-scoped token" rather than substituting the subject: silently
+    /// falling back to `sub` would apply a per-client limit to an individual
+    /// user and throttle the wrong principal.
+    pub fn client_id(&self) -> Option<&str> {
+        self.azp
+            .as_deref()
+            .or(self.client_id.as_deref())
+            .filter(|s| !s.is_empty())
     }
 }
 
@@ -385,6 +415,7 @@ mod tests {
             exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
             iss: None,
             aud: None,
+            ..Default::default()
         };
 
         let token = make_token(&claims, "test-secret-256-bits-minimum!!");
@@ -407,6 +438,7 @@ mod tests {
             exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
             iss: None,
             aud: None,
+            ..Default::default()
         };
 
         let token = make_token(&claims, "test-secret-256-bits-minimum!!");
@@ -428,6 +460,7 @@ mod tests {
             exp: (chrono::Utc::now() - chrono::Duration::hours(1)).timestamp() as u64,
             iss: None,
             aud: None,
+            ..Default::default()
         };
 
         let token = make_token(&claims, "test-secret-256-bits-minimum!!");
@@ -449,6 +482,7 @@ mod tests {
             exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
             iss: None,
             aud: None,
+            ..Default::default()
         };
 
         let token = make_token(&claims, "wrong-secret-256-bits-minim!!");
@@ -472,6 +506,7 @@ mod tests {
             exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
             iss: Some("grob-auth".to_string()),
             aud: None,
+            ..Default::default()
         };
         let token = make_token(&claims, "test-secret-256-bits-minimum!!");
         assert!(validator.validate(&token).is_ok());
@@ -492,6 +527,7 @@ mod tests {
             exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
             iss: None,
             aud: None,
+            ..Default::default()
         }
     }
 
@@ -567,5 +603,84 @@ mod tests {
             validator.validate(&token),
             Err(AuthError::InvalidToken(_))
         ));
+    }
+
+    /// `azp` is the client identity (Keycloak, Auth0).
+    #[test]
+    fn client_id_prefers_azp() {
+        let claims = GrobClaims {
+            sub: "user-1".to_string(),
+            azp: Some("my-app".to_string()),
+            client_id: Some("ignored".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(claims.client_id(), Some("my-app"));
+    }
+
+    /// `client_id` is the fallback for IdPs that do not emit `azp`.
+    #[test]
+    fn client_id_falls_back_to_client_id_claim() {
+        let claims = GrobClaims {
+            sub: "user-1".to_string(),
+            client_id: Some("svc-account".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(claims.client_id(), Some("svc-account"));
+    }
+
+    /// A token with no client claim is not client-scoped.
+    ///
+    /// Must be `None`, never a fallback to `sub`: substituting the subject would
+    /// apply a per-client quota to one individual user, throttling the wrong
+    /// principal while leaving the application unbounded.
+    #[test]
+    fn client_id_is_none_without_a_client_claim() {
+        let claims = GrobClaims {
+            sub: "user-1".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(claims.client_id(), None);
+    }
+
+    /// An empty claim is absent, not a client named "".
+    ///
+    /// An IdP emitting `"azp": ""` would otherwise collapse every such token
+    /// into one shared bucket.
+    #[test]
+    fn empty_client_claim_is_treated_as_absent() {
+        let claims = GrobClaims {
+            sub: "user-1".to_string(),
+            azp: Some(String::new()),
+            ..Default::default()
+        };
+        assert_eq!(claims.client_id(), None);
+    }
+
+    /// The client claims must survive a real validation round-trip.
+    ///
+    /// The accessor is only useful if `azp` actually deserializes off the wire;
+    /// a missing `#[serde]` field would silently read as `None` forever.
+    #[test]
+    fn azp_survives_token_validation() {
+        let config = JwtConfig {
+            hmac_secret: "test-secret-256-bits-minimum!!".to_string(),
+            ..Default::default()
+        };
+        let validator = JwtValidator::from_config(&config).unwrap();
+
+        let claims = GrobClaims {
+            sub: "user-123".to_string(),
+            exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
+            azp: Some("batch-indexer".to_string()),
+            ..Default::default()
+        };
+
+        let token = make_token(&claims, "test-secret-256-bits-minimum!!");
+        let decoded = validator.validate(&token).unwrap();
+        assert_eq!(
+            decoded.client_id(),
+            Some("batch-indexer"),
+            "azp must round-trip through signing and validation"
+        );
     }
 }

--- a/src/cli/config/security.rs
+++ b/src/cli/config/security.rs
@@ -22,6 +22,33 @@ pub struct SecurityConfig {
     /// Rate limit: burst capacity (only used when `rate_limit_rps` > 0).
     #[serde(default = "default_rate_limit_burst")]
     pub rate_limit_burst: u32,
+    /// Throttle by OIDC client (`azp` / `client_id`) instead of by subject.
+    ///
+    /// The default key is the tenant, which for a user token is the individual
+    /// end user. One application serving a thousand users therefore gets a
+    /// thousand independent buckets and is not bounded at all. Enabling this
+    /// keys client-scoped tokens by the *application*, which is what an API
+    /// quota usually means.
+    ///
+    /// Tokens with no client claim (a plain self-signed HMAC token, an API key,
+    /// an anonymous request) keep their existing key, so turning this on cannot
+    /// merge unrelated callers into one bucket.
+    #[serde(default)]
+    pub rate_limit_by_client: bool,
+    /// Per-client request-per-second overrides, keyed by OIDC client id.
+    ///
+    /// Only consulted when `rate_limit_by_client` is enabled. A client absent
+    /// from the map falls back to `rate_limit_rps`, so a deployment only has to
+    /// name the clients that differ from the default (a batch job that may push
+    /// harder, a partner integration that must push less).
+    ///
+    /// ```toml
+    /// [security.rate_limit_clients]
+    /// "batch-indexer" = 200
+    /// "partner-app"   = 5
+    /// ```
+    #[serde(default)]
+    pub rate_limit_clients: std::collections::HashMap<String, u32>,
     /// Maximum request body size in bytes (default 0 = unlimited).
     ///
     /// `0` disables the limit (no `RequestBodyLimitLayer` is installed). Set a
@@ -94,6 +121,8 @@ impl Default for SecurityConfig {
             enabled: true,
             rate_limit_rps: default_rate_limit_rps(),
             rate_limit_burst: default_rate_limit_burst(),
+            rate_limit_by_client: false,
+            rate_limit_clients: std::collections::HashMap::new(),
             max_body_size: BodySizeLimit::default(),
             security_headers: true,
             circuit_breaker: true,

--- a/src/security/cache.rs
+++ b/src/security/cache.rs
@@ -43,6 +43,7 @@ mod tests {
                 exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
                 iss: None,
                 aud: None,
+                ..Default::default()
             },
         };
 

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -67,6 +67,13 @@ pub enum RateLimitKey {
     Tenant(String),
     /// Keyed by source IP address (fallback).
     Ip(String),
+    /// Keyed by OIDC client (`azp` / `client_id`).
+    ///
+    /// A separate variant rather than a prefixed [`RateLimitKey::Tenant`] so a
+    /// client id can never collide with a tenant id that happens to share the
+    /// same string, which would silently merge two different principals into
+    /// one bucket.
+    Client(String),
 }
 
 /// Rate limiter with automatic cleanup
@@ -159,6 +166,44 @@ impl RateLimiter {
         (allowed, remaining, reset_after)
     }
 
+    /// Like [`RateLimiter::check`], but overrides this key's rate **and** burst.
+    ///
+    /// Distinct from [`RateLimiter::check_with_rps`], which pins `burst = rps`
+    /// and is meant for a dedicated policy limiter. Per-client overrides share
+    /// the middleware's limiter, where the deployment's configured burst is a
+    /// separate knob and must be preserved: collapsing it to `rps` would
+    /// silently remove the burst allowance for exactly the clients that were
+    /// given a custom rate.
+    pub async fn check_with_config(
+        &self,
+        key: &RateLimitKey,
+        config: RateLimitConfig,
+    ) -> (bool, u32, Option<Duration>) {
+        let rps = config.requests_per_second.max(1);
+        let burst_milli = config.burst.max(1) as u64 * 1000;
+
+        let mut buckets = self.buckets.write().await;
+        let bucket = buckets
+            .entry(key.clone())
+            .or_insert_with(|| TokenBucket::new(config.clone()));
+
+        // Honour the current configuration even if the bucket predates it, so a
+        // config reload takes effect without waiting for bucket expiry.
+        bucket.rps = rps;
+        bucket.burst_milli = burst_milli;
+        bucket.tokens_milli = bucket.tokens_milli.min(burst_milli);
+
+        let allowed = bucket.try_consume();
+        let remaining = bucket.remaining();
+        let reset_after = if allowed {
+            None
+        } else {
+            let needed_milli = 1000u64.saturating_sub(bucket.tokens_milli);
+            Some(Duration::from_millis(needed_milli / rps as u64))
+        };
+        (allowed, remaining, reset_after)
+    }
+
     /// Cleanup stale buckets (idle > 10 minutes)
     async fn cleanup_stale_buckets(buckets: &Arc<RwLock<HashMap<RateLimitKey, TokenBucket>>>) {
         const IDLE_TIMEOUT: Duration = Duration::from_secs(600);
@@ -226,5 +271,114 @@ mod tests {
         assert!(!allowed);
         assert_eq!(remaining, 0);
         assert!(reset.is_some());
+    }
+
+    /// Distinct clients must not share a bucket.
+    ///
+    /// The whole point of keying by client: exhausting one application's quota
+    /// must not throttle another.
+    #[tokio::test]
+    async fn client_keys_are_isolated() {
+        let limiter = RateLimiter::new(RateLimitConfig {
+            requests_per_second: 1,
+            burst: 1,
+        });
+        let a = RateLimitKey::Client("app-a".to_string());
+        let b = RateLimitKey::Client("app-b".to_string());
+
+        assert!(limiter.check(&a).await.0, "first request for app-a passes");
+        assert!(!limiter.check(&a).await.0, "app-a is now out of tokens");
+        assert!(
+            limiter.check(&b).await.0,
+            "app-b must be unaffected by app-a exhausting its bucket"
+        );
+    }
+
+    /// A client id must not collide with an identical tenant id.
+    ///
+    /// Both are user-controlled strings from different namespaces. If the key
+    /// were a prefixed string rather than a distinct variant, a tenant named
+    /// like a client would silently share its quota.
+    #[tokio::test]
+    async fn client_and_tenant_keys_do_not_collide() {
+        let limiter = RateLimiter::new(RateLimitConfig {
+            requests_per_second: 1,
+            burst: 1,
+        });
+        let as_client = RateLimitKey::Client("same-name".to_string());
+        let as_tenant = RateLimitKey::Tenant("same-name".to_string());
+
+        assert!(limiter.check(&as_client).await.0);
+        assert!(!limiter.check(&as_client).await.0, "client bucket drained");
+        assert!(
+            limiter.check(&as_tenant).await.0,
+            "a tenant sharing the client's name must have its own bucket"
+        );
+    }
+
+    /// A per-client override must apply its own rate *and* burst.
+    #[tokio::test]
+    async fn check_with_config_applies_rate_and_burst() {
+        let limiter = RateLimiter::new(RateLimitConfig {
+            requests_per_second: 1,
+            burst: 1,
+        });
+        let key = RateLimitKey::Client("batch".to_string());
+        let generous = RateLimitConfig {
+            requests_per_second: 50,
+            burst: 5,
+        };
+
+        // Five requests fit the overridden burst, where the default allowed one.
+        for i in 0..5 {
+            assert!(
+                limiter.check_with_config(&key, generous.clone()).await.0,
+                "request {i} must fit the overridden burst of 5"
+            );
+        }
+        assert!(
+            !limiter.check_with_config(&key, generous).await.0,
+            "the sixth must be throttled: an override raises the limit, not removes it"
+        );
+    }
+
+    /// A config change must take effect on an existing bucket.
+    ///
+    /// Buckets outlive a reload, so an override that only applied to freshly
+    /// created buckets would leave live clients on the old quota until they
+    /// went idle for ten minutes.
+    ///
+    /// Note what is asserted: raising the rate does **not** instantly grant
+    /// tokens (a token bucket accrues them over time, and handing out a windfall
+    /// on every reload would let a client burst past its quota by triggering
+    /// reloads). What must change is the *refill speed*.
+    #[tokio::test]
+    async fn check_with_config_updates_an_existing_bucket() {
+        let tight = RateLimitConfig {
+            requests_per_second: 1,
+            burst: 1,
+        };
+        let loose = RateLimitConfig {
+            requests_per_second: 200,
+            burst: 10,
+        };
+
+        // Baseline: at 1 rps, 30 ms is far too short to earn a token back.
+        let limiter = RateLimiter::new(tight.clone());
+        let key = RateLimitKey::Client("app".to_string());
+        assert!(limiter.check_with_config(&key, tight.clone()).await.0);
+        assert!(!limiter.check_with_config(&key, tight.clone()).await.0);
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            !limiter.check_with_config(&key, tight).await.0,
+            "at 1 rps the bucket must still be empty after 30 ms"
+        );
+
+        // Same bucket, raised quota: the same wait now refills it.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            limiter.check_with_config(&key, loose).await.0,
+            "the raised rate must apply to the bucket that already exists"
+        );
     }
 }

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -279,6 +279,60 @@ pub(crate) async fn request_id_middleware(mut request: Request<Body>, next: Next
     response
 }
 
+/// Returns the per-client rate-limit key for `claims`, when enabled and available.
+///
+/// `None` means "not client-scoped": either the feature is off or the token
+/// carries no `azp`/`client_id`. The caller then keeps the tenant key rather
+/// than inventing one, so a self-signed token or an API key is never merged
+/// into a client bucket it does not belong to.
+fn client_rate_limit_key(
+    state: &AppState,
+    claims: &crate::auth::GrobClaims,
+) -> Option<RateLimitKey> {
+    let inner = state.snapshot();
+    if !inner.config.security.rate_limit_by_client {
+        return None;
+    }
+    claims
+        .client_id()
+        .map(|id| RateLimitKey::Client(id.to_string()))
+}
+
+/// Returns the rate-limit configuration for a client key, when overridden.
+///
+/// Only [`RateLimitKey::Client`] can carry an override: the map is keyed by
+/// client id, and matching it against a tenant or IP key would apply one
+/// client's quota to an unrelated principal that happens to share the string.
+///
+/// The burst is scaled by the same factor as the rate, so a client granted 10x
+/// the throughput also gets 10x the burst window rather than inheriting a burst
+/// sized for the default rate.
+fn client_rps_override(
+    state: &AppState,
+    key: &RateLimitKey,
+) -> Option<crate::security::RateLimitConfig> {
+    let RateLimitKey::Client(id) = key else {
+        return None;
+    };
+    let inner = state.snapshot();
+    let security = &inner.config.security;
+    let rps = security.rate_limit_clients.get(id).copied()?;
+    if rps == 0 {
+        return None;
+    }
+    let default_rps = security.rate_limit_rps.max(1);
+    let burst = security
+        .rate_limit_burst
+        .saturating_mul(rps)
+        .checked_div(default_rps)
+        .unwrap_or(rps)
+        .max(rps);
+    Some(crate::security::RateLimitConfig {
+        requests_per_second: rps,
+        burst,
+    })
+}
+
 /// Rate limiting middleware: checks rate limiter before processing.
 /// Returns 429 with Retry-After header when rate exceeded.
 pub(crate) async fn rate_limit_check_middleware(
@@ -302,14 +356,26 @@ pub(crate) async fn rate_limit_check_middleware(
     {
         RateLimitKey::Tenant(format!("vk:{}", vk.key_id))
     } else if let Some(claims) = request.extensions().get::<crate::auth::GrobClaims>() {
-        RateLimitKey::Tenant(claims.tenant_id().to_string())
+        // Prefer the OIDC client when asked to: `sub` is the end user, so a
+        // per-subject bucket does not bound what one application can send.
+        // Falls back to the tenant when the token carries no client claim, so
+        // enabling this cannot lump unrelated callers together.
+        match client_rate_limit_key(&state, claims) {
+            Some(key) => key,
+            None => RateLimitKey::Tenant(claims.tenant_id().to_string()),
+        }
     } else if let Some(credential) = extract_api_credential(request.headers()) {
         RateLimitKey::Tenant(credential.to_string())
     } else {
         RateLimitKey::Ip("anonymous".to_string())
     };
 
-    let (allowed, _remaining, reset_after) = limiter.check(&key).await;
+    // A per-client override replaces the default rate for that bucket only,
+    // keeping the deployment's configured burst.
+    let (allowed, _remaining, reset_after) = match client_rps_override(&state, &key) {
+        Some(config) => limiter.check_with_config(&key, config).await,
+        None => limiter.check(&key).await,
+    };
 
     if !allowed {
         metrics::counter!("grob_ratelimit_rejected_total").increment(1);
@@ -603,6 +669,160 @@ pub(crate) async fn tenant_required_middleware(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Per-client rate limiting ──────────────────────────────────
+
+    /// Minimal config with the security knobs under test.
+    fn rl_config(extra: &str) -> crate::cli::AppConfig {
+        let toml = format!(
+            r#"
+[server]
+host = "127.0.0.1"
+port = 18098
+
+[router]
+default = "alpha"
+
+[[providers]]
+name = "mock"
+provider_type = "openai"
+auth_type = "apikey"
+api_key = "sk-test"
+base_url = "http://127.0.0.1:1"
+models = ["alpha"]
+
+[[models]]
+name = "alpha"
+[[models.mappings]]
+priority = 1
+provider = "mock"
+actual_model = "alpha"
+
+[security]
+rate_limit_rps = 10
+rate_limit_burst = 20
+{extra}
+"#
+        );
+        crate::cli::AppConfig::from_content(&toml, "rate_limit_client_test").expect("config parses")
+    }
+
+    fn state_for(extra: &str) -> Arc<AppState> {
+        crate::server::test_app_state(rl_config(extra), crate::providers::ProviderRegistry::new())
+    }
+
+    fn claims_with_azp(sub: &str, azp: Option<&str>) -> crate::auth::GrobClaims {
+        crate::auth::GrobClaims {
+            sub: sub.to_string(),
+            azp: azp.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    /// Disabled by default: the key must stay the tenant.
+    ///
+    /// Turning this on changes who gets throttled, so it must never happen
+    /// implicitly on an existing deployment.
+    #[tokio::test]
+    async fn client_key_is_not_used_unless_enabled() {
+        let state = state_for("");
+        let claims = claims_with_azp("user-1", Some("my-app"));
+        assert!(
+            client_rate_limit_key(&state, &claims).is_none(),
+            "per-client keying must be opt-in"
+        );
+    }
+
+    /// Enabled: two users of one client share a bucket.
+    ///
+    /// This is the entire point. Keyed by `sub`, an application serving many
+    /// users gets one bucket each and is not bounded at all.
+    #[tokio::test]
+    async fn enabled_keys_two_users_of_one_client_together() {
+        let state = state_for("rate_limit_by_client = true");
+        let a = client_rate_limit_key(&state, &claims_with_azp("user-1", Some("my-app")));
+        let b = client_rate_limit_key(&state, &claims_with_azp("user-2", Some("my-app")));
+
+        assert_eq!(
+            a,
+            Some(crate::security::RateLimitKey::Client("my-app".to_string()))
+        );
+        assert_eq!(a, b, "two users of the same client must share one bucket");
+    }
+
+    /// Different clients stay separate even for the same user.
+    #[tokio::test]
+    async fn enabled_keeps_distinct_clients_apart() {
+        let state = state_for("rate_limit_by_client = true");
+        let a = client_rate_limit_key(&state, &claims_with_azp("user-1", Some("app-a")));
+        let b = client_rate_limit_key(&state, &claims_with_azp("user-1", Some("app-b")));
+        assert_ne!(
+            a, b,
+            "one user acting through two clients must not share a bucket"
+        );
+    }
+
+    /// A token with no client claim falls back to the tenant key.
+    ///
+    /// Enabling the feature must not silently merge self-signed tokens, API
+    /// keys or anonymous callers into one shared bucket.
+    #[tokio::test]
+    async fn token_without_client_claim_falls_back_to_tenant() {
+        let state = state_for("rate_limit_by_client = true");
+        assert!(
+            client_rate_limit_key(&state, &claims_with_azp("user-1", None)).is_none(),
+            "no client claim means no client bucket"
+        );
+    }
+
+    /// No override configured → no per-key config, so the default applies.
+    #[tokio::test]
+    async fn no_override_uses_the_default_rate() {
+        let state = state_for("rate_limit_by_client = true");
+        let key = crate::security::RateLimitKey::Client("unlisted".to_string());
+        assert!(client_rps_override(&state, &key).is_none());
+    }
+
+    /// A configured override applies its rate and scales the burst with it.
+    ///
+    /// A client granted 10x throughput but left with the default burst would be
+    /// throttled on exactly the traffic shape the override was meant to allow.
+    #[tokio::test]
+    async fn override_applies_rate_and_scales_burst() {
+        let state = state_for(
+            "rate_limit_by_client = true\n\n[security.rate_limit_clients]\n\"batch\" = 100",
+        );
+        let key = crate::security::RateLimitKey::Client("batch".to_string());
+        let config = client_rps_override(&state, &key).expect("override must be found");
+
+        assert_eq!(config.requests_per_second, 100);
+        // default burst 20 at default rps 10 → 10x the rate means 10x the burst.
+        assert_eq!(config.burst, 200, "burst must scale with the granted rate");
+    }
+
+    /// An override must never be applied to a tenant or IP key.
+    ///
+    /// The map is keyed by client id; matching it against a tenant that happens
+    /// to share the string would hand one principal another's quota.
+    #[tokio::test]
+    async fn override_never_applies_to_a_tenant_or_ip_key() {
+        let state = state_for(
+            "rate_limit_by_client = true\n\n[security.rate_limit_clients]\n\"batch\" = 100",
+        );
+        assert!(
+            client_rps_override(
+                &state,
+                &crate::security::RateLimitKey::Tenant("batch".to_string())
+            )
+            .is_none(),
+            "a tenant named like a client must not inherit its quota"
+        );
+        assert!(client_rps_override(
+            &state,
+            &crate::security::RateLimitKey::Ip("batch".to_string())
+        )
+        .is_none());
+    }
 
     #[test]
     fn test_constant_time_eq_same() {

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -279,6 +279,15 @@ pub(crate) async fn request_id_middleware(mut request: Request<Body>, next: Next
     response
 }
 
+/// Hex-encoded SHA-256 of a credential, for use as an opaque bucket key.
+///
+/// Same input yields the same bucket, so throttling is unaffected; what changes
+/// is that the secret itself is never held in the bucket map.
+fn hash_credential(credential: &str) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(credential.as_bytes()))
+}
+
 /// Returns the per-client rate-limit key for `claims`, when enabled and available.
 ///
 /// `None` means "not client-scoped": either the feature is off or the token
@@ -365,7 +374,11 @@ pub(crate) async fn rate_limit_check_middleware(
             None => RateLimitKey::Tenant(claims.tenant_id().to_string()),
         }
     } else if let Some(credential) = extract_api_credential(request.headers()) {
-        RateLimitKey::Tenant(credential.to_string())
+        // Hash rather than store the raw credential: this key lives in the
+        // bucket map for up to ten idle minutes and derives `Debug`, so a
+        // future log line or panic message would otherwise print a usable API
+        // key. The digest partitions callers identically.
+        RateLimitKey::Tenant(format!("cred:{}", hash_credential(credential)))
     } else {
         RateLimitKey::Ip("anonymous".to_string())
     };
@@ -798,6 +811,33 @@ rate_limit_burst = 20
         assert_eq!(config.requests_per_second, 100);
         // default burst 20 at default rps 10 → 10x the rate means 10x the burst.
         assert_eq!(config.burst, 200, "burst must scale with the granted rate");
+    }
+
+    /// A raw API key must never become the bucket key.
+    ///
+    /// Bucket keys live in memory for up to ten idle minutes and `RateLimitKey`
+    /// derives `Debug`, so storing the credential verbatim would put a usable
+    /// secret one stray log line or panic message away from disclosure.
+    #[test]
+    fn api_credential_is_hashed_not_stored_verbatim() {
+        let secret = "sk-live-super-secret-value";
+        let hashed = hash_credential(secret);
+
+        assert!(
+            !hashed.contains(secret),
+            "the digest must not contain the credential"
+        );
+        assert_eq!(hashed.len(), 64, "sha-256 hex is 64 chars");
+        assert_eq!(
+            hashed,
+            hash_credential(secret),
+            "hashing must be stable, or a caller would get a new bucket per request"
+        );
+        assert_ne!(
+            hashed,
+            hash_credential("sk-live-super-secret-valuf"),
+            "distinct credentials must land in distinct buckets"
+        );
     }
 
     /// An override must never be applied to a tenant or IP key.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -354,8 +354,26 @@ pub(crate) fn test_app_state_with_source(
             pricing_table,
         },
         security: SecurityState {
-            jwt_validator: None,
-            rate_limiter: None,
+            // Mirror real startup for the two pieces middleware ordering
+            // depends on: without them every request is either unauthenticated
+            // or unthrottled, and an ordering bug between the two is invisible.
+            jwt_validator: if config.auth.mode == "jwt" {
+                crate::auth::JwtValidator::from_config(&config.auth.jwt)
+                    .ok()
+                    .map(Arc::new)
+            } else {
+                None
+            },
+            rate_limiter: (config.security.enabled && config.security.rate_limit_rps > 0).then(
+                || {
+                    Arc::new(crate::security::RateLimiter::new(
+                        crate::security::RateLimitConfig {
+                            requests_per_second: config.security.rate_limit_rps,
+                            burst: config.security.rate_limit_burst,
+                        },
+                    ))
+                },
+            ),
             dlp_sessions: None,
             provider_availability: None,
             audit_log: None,
@@ -588,14 +606,21 @@ fn build_app_router(config: &AppConfig, state: Arc<AppState>) -> axum::Router {
         tenant_required_middleware,
     ));
 
+    // Rate limiting must also run *after* auth, for the same reason: it keys on
+    // `GrobClaims` / `VirtualKeyContext`, which only exist once auth has run.
+    // Layered before `auth_middleware` here means it executes after it.
+    //
+    // Ordered this way it also stops counting a request that auth is about to
+    // reject, so a flood of bad credentials no longer consumes a legitimate
+    // caller's quota.
     let app = app.layer(axum::middleware::from_fn_with_state(
         state.clone(),
-        auth_middleware,
+        rate_limit_check_middleware,
     ));
 
     let app = app.layer(axum::middleware::from_fn_with_state(
         state.clone(),
-        rate_limit_check_middleware,
+        auth_middleware,
     ));
 
     let app = if config.security.security_headers {
@@ -912,3 +937,131 @@ const _: fn() = || {
     assert_send_sync::<AppState>();
     assert_send_sync::<ReloadableState>();
 };
+
+#[cfg(test)]
+mod middleware_order_tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    /// Config with JWT auth and a rate limit of exactly one request.
+    fn config() -> AppConfig {
+        let toml = r#"
+[server]
+host = "127.0.0.1"
+port = 18097
+
+[router]
+default = "alpha"
+
+[auth]
+mode = "jwt"
+
+[auth.jwt]
+hmac_secret = "test-secret-256-bits-minimum!!"
+
+[security]
+rate_limit_rps = 1
+rate_limit_burst = 1
+
+[[providers]]
+name = "mock"
+provider_type = "openai"
+auth_type = "apikey"
+api_key = "sk-test"
+base_url = "http://127.0.0.1:1"
+models = ["alpha"]
+
+[[models]]
+name = "alpha"
+[[models.mappings]]
+priority = 1
+provider = "mock"
+actual_model = "alpha"
+"#;
+        AppConfig::from_content(toml, "middleware_order_test").expect("config parses")
+    }
+
+    /// Signs an HMAC token matching the test config's secret.
+    fn sign_token(sub: &str, exp: u64) -> String {
+        let claims = crate::auth::GrobClaims {
+            sub: sub.to_string(),
+            exp,
+            ..Default::default()
+        };
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret(b"test-secret-256-bits-minimum!!"),
+        )
+        .expect("token signs")
+    }
+
+    fn request_with(auth: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/messages")
+            .header("authorization", auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"alpha","max_tokens":1,"messages":[{"role":"user","content":"x"}]}"#,
+            ))
+            .expect("request builds")
+    }
+
+    /// Rate limiting must run **after** authentication.
+    ///
+    /// The limiter keys on `GrobClaims` / `VirtualKeyContext`, which only exist
+    /// once auth has populated them. Layered the other way round those branches
+    /// are unreachable and every request falls back to keying on the raw
+    /// credential string — so two tokens for the same subject silently get two
+    /// separate buckets, and per-tenant (or per-client) limiting does not work
+    /// at all despite looking correct in isolation.
+    ///
+    /// Asserted through the ordering's observable consequence: two *different*
+    /// tokens carrying the same subject must share one bucket. Keying happens on
+    /// `GrobClaims::tenant_id()` only if the claims exist by then; otherwise the
+    /// limiter falls back to the raw credential string and each token gets its
+    /// own bucket, which is indistinguishable from "rate limiting works" unless
+    /// you look for exactly this.
+    #[tokio::test]
+    async fn rate_limiting_runs_after_authentication() {
+        let state = test_app_state(config(), crate::providers::ProviderRegistry::new());
+        let app = build_app_router(&state.snapshot().config.clone(), state);
+
+        // Same `sub`, different `exp` → same tenant, different credential string.
+        let now = chrono::Utc::now().timestamp() as u64;
+        let token_a = sign_token("same-user", now + 3600);
+        let token_b = sign_token("same-user", now + 3607);
+        assert_ne!(token_a, token_b, "the two tokens must differ byte-wise");
+
+        // Burst is 1: the first request spends the only token.
+        let first = app
+            .clone()
+            .oneshot(request_with(&format!("Bearer {token_a}")))
+            .await
+            .expect("router responds");
+        assert_ne!(
+            first.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "the first request must not be throttled"
+        );
+
+        // The second, with a different token for the same subject, must hit the
+        // same bucket. If it does not, the limiter keyed on the credential
+        // string, meaning it ran before auth and never saw the claims.
+        let second = app
+            .clone()
+            .oneshot(request_with(&format!("Bearer {token_b}")))
+            .await
+            .expect("router responds");
+        assert_eq!(
+            second.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "a second token for the same subject must share the tenant's bucket; \
+             anything else means the limiter ran before auth and keyed on the raw \
+             credential, silently giving one principal a bucket per token"
+        );
+    }
+}

--- a/tests/integration/multi_tenant_isolation_test.rs
+++ b/tests/integration/multi_tenant_isolation_test.rs
@@ -367,6 +367,7 @@ fn tenant_jwt_claim_is_authoritative() {
         exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
         iss: None,
         aud: None,
+        ..Default::default()
     };
     assert_eq!(
         claims.tenant_id(),
@@ -380,6 +381,7 @@ fn tenant_jwt_claim_is_authoritative() {
         exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
         iss: None,
         aud: None,
+        ..Default::default()
     };
     assert_eq!(
         claims_sub_only.tenant_id(),

--- a/tests/unit/jwt_cache_test.rs
+++ b/tests/unit/jwt_cache_test.rs
@@ -26,6 +26,7 @@ mod tests {
             exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as u64,
             iss: None,
             aud: None,
+            ..Default::default()
         }
     }
 
@@ -127,6 +128,7 @@ mod tests {
             exp: (chrono::Utc::now() - chrono::Duration::hours(1)).timestamp() as u64,
             iss: None,
             aud: None,
+            ..Default::default()
         };
         let token = make_token(&expired_claims, TEST_SECRET);
 


### PR DESCRIPTION
Answers "can we rate limit per OIDC client?" — and fixes a bug found while implementing it.

## The gap

The limiter keyed on the tenant, which for a user token is `sub`: the individual **end user**. An application serving a thousand users got a thousand independent buckets and was not bounded at all. That is rarely what an API quota means.

`azp` / `client_id` — the claims that actually identify the calling application — were not read at all.

## The change

```toml
[security]
rate_limit_rps = 10
rate_limit_burst = 20
rate_limit_by_client = true

[security.rate_limit_clients]
"batch-indexer" = 200
"partner-app"   = 5
```

- `GrobClaims` gains `azp` and `client_id`, with `client_id()` preferring `azp` (Keycloak, Auth0) and falling back to `client_id` (RFC 9068). No IdP-specific config.
- Opt-in: default behaviour is unchanged. Turning it on changes *who* gets throttled, so it must never happen implicitly.
- Tokens with **no** client claim keep their tenant/IP key. `client_id()` returns `None` rather than falling back to `sub`, because substituting the subject would apply a per-client quota to one user and throttle the wrong principal.
- `RateLimitKey::Client` is a distinct variant, not a prefixed `Tenant`, so a tenant that happens to share a client's name cannot silently share its bucket.
- Per-client overrides scale the burst by the same factor as the rate: a client granted 10x throughput that inherited a burst sized for the default rate would be throttled on exactly the traffic shape the override was meant to allow. Uses a new `check_with_config` rather than the existing `check_with_rps`, which pins `burst = rps` and is documented for a dedicated policy limiter.

## The bug this uncovered

End-to-end testing showed **no difference** with the flag on or off. The unit tests passed, so the fault was elsewhere.

`rate_limit_check_middleware` was layered to run **before** `auth_middleware`. In axum the layer applied last is outermost, so the limiter executed first, `GrobClaims` did not exist yet, and every authenticated request silently fell through to keying on the raw credential string. The `GrobClaims` branch was dead code.

Consequence beyond this feature: **per-tenant rate limiting did not work at all**. Two tokens for the same subject got two separate buckets. Proven against a live server — same `sub`, two tokens differing only in `exp`:

| | before | after |
|---|---|---|
| 10 concurrent requests, burst 1 | 4 pass | 2 pass |

Ordering it after auth also stops a flood of bad credentials from consuming a legitimate caller's quota.

## Verification

Against a **live server** with real signed JWTs, 10 concurrent requests released from a barrier (a naive loop cannot show this: each response takes long enough for the bucket to refill):

| Scenario | Result |
|---|---|
| 2 users, 1 client, flag **off** | 4 of 10 pass — a bucket each |
| 2 users, 1 client, flag **on** | 2 of 10 pass — one shared bucket |
| client with `= 50` override | 12 of 12 pass |
| client without override | 2 of 12 pass |

Every assertion mutation-verified: a `sub` fallback in `client_id()`, ignoring the enable flag, applying overrides to tenant/IP keys, and reverting the middleware order each make the corresponding test fail.

`test_app_state` now builds the JWT validator and rate limiter from config instead of hardcoding `None` — without both, an ordering bug between them is invisible to every unit test.

Full suite 1763 passed, clippy `-D warnings` clean, 24 doc tests, fmt clean.

## Known limits (documented)

Buckets are in-memory and therefore **per replica**: with N replicas the effective limit is N × `rate_limit_rps`.
