### PR TITLE
feat(security): enforce a fleet-wide rate limit without any coordination

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -329,6 +329,40 @@ refill rate, so `remaining` can never exceed `limit`. The window is how long a
 full burst takes to accrue — a token bucket refills continuously and has no
 fixed window, so this is the closest honest number to pace against.
 
+### Making the limit a real fleet-wide ceiling
+
+Buckets are per process, so N replicas each enforcing `rate_limit_rps` let the
+fleet through `N × rate_limit_rps`. When the limit is a **hard** constraint — a
+provider quota that returns 429, a contractual cap — declare the fleet size:
+
+```toml
+[security]
+rate_limit_rps = 1000          # the FLEET-wide limit
+rate_limit_burst = 1000
+rate_limit_replicas = 4        # each replica enforces its share
+rate_limit_margin_percent = 5  # withhold a little for rounding and restarts
+```
+
+Each replica then enforces `(1000 - 5%) / 4 = 237` rps, so the fleet cannot
+exceed 950. Measured on three live replicas with a limit of 30: **90 requests
+got through without the declaration, 27 with it.**
+
+The trade is utilisation for a guarantee, and it costs **no coordination at
+all** — no shared store, no gossip, not a single packet between replicas. A
+replica cannot borrow unused capacity from an idle peer, so unbalanced traffic
+leaves quota unused: with 3 replicas and all traffic hitting one of them, that
+replica is capped at a third of the fleet limit.
+
+Use it when overshooting the limit is worse than under-using it. Leave
+`rate_limit_replicas = 1` (the default) when the limit is merely protective —
+the behaviour is then bit-for-bit unchanged.
+
+The margin absorbs what division cannot: rounding up on small shares, a replica
+restarting with a full bucket, or a scale-up landing before the config catches
+up. A share never floors to zero, because a fleet larger than its own limit
+would otherwise reject **all** traffic — the limiter becoming the outage it
+exists to prevent.
+
 ### Checking what is actually enforced
 
 `/health` reports the limiter's scope, because a per-replica limit and a
@@ -338,17 +372,21 @@ fleet-wide one are indistinguishable from a response — both just answer `200`:
 {
   "rate_limit": {
     "enabled": true,
-    "scope": "per_replica",
-    "rps": 10,
-    "burst": 20,
+    "scope": "fleet",
+    "rps": 30,
+    "burst": 30,
+    "effective_rps_this_replica": 9,
+    "replicas": 3,
+    "margin_percent": 10,
     "keyed_by": "tenant",
     "client_overrides": 0
   }
 }
 ```
 
-`scope: per_replica` is the honest statement that the real fleet-wide ceiling is
-`replicas × rps`. This matters: LiteLLM's Redis-backed limiter silently degrades
+`scope` says which guarantee you have. `fleet` means `rps` is a real ceiling
+because each replica enforces `effective_rps_this_replica`. `per_replica` means
+the fleet can reach `replicas × rps`. This matters: LiteLLM's Redis-backed limiter silently degrades
 a configured global limit into a per-pod one when Redis errors
 ([BerriAI/litellm#35533](https://github.com/BerriAI/litellm/issues/35533)), so
 the deployment cannot tell which guarantee it has. grob has no shared store to

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -305,6 +305,55 @@ Two limits worth knowing: buckets are in-memory and therefore **per replica**
 runs after authentication, so rejected credentials never consume a legitimate
 caller's quota.
 
+### Quota headers
+
+Every response carries the current quota, not just the `429`. A client that only
+learns its budget from a rejection has already been throttled, which is what
+these fields exist to prevent.
+
+```http
+RateLimit-Policy: "default";q=20;w=2
+RateLimit: "default";r=19;t=2
+X-RateLimit-Limit: 20
+X-RateLimit-Remaining: 19
+X-RateLimit-Reset: 2
+```
+
+Both spellings are emitted with identical numbers: the IETF structured fields
+(`draft-ietf-httpapi-ratelimit-headers`) because that is where the ecosystem is
+heading, and the de-facto `X-RateLimit-*` because that is what clients parse
+today.
+
+The advertised quota is the **bucket capacity** (`rate_limit_burst`), not the
+refill rate, so `remaining` can never exceed `limit`. The window is how long a
+full burst takes to accrue — a token bucket refills continuously and has no
+fixed window, so this is the closest honest number to pace against.
+
+### Checking what is actually enforced
+
+`/health` reports the limiter's scope, because a per-replica limit and a
+fleet-wide one are indistinguishable from a response — both just answer `200`:
+
+```json
+{
+  "rate_limit": {
+    "enabled": true,
+    "scope": "per_replica",
+    "rps": 10,
+    "burst": 20,
+    "keyed_by": "tenant",
+    "client_overrides": 0
+  }
+}
+```
+
+`scope: per_replica` is the honest statement that the real fleet-wide ceiling is
+`replicas × rps`. This matters: LiteLLM's Redis-backed limiter silently degrades
+a configured global limit into a per-pod one when Redis errors
+([BerriAI/litellm#35533](https://github.com/BerriAI/litellm/issues/35533)), so
+the deployment cannot tell which guarantee it has. grob has no shared store to
+lose, but states the scope so the number can be reasoned about.
+
 The circuit breaker opens after 5 consecutive failures (30s timeout, 3 successes to close). When open, requests skip the provider and fall through to the next mapping.
 
 When `adaptive_scoring = true`, Grob ranks providers by a composite score (success rate, latency, recency) and computes `declared_priority / adaptive_factor` before the fallback loop. A degraded provider can move behind a lower-priority healthy provider. Scores are in-memory and decay over time to prevent stale rankings.

--- a/src/cli/config/security.rs
+++ b/src/cli/config/security.rs
@@ -49,6 +49,32 @@ pub struct SecurityConfig {
     /// ```
     #[serde(default)]
     pub rate_limit_clients: std::collections::HashMap<String, u32>,
