### PR TITLE
chore: release v0.36.104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.104](https://github.com/azerozero/grob/compare/v0.36.103...v0.36.104) - 2026-09-02
+
+### Added
+
+- *(budget)* enforce a fleet-wide spend cap across replicas ([#566](https://github.com/azerozero/grob/pull/566))
+- *(security)* enforce a fleet-wide rate limit without any coordination ([#565](https://github.com/azerozero/grob/pull/565))
+
 ## [0.36.103](https://github.com/azerozero/grob/compare/v0.36.102...v0.36.103) - 2026-09-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.103"
+version = "0.36.104"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.103"
+version = "0.36.104"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.103 -> 0.36.104

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.104](https://github.com/azerozero/grob/compare/v0.36.103...v0.36.104) - 2026-09-02

### Added

- *(budget)* enforce a fleet-wide spend cap across replicas ([#566](https://github.com/azerozero/grob/pull/566))
- *(security)* enforce a fleet-wide rate limit without any coordination ([#565](https://github.com/azerozero/grob/pull/565))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).