### PR TITLE
feat(config): let the orchestrator declare the replica count via GROB_REPLICAS

### DIFF
--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -50,6 +50,7 @@ A sample manifest is provided in `deploy/grob-kube.yml`. Key points:
 - The health endpoint is `GET /health` (returns 200 with PID)
 - Metrics are at `GET /metrics` (Prometheus format)
 - The container runs as non-root (UID/GID 65534); hostPath volumes must be writable by that user
+- Set `GROB_REPLICAS` from the Deployment's replica count if you enforce fleet-wide limits (see below)
 
 ```yaml
 livenessProbe:
@@ -65,6 +66,55 @@ startupProbe:
     path: /health
     port: 8080
 ```
+
+### Fleet-wide limits with more than one pod
+
+Rate-limit buckets and spend counters are **per process**. Each pod enforces the
+configured limit on its own, so N pods let the fleet through `N x` the limit.
+`rate_limit_replicas` (and `[budget] replicas`) fix that by making each pod
+enforce its share — but they are numbers written in a file, and on Kubernetes
+the replica count lives in the Deployment and moves under an HPA.
+
+Inject it instead of hardcoding it:
+
+```yaml
+spec:
+  replicas: 5
+  template:
+    spec:
+      containers:
+        - name: grob
+          env:
+            - name: GROB_REPLICAS
+              value: "5"          # keep in sync with spec.replicas
+```
+
+`GROB_REPLICAS` overrides the file's replica count. Unset, unparseable, or `0`
+leaves the config untouched, so a templating mistake degrades to the previous
+behaviour rather than dividing by zero.
+
+With Helm, template it from the same value that sets `spec.replicas` so the two
+cannot drift:
+
+```yaml
+env:
+  - name: GROB_REPLICAS
+    value: "{{ .Values.replicaCount }}"
+```
+
+**Under an HPA, use `maxReplicas`.** Over-declaring only under-uses the quota;
+under-declaring breaks the ceiling. An HPA scaling from 3 to 10 pods against a
+declaration of 3 would let the fleet reach 333% of the configured limit.
+
+grob deliberately does **not** query the Kubernetes API to count its own pods:
+that would mean a cluster-role, a watch, and a hard dependency on the
+orchestrator — for a number the orchestrator can simply hand over. The count
+stays a declaration; the environment is just a better place to declare it than
+a ConfigMap.
+
+Each pod keeps its own `GROB_HOME` (an `emptyDir` is fine). A shared volume is
+**not** required and does not make limits shared: spend counters are in-memory
+per process, so a peer's writes are invisible until restart.
 
 ## Build from source
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -205,9 +205,54 @@ impl AppConfig {
             .with_context(|| format!("Failed to parse config from {}", source_label))?;
 
         config.resolve_env_vars()?;
+        config.resolve_replica_count();
         config.validate()?;
 
         Ok(config)
+    }
+
+    /// Applies the `GROB_REPLICAS` override to every fleet-share setting.
+    ///
+    /// The fleet-share maths turns a configured limit into a real ceiling by
+    /// dividing it across replicas, but the replica count is a number the
+    /// operator writes by hand. In a container orchestrator that number is not
+    /// static: it is a Deployment field, and an HPA changes it without anyone
+    /// editing the config.
+    ///
+    /// Reading it from the environment is what makes the guarantee survive
+    /// there. On Kubernetes the count is already known to the control plane and
+    /// can be injected without any coupling to grob:
+    ///
+    /// ```yaml
+    /// env:
+    ///   - name: GROB_REPLICAS
+    ///     valueFrom:
+    ///       resourceFieldRef: { containerName: grob, resource: limits.cpu }
+    /// ```
+    ///
+    /// or, more usually, straight from the Deployment's `spec.replicas` via a
+    /// templating value. Under an HPA, set it to `maxReplicas`: over-declaring
+    /// only under-uses the quota, while under-declaring breaks the ceiling.
+    ///
+    /// An unset or unparseable value leaves the file config untouched, so the
+    /// static single-daemon deployment is unaffected. `0` is ignored rather
+    /// than treated as "no replicas", which would mean dividing by zero.
+    fn resolve_replica_count(&mut self) {
+        let Ok(raw) = std::env::var("GROB_REPLICAS") else {
+            return;
+        };
+        let Ok(count) = raw.trim().parse::<u32>() else {
+            tracing::warn!(
+                value = %raw,
+                "GROB_REPLICAS is not a number; keeping the configured replica count"
+            );
+            return;
+        };
+        if count == 0 {
+            tracing::warn!("GROB_REPLICAS=0 is meaningless; keeping the configured count");
+            return;
+        }
+        self.security.rate_limit_replicas = count;
     }
 
     /// Resolves `$ENV_VAR` references in provider API keys.
@@ -876,5 +921,127 @@ think = "my-think-model"
             match_conditions: None,
         }];
         assert!(AppConfig::validate_tiers(&bad_provider, &providers, &models).is_err());