+    /// Number of replicas sharing the configured limit (default 1).
+    ///
+    /// Buckets are per process, so N replicas each enforcing `rate_limit_rps`
+    /// let the fleet through `N * rate_limit_rps`. Declaring the replica count
+    /// makes each one enforce its **share** instead, turning the configured
+    /// number into a real fleet-wide ceiling.
+    ///
+    /// This trades utilisation for a hard guarantee, and it needs no
+    /// coordination: no shared store, no gossip, not a single packet between
+    /// replicas. The cost is that a replica cannot borrow unused capacity from
+    /// an idle peer, so unbalanced traffic leaves quota on the table.
+    ///
+    /// `1` (the default) keeps the historical behaviour exactly.
+    #[serde(default = "default_replica_count")]
+    pub rate_limit_replicas: u32,
+    /// Safety margin withheld from the fleet limit, in percent (default 0).
+    ///
+    /// Applied on top of the per-replica share. Absorbs the residual overshoot
+    /// that division cannot: rounding up on small shares, a replica restarting
+    /// with a full bucket, or a scale-up landing before the config catches up.
+    ///
+    /// Set it when the limit is a hard external constraint — a provider quota
+    /// that returns 429, a contractual cap — and leave it at 0 when the limit
+    /// is merely protective.
+    #[serde(default)]
+    pub rate_limit_margin_percent: u32,
     /// Maximum request body size in bytes (default 0 = unlimited).
     ///
     /// `0` disables the limit (no `RequestBodyLimitLayer` is installed). Set a
