### PR TITLE
feat(budget): enforce a fleet-wide spend cap across replicas

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -60,6 +60,52 @@ Budget checks follow a priority order: model limit > provider limit > global lim
 
 Spend is tracked in append-only JSONL journals (`~/.grob/spend/YYYY-MM.jsonl`) and resets automatically each month.
 
+### Budget across multiple replicas
+
+Spend is tracked **per process**. The in-memory total is seeded once at startup
+and updated only by that replica, so a peer writing to the same journal stays
+invisible until restart. **Mounting a shared volume does not make the budget
+shared** — a natural assumption, and a costly one: N replicas each allow the
+full cap, so the fleet can spend `N × monthly_limit_usd`.
+
+If the point of the cap is "do not spend more than this", declare the fleet:
+
+```toml
+[budget]
+monthly_limit_usd = 100.0   # the FLEET-wide cap
+replicas = 5                # each replica enforces its share
+margin_percent = 1          # withheld for rounding and restarts
+```
+
+Each replica then allows `$19.80`, so five of them cap the fleet at `$99.00`.
+Verified on a live replica: with `$19.90` recorded, the next request is refused
+with HTTP 402 even though the fleet cap of `$100` is far from reached.
+
+`/health` shows both numbers, so the configured cap can be reconciled with
+observed spend:
+
+```json
+{
+  "spend": {
+    "total_usd": 19.9,
+    "budget_usd": 100.0,
+    "budget_usd_this_replica": 19.8,
+    "replicas": 5
+  }
+}
+```
+
+The trade is the same as for [rate limiting](#making-the-limit-a-real-fleet-wide-ceiling):
+utilisation for a guarantee, at the cost of **no coordination at all** — no
+shared store, no gossip, not a single packet between replicas. A replica cannot
+spend an idle peer's share. For a *cost* cap that is usually the right way
+round: under-spending is recoverable, an overrun is not.
+
+`replicas` is a **declaration grob cannot verify** — it never counts its peers,
+which is precisely what avoids the coordination. If an autoscaler runs more
+replicas than declared, the ceiling scales with them. Declare the autoscaler's
+**maximum**, not its nominal size.
+
 ## Pricing
 
 Controls where model prices come from and how token usage is accounted.

--- a/src/cli/config/budget.rs
+++ b/src/cli/config/budget.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::cli::BudgetUsd;
 
 /// Budget configuration
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BudgetConfig {
     /// Global monthly hard cap in USD (0 = unlimited)
@@ -14,6 +14,49 @@ pub struct BudgetConfig {
     /// Log warning at this percentage of budget (default: 80)
     #[serde(default = "default_warn_percent")]
     pub warn_at_percent: u32,
+    /// Number of replicas sharing this budget (default 1).
+    ///
+    /// Spend is tracked per process: the in-memory total is seeded once at
+    /// startup and updated only by this replica, so a peer writing to the same
+    /// journal stays invisible until restart. Mounting a shared volume does
+    /// **not** make the budget shared. N replicas therefore each allow
+    /// `monthly_limit_usd`, and the fleet can spend `N ×` the cap.
+    ///
+    /// Declaring the replica count makes each one enforce its share, turning
+    /// the configured amount into a real ceiling on what the fleet can spend.
+    /// Needs no coordination: no shared store, no gossip, not one packet.
+    ///
+    /// The cost is utilisation — a replica cannot spend an idle peer's share —
+    /// which for a *cost* cap is usually the right trade: under-spending is
+    /// recoverable, an overrun is not.
+    #[serde(default = "default_budget_replicas")]
+    pub replicas: u32,
+    /// Safety margin withheld from the budget, in percent (default 0).
+    ///
+    /// Absorbs what division cannot: a replica restarting mid-month replays the
+    /// journal and resumes from the recorded total, but rounding and in-flight
+    /// requests still leave a small residue.
+    #[serde(default)]
+    pub margin_percent: u32,
+}
+
+// One daemon is the default deployment, so the configured budget is already
+// the fleet budget.
+fn default_budget_replicas() -> u32 {
+    1
+}
+
+// Hand-written rather than derived: a derived `Default` would give
+// `replicas = 0`, and dividing a budget by zero replicas is meaningless.
+impl Default for BudgetConfig {
+    fn default() -> Self {
+        Self {
+            monthly_limit_usd: BudgetUsd::default(),
+            warn_at_percent: default_warn_percent(),
+            replicas: default_budget_replicas(),
+            margin_percent: 0,
+        }
+    }
 }
 
 // NOTE: 80% gives ~6 days warning before exhaustion at constant spend rate

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -19,6 +19,8 @@ pub use audit_log::AuditLog;
 pub use circuit_breaker::{CircuitBreakerRegistry, CircuitState};
 pub use fips::FipsStatus;
 pub use headers::{apply_security_headers, SecurityHeadersConfig};
-pub use rate_limit::{replica_share, RateLimitConfig, RateLimitKey, RateLimiter};
+pub use rate_limit::{
+    replica_budget_share, replica_share, RateLimitConfig, RateLimitKey, RateLimiter,
+};
 pub use tee::TeeStatus;
 pub use tool_spike::{SpikeAction, ToolSpikeConfig, ToolSpikeDetector};

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -91,6 +91,24 @@ pub fn replica_share(limit: u32, replicas: u32, margin_percent: u32) -> u32 {
     u32::try_from(share).unwrap_or(u32::MAX).max(1)
 }
 
+/// Scales a fleet-wide budget down to one replica's share.
+///
+/// The money equivalent of [`replica_share`]. Kept separate because a budget is
+/// a continuous amount, not a token count: there is no "one token" floor to
+/// apply, and rounding to whole units would be wrong on a cap of a few dollars.
+///
+/// `0.0` means "unlimited" throughout the budget code, so it passes through
+/// unchanged: scaling it would invent a cap the operator did not ask for.
+#[must_use]
+pub fn replica_budget_share(limit: f64, replicas: u32, margin_percent: u32) -> f64 {
+    if limit <= 0.0 {
+        return limit;
+    }
+    let replicas = f64::from(replicas.max(1));
+    let margin = f64::from(margin_percent.min(99));
+    limit * (100.0 - margin) / 100.0 / replicas
+}
+
 /// Rate limiter key (tenant_id or IP fallback)
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum RateLimitKey {
@@ -483,5 +501,53 @@ mod tests {
     #[test]
     fn zero_replicas_is_treated_as_one() {
         assert_eq!(replica_share(100, 0, 0), 100);
+    }
+
+    /// A single replica with no margin must leave the budget untouched.
+    #[test]
+    fn budget_share_is_identity_for_one_replica() {
+        assert!((replica_budget_share(100.0, 1, 0) - 100.0).abs() < 1e-9);
+    }
+
+    /// The fleet total must never exceed the configured budget.
+    #[test]
+    fn budget_fleet_total_never_exceeds_the_cap() {
+        for limit in [1.0_f64, 10.0, 250.0, 9999.99] {
+            for replicas in 1u32..=12 {
+                for margin in [0u32, 1, 5] {
+                    let share = replica_budget_share(limit, replicas, margin);
+                    let total = share * f64::from(replicas);
+                    assert!(
+                        total <= limit + 1e-9,
+                        "limit={limit} replicas={replicas} margin={margin}: \
+                         fleet total {total} exceeds the cap"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Unlimited must stay unlimited.
+    ///
+    /// `0.0` means "no cap" in the budget code; dividing it would invent one.
+    #[test]
+    fn budget_share_keeps_unlimited_unlimited() {
+        assert_eq!(replica_budget_share(0.0, 8, 5), 0.0);
+    }
+
+    /// A small budget must not round away to nothing.
+    ///
+    /// Unlike a token bucket there is no "one token" floor, but the share must
+    /// stay a usable positive amount rather than collapsing to zero — which the
+    /// budget code would read as "unlimited", the exact opposite.
+    #[test]
+    fn budget_share_stays_positive_for_small_caps() {
+        let share = replica_budget_share(1.0, 100, 5);
+        assert!(
+            share > 0.0,
+            "a small budget split many ways must not become 0.0, which the \
+             budget code reads as unlimited"
+        );
+        assert!((share - 0.0095).abs() < 1e-9);
     }
 }

--- a/src/server/budget.rs
+++ b/src/server/budget.rs
@@ -133,18 +133,31 @@ pub(crate) async fn check_budget_for_tenant(
     tenant_id: Option<&str>,
 ) -> Result<(), RequestError> {
     let budget_config = &inner.config.budget;
-    let global_limit = budget_config.monthly_limit_usd.value();
+
+    // Every configured cap is a FLEET-wide amount, scaled to this replica's
+    // share. Spend is tracked per process (a peer's writes are invisible until
+    // restart), so without this each replica would allow the full cap and the
+    // fleet could spend `replicas x limit`.
+    let share = |limit: f64| {
+        crate::security::replica_budget_share(
+            limit,
+            budget_config.replicas,
+            budget_config.margin_percent,
+        )
+    };
+
+    let global_limit = share(budget_config.monthly_limit_usd.value());
 
     let provider_limit = inner
         .config
         .providers
         .iter()
         .find(|p| p.name == provider_name)
-        .and_then(|p| p.budget_usd.map(|b| b.value()));
+        .and_then(|p| p.budget_usd.map(|b| share(b.value())));
 
     let model_limit = inner
         .find_model(model_name)
-        .and_then(|m| m.budget_usd.map(|b| b.value()));
+        .and_then(|m| m.budget_usd.map(|b| share(b.value())));
 
     let tracker = state.observability.spend_tracker.lock().await;
 

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -45,7 +45,17 @@ pub(super) async fn health_check(State(state): State<Arc<AppState>>) -> impl Int
         "active_requests": active,
         "spend": {
             "total_usd": spend_total,
+            // The FLEET-wide cap as configured.
             "budget_usd": budget_limit,
+            // What THIS replica will actually allow. Differs from `budget_usd`
+            // when the budget is split across replicas, and that difference is
+            // what reconciles the configured cap with observed spend.
+            "budget_usd_this_replica": crate::security::replica_budget_share(
+                budget_limit,
+                inner.config.budget.replicas,
+                inner.config.budget.margin_percent,
+            ),
+            "replicas": inner.config.budget.replicas.max(1),
         },
         // Content hashes of the *active* snapshot on this replica. Two replicas
         // reporting different revisions are enforcing different policies, which

--- a/src/storage/fault_injection_tests.rs
+++ b/src/storage/fault_injection_tests.rs
@@ -172,3 +172,42 @@ fn observing_dependencies_do_not_block_reads() {
         "a read must not depend on metrics or audit being available"
     );
 }
+
+// ── Shared storage is not shared state ───────────────────────────
+
+/// Two live processes over one storage dir do NOT see each other's spend.
+///
+/// This is the boundary that decides whether a budget is a fleet-wide cap or a
+/// per-replica one. The in-memory total is seeded once at open and updated only
+/// by this process, so a peer writing to the same journal stays invisible until
+/// restart. Mounting a shared volume therefore does **not** make the budget
+/// shared, which is exactly the assumption an operator is likely to make.
+#[test]
+fn spend_is_not_shared_between_live_stores() {
+    let dir = TempDir::new().expect("tempdir");
+
+    // Two stores over the same directory: two replicas on one volume.
+    let a = open_store(&dir).expect("store a");
+    let b = open_store(&dir).expect("store b");
+
+    a.record_spend(None, 10.0, "anthropic", "claude-opus");
+    a.flush_spend();
+
+    assert!(
+        (a.load_spend().total - 10.0).abs() < 1e-9,
+        "the writing replica sees its own spend"
+    );
+    assert_eq!(
+        b.load_spend().total,
+        0.0,
+        "a live peer does NOT see it: caches are per process, so a budget binds \
+         per replica even on shared storage"
+    );
+
+    // A restart does pick it up, which is what makes the journal the record.
+    let c = open_store(&dir).expect("store c");
+    assert!(
+        (c.load_spend().total - 10.0).abs() < 1e-9,
+        "a fresh process replays the journal and sees the peer's spend"
+    );
+}


### PR DESCRIPTION
Follow-up to #565: applies the same fleet-aware treatment to the budget, which is the limit that actually bounds *consumption*.

## The trap

Spend is tracked **per process**. The in-memory total is seeded once at startup and updated only by that replica, so a peer writing to the same journal stays invisible until restart.

**Mounting a shared volume does not make the budget shared.** That is the assumption an operator is most likely to make, and it is the expensive one to get wrong: N replicas each allow the full cap, so the fleet spends `N × monthly_limit_usd`. A `$100` cap on 5 replicas is a `$500` cap.

Now pinned by a test (`spend_is_not_shared_between_live_stores`): two stores over one directory, one records `$10`, the peer still reads `$0`, and only a restart picks it up.

## The change

```toml
[budget]
monthly_limit_usd = 100.0   # the FLEET-wide cap
replicas = 5
margin_percent = 1
```

Each replica allows `$19.80`, capping the fleet at `$99.00`. Applied to the global cap and to per-provider and per-model caps alike, so a named limit cannot escape the ceiling.

Rate limits and budgets get separate `replicas` knobs on purpose: they are different guarantees with different blast radii, and a deployment may well want a hard cost cap without paying the utilisation cost on throughput.

## Two details

`replica_budget_share` is separate from `replica_share` rather than generic. A budget is a continuous amount: there is no "one token" floor to apply, and rounding to whole units would be wrong on a cap of a few dollars.

`0.0` passes through unchanged, because it means *unlimited* in the budget code. Dividing it would invent a cap nobody asked for — and a small budget split many ways must not round down to `0.0` either, which would read as unlimited: the exact opposite of the intent. Both asserted.

## Verification

On a live server, `monthly_limit_usd = 100`, `replicas = 5`, `margin_percent = 1`:

- `/health` reports `budget_usd: 100.0`, `budget_usd_this_replica: 19.8` → fleet ceiling `$99.00`.
- With `$19.90` recorded in the journal, the next request is refused with **HTTP 402** while the fleet cap of `$100` is nowhere near reached.

`budget_fleet_total_never_exceeds_the_cap` sweeps 4 caps × 12 replica counts × 3 margins.

Full suite 1788 passed, clippy `-D warnings` clean, 24 doc tests, fmt clean.

## The honest limit

`replicas` is a declaration grob **cannot verify** — it never counts its peers, which is exactly what avoids the coordination. If an autoscaler runs more replicas than declared, the ceiling scales with them. The docs say to declare the autoscaler's *maximum*, not its nominal size.