+    }
+
+    /// The environment overrides the file's replica count.
+    ///
+    /// This is what makes the fleet ceiling usable on Kubernetes, where the
+    /// replica count lives in the Deployment (and moves under an HPA) rather
+    /// than in a config file baked into a ConfigMap.
+    #[test]
+    fn grob_replicas_env_overrides_the_config() {
+        let _guard = crate::GROB_REPLICAS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let toml = r#"
+[router]
+default = "m"
+
+[security]
+rate_limit_rps = 100
+rate_limit_replicas = 2
+
+[[models]]
+name = "m"
+
+[[models.mappings]]
+priority = 1
+provider = "p"
+actual_model = "m"
+
+[[providers]]
+name = "p"
+provider_type = "openai"
+auth_type = "apikey"
+api_key = "sk-test"
+models = ["m"]
+"#;
+        std::env::set_var("GROB_REPLICAS", "7");
+        let config = AppConfig::from_content(toml, "replica_env_test").expect("parses");
+        std::env::remove_var("GROB_REPLICAS");
+
+        assert_eq!(
+            config.security.rate_limit_replicas, 7,
+            "the orchestrator's count must win over the file"
+        );
+    }
+
+    /// An unset variable leaves the file config alone.
+    #[test]
+    fn unset_grob_replicas_keeps_the_configured_count() {
+        let _guard = crate::GROB_REPLICAS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("GROB_REPLICAS");
+
+        let toml = r#"
+[router]
+default = "m"
+
+[security]
+rate_limit_replicas = 3
+
+[[models]]
+name = "m"
+
+[[models.mappings]]
+priority = 1
+provider = "p"
+actual_model = "m"
+
+[[providers]]
+name = "p"
+provider_type = "openai"
+auth_type = "apikey"
+api_key = "sk-test"
+models = ["m"]
+"#;
+        let config = AppConfig::from_content(toml, "replica_env_test").expect("parses");
+        assert_eq!(config.security.rate_limit_replicas, 3);
+    }
+
+    /// Garbage and zero must not silently break the ceiling.
+    ///
+    /// `0` would divide the limit by zero replicas; a typo would otherwise
+    /// parse as "no replicas declared" and quietly restore the per-replica
+    /// behaviour the operator was trying to avoid.
+    #[test]
+    fn invalid_grob_replicas_is_ignored() {
+        let _guard = crate::GROB_REPLICAS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let toml = r#"
+[router]
+default = "m"
+
+[security]
+rate_limit_replicas = 4
+
+[[models]]
+name = "m"
+
+[[models.mappings]]
+priority = 1
+provider = "p"
+actual_model = "m"
+
+[[providers]]
+name = "p"
+provider_type = "openai"
+auth_type = "apikey"
+api_key = "sk-test"
+models = ["m"]
+"#;
+        for bad in ["", "abc", "0", "-1", "3.5"] {
+            std::env::set_var("GROB_REPLICAS", bad);
+            let config = AppConfig::from_content(toml, "replica_env_test").expect("parses");
+            assert_eq!(
+                config.security.rate_limit_replicas, 4,
+                "GROB_REPLICAS={bad:?} must be ignored, not applied"
+            );
+        }
+        std::env::remove_var("GROB_REPLICAS");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,13 @@ use std::path::PathBuf;
 #[cfg(test)]
 pub(crate) static GROB_HOME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Serialises tests that set `GROB_REPLICAS`.
+///
+/// Same hazard as [`GROB_HOME_TEST_LOCK`]: the environment is process-global,
+/// so two tests mutating it in parallel would read each other's value.
+#[cfg(test)]
+pub(crate) static GROB_REPLICAS_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Returns the Grob home directory (`~/.grob`).
 ///
 /// When the `dirs` feature is disabled, falls back to reading `GROB_HOME`


### PR DESCRIPTION
Answers "what happens when we go to a Kubernetes cluster?" for the fleet-wide limits added in #565 and #566.

## The problem

The fleet-share maths is exact, but it rests on `rate_limit_replicas` — a number written by hand in a config file. On Kubernetes that number does not live in a file: it is `spec.replicas`, and under an HPA it changes without anyone editing anything.

A ConfigMap baked with `replicas = 3` while an HPA runs 10 pods gives a fleet ceiling of **333%** of the configured limit, silently. Every pod reports healthy and enforces exactly what it was told.

## The change

`GROB_REPLICAS` overrides the configured count:

```yaml
spec:
  replicas: 5
  template:
    spec:
      containers:
        - name: grob
          env:
            - name: GROB_REPLICAS
              value: "5"
```

With Helm, template it from the same value that sets `spec.replicas` so the two cannot drift.

Unset, unparseable, or `0` leaves the file config untouched. A templating mistake (`value: "{{ .Values.missing }}"` rendering empty) degrades to the previous behaviour instead of dividing by zero — asserted for `""`, `"abc"`, `"0"`, `"-1"`, `"3.5"`.

## What I tried first, and why I dropped it

My first approach was a **replica census**: each replica drops a heartbeat file in a shared `GROB_HOME` and counts the fresh ones, so grob could *detect* a wrong declaration instead of trusting it. Fully written, with tests.

Then I checked the Kubernetes assumption and deleted it. Pods do not share a filesystem by default — a shared volume needs `ReadWriteMany`, which most storage classes do not provide. The census would have reported "1 replica" on every pod: not merely useless, but actively misleading, since it would have looked like confirmation that the declaration was correct.

## What I deliberately did not do

Query the Kubernetes API to self-count pods. That buys a cluster-role, a watch, an in-cluster client, and a hard dependency on the orchestrator — for a number the orchestrator already knows and can hand over in an env var. It would also only work on Kubernetes, while `GROB_REPLICAS` works under Nomad, systemd, or a hand-rolled fleet.

The count stays a declaration. The environment is simply a better place to declare it than a file.

## Verification

Same config file, live server:

| | `replicas` reported | enforced share |
|---|---|---|
| config says 2 | 2 | 50 rps |
| `GROB_REPLICAS=8` | 8 | 12 rps |

Full suite 1786 passed, clippy `-D warnings` clean, fmt clean.

Docs: a Kubernetes section covering the HPA case (**declare `maxReplicas`** — over-declaring under-uses the quota, under-declaring breaks the ceiling) and stating that each pod keeps its own `GROB_HOME`, because a shared volume is not required and does not make limits shared.