@@ -123,6 +149,8 @@ impl Default for SecurityConfig {
             rate_limit_burst: default_rate_limit_burst(),
             rate_limit_by_client: false,
             rate_limit_clients: std::collections::HashMap::new(),
+            rate_limit_replicas: default_replica_count(),
+            rate_limit_margin_percent: 0,
             max_body_size: BodySizeLimit::default(),
             security_headers: true,
             circuit_breaker: true,
@@ -157,6 +185,12 @@ fn default_flush_interval_ms() -> u64 {
 // legitimate burst (an autonomous agent easily exceeds any fixed rps). Re-enable
 // for multi-tenant deployments by setting `rate_limit_rps` (e.g. 100) in
 // `[security]`; a value of `0` skips installing the limiter entirely.
+// A single daemon is the default deployment, so the fleet is one replica and
+// the configured limit is already the fleet limit.
+fn default_replica_count() -> u32 {
+    1
+}
+
 fn default_rate_limit_rps() -> u32 {
     0
 }

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -19,6 +19,6 @@ pub use audit_log::AuditLog;
 pub use circuit_breaker::{CircuitBreakerRegistry, CircuitState};
 pub use fips::FipsStatus;
 pub use headers::{apply_security_headers, SecurityHeadersConfig};
-pub use rate_limit::{RateLimitConfig, RateLimitKey, RateLimiter};
+pub use rate_limit::{replica_share, RateLimitConfig, RateLimitKey, RateLimiter};
 pub use tee::TeeStatus;
 pub use tool_spike::{SpikeAction, ToolSpikeConfig, ToolSpikeDetector};

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -60,6 +60,37 @@ impl TokenBucket {
     }
 }
 
+/// Scales a fleet-wide limit down to one replica's share.
+///
+/// `N` replicas each enforcing the configured limit let the fleet through
+/// `N * limit`. Dividing by the replica count and withholding a margin turns
+/// the configured number into a ceiling the fleet cannot exceed — with no
+/// coordination at all: no shared store, no gossip, not one packet.
+///
+/// The floor of `1` is deliberate. A large fleet with a small limit would
+/// otherwise round each share down to zero and reject **all** traffic, turning
+/// a rate limiter into an outage. Overshooting a tiny limit is a far better
+/// failure than serving nothing, so the share never drops below one.
+///
+/// Returns the input unchanged for a single replica with no margin, so the
+/// default deployment is bit-for-bit unaffected.
+#[must_use]
+pub fn replica_share(limit: u32, replicas: u32, margin_percent: u32) -> u32 {
+    if limit == 0 {
+        // 0 means "no limit configured"; scaling it would invent one.
+        return 0;
+    }
+    let replicas = replicas.max(1);
+    // Cap the margin below 100: a 100% margin would withhold the entire quota.
+    let margin = margin_percent.min(99);
+
+    let after_margin = u64::from(limit) * u64::from(100 - margin) / 100;
+    let share = after_margin / u64::from(replicas);
+
+    // Never fewer than one token: see the floor rationale above.
+    u32::try_from(share).unwrap_or(u32::MAX).max(1)
+}
+
 /// Rate limiter key (tenant_id or IP fallback)
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum RateLimitKey {
@@ -380,5 +411,77 @@ mod tests {
             limiter.check_with_config(&key, loose).await.0,
             "the raised rate must apply to the bucket that already exists"
         );
+    }
+
+    /// The default deployment must be bit-for-bit unchanged.
+    #[test]
+    fn single_replica_no_margin_is_identity() {
+        assert_eq!(replica_share(100, 1, 0), 100);
+        assert_eq!(replica_share(7, 1, 0), 7);
+    }
+
+    /// The fleet total must never exceed the configured limit.
+    ///
+    /// This is the whole point: the configured number becomes a real ceiling
+    /// instead of a per-replica one that multiplies by the replica count.
+    #[test]
+    fn fleet_total_never_exceeds_the_configured_limit() {
+        for limit in [10u32, 100, 1000, 9999] {
+            for replicas in 1u32..=16 {
+                for margin in [0u32, 5, 20] {
+                    let share = replica_share(limit, replicas, margin);
+                    let fleet_total = u64::from(share) * u64::from(replicas);
+                    // The floor of 1 can overshoot a limit smaller than the
+                    // replica count; that case is asserted separately below.
+                    if u64::from(limit) >= u64::from(replicas) {
+                        assert!(
+                            fleet_total <= u64::from(limit),
+                            "limit={limit} replicas={replicas} margin={margin}: \
+                             fleet total {fleet_total} exceeds the configured limit"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// The margin is withheld from the fleet limit, as a percentage.
+    #[test]
+    fn margin_withholds_the_requested_share() {
+        // 1000 rps over 4 replicas, 5% withheld → 950 / 4 = 237.
+        assert_eq!(replica_share(1000, 4, 5), 237);
+        // 20% withheld → 800 / 4 = 200.
+        assert_eq!(replica_share(1000, 4, 20), 200);
+        // Margin alone, single replica.
+        assert_eq!(replica_share(1000, 1, 10), 900);
+    }
+
+    /// A limit smaller than the fleet must not reject everything.
+    ///
+    /// Dividing 5 rps across 10 replicas rounds each share to zero. Enforcing
+    /// that would serve **no** traffic at all — a rate limiter becoming the
+    /// outage it exists to prevent. Overshooting a tiny limit is the better
+    /// failure, so the share floors at one.
+    #[test]
+    fn share_never_floors_to_zero() {
+        assert_eq!(replica_share(5, 10, 0), 1, "must not reject all traffic");
+        assert_eq!(replica_share(1, 100, 0), 1);
+        // Even a pathological margin leaves one token.
+        assert_eq!(replica_share(10, 2, 99), 1);
+        assert_eq!(replica_share(10, 2, 100), 1, "margin is capped below 100%");
+    }
+
+    /// An unconfigured limit must stay unconfigured.
+    ///
+    /// Scaling zero would invent a limit where the operator asked for none.
+    #[test]
+    fn zero_limit_stays_zero() {
+        assert_eq!(replica_share(0, 8, 20), 0);
+    }
+
+    /// A zero replica count must not divide by zero.
+    #[test]
+    fn zero_replicas_is_treated_as_one() {
+        assert_eq!(replica_share(100, 0, 0), 100);
     }
 }

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -703,6 +703,16 @@ async fn enforce_post_route_policy(
         let key = crate::security::RateLimitKey::Tenant(
             ctx.tenant_id.clone().unwrap_or_else(|| "anon".to_string()),
         );
+        // A policy rps is a fleet-wide number like every other configured
+        // limit, so it takes this replica's share too. Without this, naming a
+        // rate limit in a policy would quietly exempt it from the fleet
+        // ceiling that `[security]` enforces everywhere else.
+        let sec = &ctx.inner.config.security;
+        let rps = crate::security::replica_share(
+            rps,
+            sec.rate_limit_replicas,
+            sec.rate_limit_margin_percent,
+        );
         let (allowed, _, _) = ctx
             .state
             .policy_rate_limiter

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -79,13 +79,26 @@ fn rate_limit_status(
     if !limiter_active || security.rate_limit_rps == 0 {
         return serde_json::json!({ "enabled": false });
     }
+    let replicas = security.rate_limit_replicas.max(1);
+    let share = crate::security::replica_share(
+        security.rate_limit_rps,
+        replicas,
+        security.rate_limit_margin_percent,
+    );
     serde_json::json!({
         "enabled": true,
-        // "per_replica" is a promise about the blast radius of this number, not
-        // a description of the storage backend.
-        "scope": "per_replica",
+        // The scope is a promise about the blast radius of `rps`, not a
+        // description of the storage backend. `fleet` means the configured
+        // number is a real ceiling because each replica enforces its share;
+        // `per_replica` means the fleet can reach `replicas * rps`.
+        "scope": if replicas > 1 { "fleet" } else { "per_replica" },
         "rps": security.rate_limit_rps,
         "burst": security.rate_limit_burst,
+        // What THIS process actually enforces, which is what an operator needs
+        // to reconcile the configured number with observed throughput.
+        "effective_rps_this_replica": share,
+        "replicas": replicas,
+        "margin_percent": security.rate_limit_margin_percent,
         "keyed_by": if security.rate_limit_by_client { "oidc_client" } else { "tenant" },
         "client_overrides": security.rate_limit_clients.len(),
     })
@@ -465,6 +478,32 @@ actual_model = "alpha"
         );
         assert_eq!(body["rate_limit"]["rps"], 10);
         assert_eq!(body["rate_limit"]["keyed_by"], "tenant");
+    }
+
+    /// Declaring a fleet must flip the scope and report the real share.
+    #[tokio::test]
+    async fn health_reports_fleet_scope_and_effective_share() {
+        let state = test_app_state(
+            config(
+                "\n[security]\nrate_limit_rps = 1000\nrate_limit_burst = 2000\n\
+                 rate_limit_replicas = 4\nrate_limit_margin_percent = 5\n",
+            ),
+            registry_with_provider(),
+        );
+        let resp = health_check(State(state)).await.into_response();
+        let body = json_body(resp).await;
+
+        assert_eq!(
+            body["rate_limit"]["scope"], "fleet",
+            "declaring replicas makes the configured number a real ceiling"
+        );
+        assert_eq!(body["rate_limit"]["rps"], 1000, "the fleet-wide limit");
+        // 1000 - 5% = 950, split four ways.
+        assert_eq!(
+            body["rate_limit"]["effective_rps_this_replica"], 237,
+            "the operator must see what THIS process enforces"
+        );
+        assert_eq!(body["rate_limit"]["replicas"], 4);
     }
 
     /// A disabled limiter must say so rather than report a phantom quota.

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -54,8 +54,41 @@ pub(super) async fn health_check(State(state): State<Arc<AppState>>) -> impl Int
         "revision": {
             "config": inner.config_revision.full(),
             "policy": inner.policy_revision.full(),
-        }
+        },
+        // What the limiter actually enforces on THIS replica. A limit that is
+        // only per-process is a different guarantee from a fleet-wide one, and
+        // the difference is invisible from a response: both just answer 200.
+        // Stating the scope is what lets an operator compute the real
+        // fleet-wide ceiling instead of assuming the configured number.
+        "rate_limit": rate_limit_status(&inner, state.security.rate_limiter.is_some()),
     }))
+}
+
+/// Reports the limiter's configuration and, crucially, its enforcement scope.
+///
+/// The scope is the honest part. Buckets are per process, so with N replicas
+/// the fleet-wide ceiling is `N * rps`, not `rps`. LiteLLM's equivalent silently
+/// degrades a configured global limit into a per-pod one on a Redis error;
+/// grob has no shared store to lose, but the same reasoning applies — the
+/// deployment must be told which guarantee it actually has.
+fn rate_limit_status(
+    inner: &crate::server::ReloadableState,
+    limiter_active: bool,
+) -> serde_json::Value {
+    let security = &inner.config.security;
+    if !limiter_active || security.rate_limit_rps == 0 {
+        return serde_json::json!({ "enabled": false });
+    }
+    serde_json::json!({
+        "enabled": true,
+        // "per_replica" is a promise about the blast radius of this number, not
+        // a description of the storage backend.
+        "scope": "per_replica",
+        "rps": security.rate_limit_rps,
+        "burst": security.rate_limit_burst,
+        "keyed_by": if security.rate_limit_by_client { "oidc_client" } else { "tenant" },
+        "client_overrides": security.rate_limit_clients.len(),
+    })
 }
 
 /// Liveness probe: process is alive, returns 200 always.
@@ -406,6 +439,43 @@ actual_model = "alpha"
             resp.status(),
             StatusCode::OK,
             "the 12-char form shown in logs must be usable as a pin"
+        );
+    }
+
+    /// Health must state the limiter's enforcement scope.
+    ///
+    /// A per-replica limit and a fleet-wide one are indistinguishable from a
+    /// response, so the scope has to be stated for the number to mean anything.
+    #[tokio::test]
+    async fn health_reports_rate_limit_scope() {
+        // The section must be a real `[security]` table: `config()` appends its
+        // argument at the end of the document, so bare keys would land in
+        // whatever table happens to be last.
+        let state = test_app_state(
+            config("\n[security]\nrate_limit_rps = 10\nrate_limit_burst = 20\n"),
+            registry_with_provider(),
+        );
+        let resp = health_check(State(state)).await.into_response();
+        let body = json_body(resp).await;
+
+        assert_eq!(body["rate_limit"]["enabled"], true);
+        assert_eq!(
+            body["rate_limit"]["scope"], "per_replica",
+            "the scope must be explicit: with N replicas the real ceiling is N * rps"
+        );
+        assert_eq!(body["rate_limit"]["rps"], 10);
+        assert_eq!(body["rate_limit"]["keyed_by"], "tenant");
+    }
+
+    /// A disabled limiter must say so rather than report a phantom quota.
+    #[tokio::test]
+    async fn health_reports_rate_limit_disabled() {
+        let state = test_app_state(config(""), registry_with_provider());
+        let resp = health_check(State(state)).await.into_response();
+        let body = json_body(resp).await;
+        assert_eq!(
+            body["rate_limit"]["enabled"], false,
+            "no configured quota must not look like an enforced one"
         );
     }
 

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -635,18 +635,45 @@ pub(crate) fn init_security(config: &AppConfig) -> anyhow::Result<SecurityServic
     // A rate_limit_rps of 0 disables throttling — don't install the limiter
     // (rps=0 would otherwise starve the token bucket and reject every request).
     let rate_limiter = if security_enabled && config.security.rate_limit_rps > 0 {
+        // The limiter is built once with THIS replica's share, because
+        // `RateLimiter::check` uses the bucket's own config: scaling only at
+        // the call site would leave the default path enforcing the whole fleet
+        // limit on every replica.
         let rl_config = RateLimitConfig {
-            requests_per_second: config.security.rate_limit_rps,
-            burst: config.security.rate_limit_burst,
+            requests_per_second: crate::security::replica_share(
+                config.security.rate_limit_rps,
+                config.security.rate_limit_replicas,
+                config.security.rate_limit_margin_percent,
+            ),
+            burst: crate::security::replica_share(
+                config.security.rate_limit_burst,
+                config.security.rate_limit_replicas,
+                config.security.rate_limit_margin_percent,
+            ),
         };
-        info!(
-            "🛡️  Security: rate limit {}rps burst={}, body limit {}, headers={}, circuit_breaker={}",
-            config.security.rate_limit_rps,
-            config.security.rate_limit_burst,
-            body_limit_desc,
-            config.security.security_headers,
-            config.security.circuit_breaker,
-        );
+        if config.security.rate_limit_replicas > 1 {
+            info!(
+                "🛡️  Security: fleet rate limit {}rps burst={} over {} replicas                  (margin {}%) → this replica enforces {}rps burst={}, body limit {},                  headers={}, circuit_breaker={}",
+                config.security.rate_limit_rps,
+                config.security.rate_limit_burst,
+                config.security.rate_limit_replicas,
+                config.security.rate_limit_margin_percent,
+                rl_config.requests_per_second,
+                rl_config.burst,
+                body_limit_desc,
+                config.security.security_headers,
+                config.security.circuit_breaker,
+            );
+        } else {
+            info!(
+                "🛡️  Security: rate limit {}rps burst={}, body limit {}, headers={}, circuit_breaker={}",
+                config.security.rate_limit_rps,
+                config.security.rate_limit_burst,
+                body_limit_desc,
+                config.security.security_headers,
+                config.security.circuit_breaker,
+            );
+        }
         Some(Arc::new(RateLimiter::new(rl_config)))
     } else if security_enabled {
         info!(

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -401,9 +401,20 @@ fn client_rps_override(
         .checked_div(default_rps)
         .unwrap_or(rps)
         .max(rps);
+    // A per-client quota is a fleet-wide number too, so it takes the same
+    // share; otherwise naming a client in the overrides map would quietly
+    // exempt it from the fleet ceiling.
     Some(crate::security::RateLimitConfig {
-        requests_per_second: rps,
-        burst,
+        requests_per_second: crate::security::replica_share(
+            rps,
+            security.rate_limit_replicas,
+            security.rate_limit_margin_percent,
+        ),
+        burst: crate::security::replica_share(
+            burst,
+            security.rate_limit_replicas,
+            security.rate_limit_margin_percent,
+        ),
     })
 }
 
@@ -449,9 +460,25 @@ pub(crate) async fn rate_limit_check_middleware(
     };
 
     // Default quota, unless a per-client override replaces it below.
-    let default_config = crate::security::RateLimitConfig {
-        requests_per_second: state.snapshot().config.security.rate_limit_rps,
-        burst: state.snapshot().config.security.rate_limit_burst,
+    //
+    // Scaled to this replica's share when the deployment declares a fleet size,
+    // so the configured number is a fleet-wide ceiling rather than a per-process
+    // one that silently multiplies by the replica count.
+    let default_config = {
+        let inner = state.snapshot();
+        let sec = &inner.config.security;
+        crate::security::RateLimitConfig {
+            requests_per_second: crate::security::replica_share(
+                sec.rate_limit_rps,
+                sec.rate_limit_replicas,
+                sec.rate_limit_margin_percent,
+            ),
+            burst: crate::security::replica_share(
+                sec.rate_limit_burst,
+                sec.rate_limit_replicas,
+                sec.rate_limit_margin_percent,
+            ),
+        }
     };
     let mut effective_limit = advertised_quota(&default_config);
     let mut effective_window = window_seconds(&default_config);

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -279,6 +279,71 @@ pub(crate) async fn request_id_middleware(mut request: Request<Body>, next: Next
     response
 }
 
+/// Quota advertised to clients, in requests.
+///
+/// The bucket's capacity (`burst`), not the refill rate. `remaining` is a count
+/// of tokens held, which is bounded by the capacity, so advertising the rate
+/// instead would let `remaining` exceed the limit — a client seeing
+/// `limit=10, remaining=19` cannot pace itself against either number.
+fn advertised_quota(config: &crate::security::RateLimitConfig) -> u32 {
+    config.burst.max(config.requests_per_second)
+}
+
+/// Window advertised for a quota, in whole seconds.
+///
+/// A token bucket has no fixed window: it refills continuously. The closest
+/// honest equivalent is how long a full burst takes to accrue, which is what a
+/// client needs in order to pace itself. Rounded up and floored at 1, because
+/// the IETF field is a non-zero integer number of seconds.
+fn window_seconds(config: &crate::security::RateLimitConfig) -> u64 {
+    let rps = u64::from(config.requests_per_second.max(1));
+    let burst = u64::from(config.burst.max(1));
+    burst.div_ceil(rps).max(1)
+}
+
+/// Writes the quota fields onto a response.
+///
+/// Emits both the IETF `RateLimit` / `RateLimit-Policy` fields
+/// (draft-ietf-httpapi-ratelimit-headers) and the de-facto `X-RateLimit-*`
+/// headers. The draft is not yet an RFC and no client library speaks it
+/// exclusively, so sending only the standard fields would be correct and
+/// useless; sending only `X-` would ignore where the ecosystem is going. Both
+/// carry identical numbers.
+///
+/// Silently skips a field whose value will not parse as a header, so a
+/// malformed quota can never turn a served response into a failure: these
+/// fields are advisory, and the request has already been decided.
+fn apply_ratelimit_headers(headers: &mut HeaderMap, limit: u32, remaining: u32, window_secs: u64) {
+    // A limit of 0 means "no quota configured"; advertising it would tell the
+    // client it may never send anything.
+    if limit == 0 {
+        return;
+    }
+
+    let set = |headers: &mut HeaderMap, name: &'static str, value: String| {
+        if let Ok(v) = HeaderValue::from_str(&value) {
+            headers.insert(name, v);
+        }
+    };
+
+    // IETF structured fields: the policy is stable, the service limit is not.
+    set(
+        headers,
+        "ratelimit-policy",
+        format!(r#""default";q={limit};w={window_secs}"#),
+    );
+    set(
+        headers,
+        "ratelimit",
+        format!(r#""default";r={remaining};t={window_secs}"#),
+    );
+
+    // De-facto headers, for every client that already parses them.
+    set(headers, "x-ratelimit-limit", limit.to_string());
+    set(headers, "x-ratelimit-remaining", remaining.to_string());
+    set(headers, "x-ratelimit-reset", window_secs.to_string());
+}
+
 /// Hex-encoded SHA-256 of a credential, for use as an opaque bucket key.
 ///
 /// Same input yields the same bucket, so throttling is unaffected; what changes
@@ -383,10 +448,22 @@ pub(crate) async fn rate_limit_check_middleware(
         RateLimitKey::Ip("anonymous".to_string())
     };
 
+    // Default quota, unless a per-client override replaces it below.
+    let default_config = crate::security::RateLimitConfig {
+        requests_per_second: state.snapshot().config.security.rate_limit_rps,
+        burst: state.snapshot().config.security.rate_limit_burst,
+    };
+    let mut effective_limit = advertised_quota(&default_config);
+    let mut effective_window = window_seconds(&default_config);
+
     // A per-client override replaces the default rate for that bucket only,
     // keeping the deployment's configured burst.
-    let (allowed, _remaining, reset_after) = match client_rps_override(&state, &key) {
-        Some(config) => limiter.check_with_config(&key, config).await,
+    let (allowed, remaining, reset_after) = match client_rps_override(&state, &key) {
+        Some(config) => {
+            effective_limit = advertised_quota(&config);
+            effective_window = window_seconds(&config);
+            limiter.check_with_config(&key, config).await
+        }
         None => limiter.check(&key).await,
     };
 
@@ -395,10 +472,9 @@ pub(crate) async fn rate_limit_check_middleware(
         let retry_after = reset_after
             .map(|d| d.as_secs().max(1).to_string())
             .unwrap_or_else(|| "1".to_string());
-        return Response::builder()
+        let mut response = Response::builder()
             .status(StatusCode::TOO_MANY_REQUESTS)
             .header("Retry-After", &retry_after)
-            .header("X-RateLimit-Remaining", "0")
             .header("Content-Type", "application/json")
             .body(Body::from(
                 r#"{"error":{"type":"rate_limit_error","message":"Rate limit exceeded. Please slow down."}}"#,
@@ -407,9 +483,21 @@ pub(crate) async fn rate_limit_check_middleware(
             .unwrap_or_else(|_| {
                 Response::new(Body::from(r#"{"error":{"type":"rate_limit_error","message":"Rate limit exceeded."}}"#))
             });
+        apply_ratelimit_headers(response.headers_mut(), effective_limit, 0, effective_window);
+        return response;
     }
 
-    next.run(request).await
+    // Advertise the quota on the *successful* path too: a client that only
+    // learns its budget from a 429 has already been throttled, which is exactly
+    // the outcome these fields exist to avoid.
+    let mut response = next.run(request).await;
+    apply_ratelimit_headers(
+        response.headers_mut(),
+        effective_limit,
+        remaining,
+        effective_window,
+    );
+    response
 }
 
 /// Security headers middleware: applies OWASP security headers to all responses.
@@ -811,6 +899,84 @@ rate_limit_burst = 20
         assert_eq!(config.requests_per_second, 100);
         // default burst 20 at default rps 10 → 10x the rate means 10x the burst.
         assert_eq!(config.burst, 200, "burst must scale with the granted rate");
+    }
+
+    /// The advertised window is how long a full burst takes to accrue.
+    ///
+    /// A token bucket has no fixed window; this is the closest honest number a
+    /// client can pace itself against.
+    #[test]
+    fn window_seconds_reports_burst_refill_time() {
+        let cfg = |rps, burst| crate::security::RateLimitConfig {
+            requests_per_second: rps,
+            burst,
+        };
+        // 20 tokens accruing at 10/s take 2 s to refill.
+        assert_eq!(window_seconds(&cfg(10, 20)), 2);
+        // Sub-second windows round up: the field is a non-zero integer.
+        assert_eq!(window_seconds(&cfg(100, 10)), 1);
+        // Degenerate config must not divide by zero.
+        assert_eq!(window_seconds(&cfg(0, 0)), 1);
+    }
+
+    /// The advertised quota is the bucket capacity, so `remaining` can never
+    /// exceed it.
+    ///
+    /// Advertising the refill rate instead produced `limit=10, remaining=19`,
+    /// which is unusable: a client cannot pace itself against a budget its own
+    /// balance exceeds.
+    #[test]
+    fn advertised_quota_is_never_below_remaining() {
+        let cfg = crate::security::RateLimitConfig {
+            requests_per_second: 10,
+            burst: 20,
+        };
+        let quota = advertised_quota(&cfg);
+        assert_eq!(quota, 20, "the quota is the bucket capacity");
+        assert!(
+            quota >= cfg.burst,
+            "remaining is capped at burst, so the advertised quota must cover it"
+        );
+
+        // Burst unset (0) must fall back to the rate rather than advertise zero.
+        let no_burst = crate::security::RateLimitConfig {
+            requests_per_second: 7,
+            burst: 0,
+        };
+        assert_eq!(advertised_quota(&no_burst), 7);
+    }
+
+    /// Quota fields must be emitted in both the IETF and de-facto spellings.
+    #[test]
+    fn ratelimit_headers_carry_both_spellings() {
+        let mut headers = HeaderMap::new();
+        apply_ratelimit_headers(&mut headers, 100, 87, 60);
+
+        // IETF structured fields (draft-ietf-httpapi-ratelimit-headers).
+        assert_eq!(
+            headers.get("ratelimit-policy").unwrap(),
+            "\"default\";q=100;w=60"
+        );
+        assert_eq!(headers.get("ratelimit").unwrap(), "\"default\";r=87;t=60");
+
+        // De-facto headers, which is what clients actually parse today.
+        assert_eq!(headers.get("x-ratelimit-limit").unwrap(), "100");
+        assert_eq!(headers.get("x-ratelimit-remaining").unwrap(), "87");
+        assert_eq!(headers.get("x-ratelimit-reset").unwrap(), "60");
+    }
+
+    /// With no quota configured, nothing must be advertised.
+    ///
+    /// Emitting `limit=0` would tell a client it may never send a request,
+    /// which is the opposite of "unlimited".
+    #[test]
+    fn no_quota_advertises_nothing() {
+        let mut headers = HeaderMap::new();
+        apply_ratelimit_headers(&mut headers, 0, 0, 1);
+        assert!(
+            headers.is_empty(),
+            "an unconfigured limiter must not advertise a zero quota"
+        );
     }
 
     /// A raw API key must never become the bucket key.


### PR DESCRIPTION
Answers "is a 1-5% margin not cheaper than gossip?" — yes, and it gives a *stronger* guarantee.

## The insight

Buckets are per process, so N replicas each enforcing `rate_limit_rps` let the fleet through `N × rps`. The reflex is to add coordination (Redis, gossip) so replicas can share a counter.

But if the point is "never exceed a hard limit", coordination is the expensive way to get a *weaker* result:

| Approach | Guarantee | Cost |
|---|---|---|
| Shared store (Redis) | exact, until the store fails | a dependency, a network hop per borrow, [silent degradation on error](https://github.com/BerriAI/litellm/issues/35533) |
| Gossip / CRDT | eventual, `limit × partitions` during a split | a membership protocol, unbounded overshoot |
| **Divide + margin** | **hard ceiling, always** | **utilisation** |

Dividing cannot overshoot, and there is nothing to fail: no shared store, no gossip, **not a single packet between replicas**.

## The change

```toml
[security]
rate_limit_rps = 1000          # the FLEET-wide limit
rate_limit_replicas = 4        # each replica enforces its share
rate_limit_margin_percent = 5  # withheld for what division cannot absorb
```

Each replica enforces `(1000 - 5%) / 4 = 237` rps.

The margin covers the residue: rounding up on small shares, a replica restarting with a full bucket, a scale-up landing before the config does. Applied to the default path, per-client overrides, and policy rate limits alike — otherwise naming a limit in a policy would quietly exempt it from the ceiling.

`rate_limit_replicas = 1` (the default) is bit-for-bit unchanged.

## Two decisions worth reviewing

**A share never floors to zero.** 5 rps across 10 replicas rounds each share to 0, which would reject *all* traffic — the limiter becoming the outage it exists to prevent. Overshooting a tiny limit is the better failure, so the share floors at 1. Asserted explicitly.

**The limiter is built with the share at startup**, not scaled at the call site. `RateLimiter::check` reads the bucket's own config, so scaling only in the middleware left the default path enforcing the whole fleet limit on every replica. Caught by end-to-end measurement, not by the unit tests — they passed throughout.

## Verification

Three live replicas, `rate_limit_rps = 30`, 120 concurrent requests released from a barrier:

| | requests through | verdict |
|---|---|---|
| `rate_limit_replicas = 1` (default) | **90** | 3× the configured limit |
| `rate_limit_replicas = 3`, margin 10% | **27** | ceiling of 30 respected |

Also checked: `/health` reports `scope: fleet` with `effective_rps_this_replica: 9`, and the quota headers advertise the share (9) rather than the fleet limit (30) — a client pacing itself against 30 on a replica enforcing 9 would be throttled at every attempt.

`fleet_total_never_exceeds_the_configured_limit` sweeps 4 limits × 16 replica counts × 3 margins and asserts the product never exceeds the configured limit.

Full suite 1783 passed, clippy `-D warnings` clean, 24 doc tests, fmt clean.

## What this does not do

It does not let a replica borrow an idle peer's capacity. With 3 replicas and all traffic on one, that replica is capped at a third of the fleet limit. That is the deliberate trade, and it is documented rather than hidden — gossip would fix it at the cost of a membership protocol and unbounded overshoot during a partition.
