### PR TITLE
chore: release v0.36.106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.106](https://github.com/azerozero/grob/compare/v0.36.105...v0.36.106) - 2026-09-02
+
+### Fixed
+
+- *(config)* stop rejecting a reload for a host the daemon rewrote itself ([#572](https://github.com/azerozero/grob/pull/572))
+
+### Other
+
+- *(dispatch)* kill the surviving agent_id and gate_media mutants ([#573](https://github.com/azerozero/grob/pull/573))
+
 ## [0.36.105](https://github.com/azerozero/grob/compare/v0.36.104...v0.36.105) - 2026-09-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.105"
+version = "0.36.106"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.105"
+version = "0.36.106"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.105 -> 0.36.106

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.106](https://github.com/azerozero/grob/compare/v0.36.105...v0.36.106) - 2026-09-02

### Fixed

- *(config)* stop rejecting a reload for a host the daemon rewrote itself ([#572](https://github.com/azerozero/grob/pull/572))

### Other

- *(dispatch)* kill the surviving agent_id and gate_media mutants ([#573](https://github.com/azerozero/grob/pull/573))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).