### PR TITLE
chore: release v0.36.107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.107](https://github.com/azerozero/grob/compare/v0.36.106...v0.36.107) - 2026-09-02
+
+### Added
+
+- *(config)* let the orchestrator declare the replica count via GROB_REPLICAS ([#568](https://github.com/azerozero/grob/pull/568))
+
 ## [0.36.106](https://github.com/azerozero/grob/compare/v0.36.105...v0.36.106) - 2026-09-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "grob"
-version = "0.36.106"
+version = "0.36.107"
 dependencies = [
  "aes-gcm",
  "age",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grob"
-version = "0.36.106"
+version = "0.36.107"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance LLM routing proxy — routes to Anthropic, OpenAI, Gemini, DeepSeek, Ollama & more with streaming, tool calling, and multi-provider fallback"


### PR DESCRIPTION



## 🤖 New release

* `grob`: 0.36.106 -> 0.36.107

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.36.107](https://github.com/azerozero/grob/compare/v0.36.106...v0.36.107) - 2026-09-02

### Added

- *(config)* let the orchestrator declare the replica count via GROB_REPLICAS ([#568](https://github.com/azerozero/grob/pull/568))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).