### PR TITLE
fix(budget): apply the fleet share to policy budget overrides

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -101,6 +101,26 @@ shared store, no gossip, not a single packet between replicas. A replica cannot
 spend an idle peer's share. For a *cost* cap that is usually the right way
 round: under-spending is recoverable, an overrun is not.
 
+### Which limits are fleet-aware
+
+Not every limit accumulates across replicas, so not every limit needs dividing.
+The distinction is whether the thing being counted is **shared** by the fleet:
+
+| Limit | Fleet-aware | Why |
+|---|---|---|
+| `[security] rate_limit_rps` / `burst` | ✅ `rate_limit_replicas` | every replica throttles the same caller |
+| `[security.rate_limit_clients]` overrides | ✅ same knob | a named client must not escape the ceiling |
+| `[[policies]] rate_limit.rps` | ✅ same knob | a policy must not escape it either |
+| `[budget] monthly_limit_usd` | ✅ `[budget] replicas` | the money is one pot |
+| `[[providers]] budget_usd`, `[[models]] budget_usd` | ✅ same knob | same pot, narrower scope |
+| `[[policies]] budget.monthly_usd` | ✅ same knob | same pot again |
+| `tool_spike_*_per_min` | ❌ not needed | keyed per **session**, and a session is served by one replica |
+| `[cache] max_capacity`, `max_entry_bytes` | ❌ not needed | a per-process memory bound, not a shared quota |
+| `max_body_size` | ❌ not needed | a property of a single request |
+
+A limit in the second group is already correct on every replica: dividing it
+would shrink a per-process bound for no reason.
+
 `replicas` is a **declaration grob cannot verify** — it never counts its peers,
 which is precisely what avoids the coordination. If an autoscaler runs more
 replicas than declared, the ceiling scales with them. Declare the autoscaler's

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -678,6 +678,17 @@ async fn enforce_post_route_policy(
 
     // (2) Budget override — enforced before the provider loop's spend check.
     if let Some(limit) = policy.budget.as_ref().and_then(|b| b.monthly_usd) {
+        // A policy budget is a fleet-wide amount like every other cap, so it
+        // takes this replica's share. Without this, moving a cap into a policy
+        // would quietly exempt it from the fleet ceiling that `[budget]`
+        // enforces everywhere else — the limit would still be honoured per
+        // process, and still be multiplied by the replica count.
+        let budget_config = &ctx.inner.config.budget;
+        let limit = crate::security::replica_budget_share(
+            limit,
+            budget_config.replicas,
+            budget_config.margin_percent,
+        );
         let tracker = ctx.state.observability.spend_tracker.lock().await;
         let result = match ctx.tenant_id.as_deref() {
             Some(tenant) => tracker.check_tenant_budget(
@@ -1480,6 +1491,49 @@ provider = "{provider}"
         assert!(
             !called.load(std::sync::atomic::Ordering::SeqCst),
             "the provider must NOT be reached when the budget policy blocks"
+        );
+    }
+
+    /// A policy budget must take the fleet share like every other cap.
+    ///
+    /// Otherwise moving a cap into a policy would quietly exempt it from the
+    /// fleet ceiling: the limit would still be honoured per process, and still
+    /// be multiplied by the replica count. Spend here sits *under* the
+    /// configured cap but *over* this replica's share, so it can only block if
+    /// the share is applied.
+    #[cfg(feature = "policies")]
+    #[tokio::test]
+    async fn dispatch_policy_budget_override_takes_the_fleet_share() {
+        let mut config = policy_config("default", "[policies.budget]\nmonthly_usd = 100.0");
+        // Four replicas, 5% withheld → this one may spend 100 * 0.95 / 4 = 23.75.
+        config.budget.replicas = 4;
+        config.budget.margin_percent = 5;
+
+        let called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let mut registry = crate::providers::ProviderRegistry::new();
+        registry.insert_provider_for_test(
+            "anthropic",
+            Arc::new(CountingProvider {
+                called: called.clone(),
+            }),
+        );
+        let state = crate::server::test_app_state(config, registry);
+
+        {
+            let mut tracker = state.observability.spend_tracker.lock().await;
+            // Well under the 100.0 policy cap, but over this replica's 23.75.
+            tracker.record("anthropic", "alpha", 30.0);
+        }
+
+        let result = run_dispatch(&state, None).await;
+        assert!(
+            matches!(result, Err(RequestError::BudgetExceeded { .. })),
+            "a policy budget must be divided across replicas: $30 is under the \
+             $100 cap but over this replica's $23.75 share"
+        );
+        assert!(
+            !called.load(std::sync::atomic::Ordering::SeqCst),
+            "the provider must not be reached once the share is exhausted"
         );
     }
 


### PR DESCRIPTION
Completeness pass over #565 / #566: are all the accumulating limits fleet-aware?

## The gap found

`[budget] replicas` covered the global, per-provider and per-model caps, but **not** `[[policies]] budget.monthly_usd`. Moving a cap into a policy exempted it from the ceiling: still honoured per process, still multiplied by the replica count.

Same class as the rate-limit override handled in #565, missed on the budget side.

Caught by a test that fails without the fix: `$30` spent against a `$100` policy cap with `replicas = 4, margin = 5%` must block, because this replica's share is `$23.75`. Mutation-verified — removing the scaling makes it fail.

## The audit

Every configured limit, and whether it accumulates across replicas:

| Limit | Fleet-aware | Why |
|---|---|---|
| `rate_limit_rps` / `burst` | ✅ | every replica throttles the same caller |
| `rate_limit_clients` overrides | ✅ | a named client must not escape the ceiling |
| `[[policies]] rate_limit.rps` | ✅ (#565) | a policy must not escape it either |
| `[budget] monthly_limit_usd` | ✅ (#566) | the money is one pot |
| `[[providers]]` / `[[models]] budget_usd` | ✅ (#566) | same pot, narrower scope |
| **`[[policies]] budget.monthly_usd`** | ✅ **this PR** | was the gap |
| `tool_spike_*_per_min` | ❌ correct as-is | keyed per **session**, and a session is served by one replica |
| `[cache] max_capacity` / `max_entry_bytes` | ❌ correct as-is | a per-process memory bound, not a shared quota |
| `max_body_size` | ❌ correct as-is | a property of one request |

The second group is the point worth stating: those limits are already right on every replica, and dividing them would shrink a local bound for no reason. A per-session threshold does not accumulate, because the session lives on one replica.

Now documented as a table, so the next limit added has an obvious question to answer.

Full suite 1789 passed, clippy `-D warnings` clean, 24 doc tests, fmt clean.
