### PR TITLE
fix(ci): run mutation testing with --all-features

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -35,4 +35,16 @@ exclude_re = [
     "replace % with \\+ in generate_canary_iban",
     "replace build_encrypted_content -> .* with",
     "in build_encrypted_content$",
+    # `agent_id` a deux corps mutuellement exclusifs (`#[cfg(feature =
+    # "agents")]` / `#[cfg(not(...))]`). cargo-mutants mute le *source*, donc
+    # sous `--all-features` il propose aussi des mutants sur le corps de repli,
+    # qui n'est pas compile et retourne `None` par construction: aucun test ne
+    # peut les tuer, et retirer `--all-features` ne ferait que deplacer le
+    # probleme sur l'autre corps.
+    #
+    # Seul le corps de repli est exclu, via le retour `Some(...)` qu'il ne peut
+    # pas produire. Les mutants du corps reel restent actifs et sont tues par
+    # `agent_id_round_trips_through_the_dispatch_context` (contre `None`) et
+    # `absent_agent_is_not_invented` (contre une constante).
+    "replace DispatchContext<.*>::agent_id -> Option<&str> with Some",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,10 +490,15 @@ jobs:
           if [ -n "${{ matrix.mutants_shard }}" ]; then
             SHARD_ARGS+=(--shard "${{ matrix.mutants_shard }}")
           fi
+          # --all-features: several mutated functions only exist behind a
+          # non-default feature (`gate_media` is a no-op without `media`,
+          # `agent_id` without `agents`). Building the default feature set meant
+          # the tests that kill those mutants were never compiled, so the
+          # mutants survived against a suite that could not see them.
           cargo mutants --package grob --timeout 120 -j 2 \
             "${SHARD_ARGS[@]}" \
             --file ${{ matrix.file }} \
-            -- --lib
+            -- --lib --all-features
       - name: Upload mutation testing results
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The four mutants #573 claimed to kill were **still surviving on `main`**. My tests were correct; they were never compiled.

## What I got wrong

`cargo mutants` runs with the **default** feature set. But:

- `gate_media` is a no-op without the `media` feature
- `agent_id` returns `None` unconditionally without `agents`

Neither is a default feature. So the tests I gated with `#[cfg(feature = ...)]` to match the code under test were `cfg`'d out of the very binary the mutants were tested against. I verified the fix with `cargo nextest run --all-features` and never checked what the mutation job actually builds.

Measured: **1 of my 5 new tests** compiles under the default feature set.

## The fix, and the second problem it exposed

`-- --lib --all-features` on the mutation job.

That alone is not enough. cargo-mutants mutates the **source**, so under `--all-features` it also proposes mutants on `agent_id`'s `#[cfg(not(feature = "agents"))]` body — which is not compiled, and returns `None` by construction. No test can kill those, and dropping `--all-features` just moves the problem to the other body.

Only the fallback body is excluded, matched on the `Some(...)` return it cannot produce:

```toml
"replace DispatchContext<.*>::agent_id -> Option<&str> with Some",
```

The real body keeps its `None` mutant active, killed by `absent_agent_is_not_invented` / `agent_id_round_trips_through_the_dispatch_context`.

## Verification

Ran the same `cargo-mutants 24.11.2` as CI, with the CI's own arguments:

| | before | after |
|---|---|---|
| `MISSED` on `agent_id` / `gate_media` | 4 | **0** |

Checked every other file in the mutation matrix for mutants that `--all-features` might newly expose — `router/mod.rs`, `dlp/{mod,pii,dfa}.rs`, `dispatch/{retry,provider_loop}.rs`, `mcp/mod.rs`: **counts identical**, so no shard grows and no new survivor appears elsewhere.

Suites: 1795 default, 1961 `--all-features`.

## Lesson

A mutation job that does not build the feature set its tests need reports a green suite as coverage it does not have. Worth remembering: the previous PR's local verification (re-injecting each mutant and watching tests go red) was sound in isolation but tested a different build than CI did.
