### PR TITLE
chore: release v0.36.105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.105](https://github.com/azerozero/grob/compare/v0.36.104...v0.36.105) - 2026-09-02
+
+### Fixed
+
+- *(budget)* apply the fleet share to policy budget overrides ([#569](https://github.com/azerozero/grob/pull/569))
+
 ## [0.36.104](https://github.com/azerozero/grob/compare/v0.36.103...v0.36.104) - 2026-09-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.104"
+version = "0.36.105"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.104"
+version = "0.36.105"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.104 -> 0.36.105

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.105](https://github.com/azerozero/grob/compare/v0.36.104...v0.36.105) - 2026-09-02

### Fixed

- *(budget)* apply the fleet share to policy budget overrides ([#569](https://github.com/azerozero/grob/pull/569))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).